### PR TITLE
Add --stash flag to `pueue add`

### DIFF
--- a/client/cli.rs
+++ b/client/cli.rs
@@ -18,7 +18,7 @@ pub enum SubCommand {
         /// The task ids to be removed
         task_ids: Vec<usize>,
     },
-    /// Switches the queue position of two commands. Only works on queued and stashed commandse.
+    /// Switches the queue position of two commands. Only works on queued and stashed commands.
     Switch {
         /// The first task id
         task_id_1: usize,

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -9,8 +9,13 @@ pub enum SubCommand {
         command: Vec<String>,
 
         /// Start the task immediately
-        #[structopt(name = "immediate", short, long)]
+        #[structopt(name = "immediate", short, long, conflicts_with = "stash")]
         start_immediately: bool,
+
+        /// Create the task stashed.
+        /// Useful to avoid immediate execution if the queue is empty.
+        #[structopt(name = "stash", short, long, conflicts_with = "immediate")]
+        create_stashed: bool
     },
     /// Remove tasks from the list.
     /// Running or paused tasks need to be killed first.

--- a/client/message.rs
+++ b/client/message.rs
@@ -13,6 +13,7 @@ pub fn get_message_from_opt(opt: &Opt) -> Result<Message> {
         SubCommand::Add {
             command,
             start_immediately,
+            create_stashed,
         } => {
             let cwd_pathbuf = current_dir()?;
             let cwd = cwd_pathbuf.to_str().ok_or(anyhow!(
@@ -22,6 +23,7 @@ pub fn get_message_from_opt(opt: &Opt) -> Result<Message> {
                 command: command.join(" "),
                 path: cwd.to_string(),
                 start_immediately: *start_immediately,
+                create_stashed: *create_stashed,
             }))
         }
         SubCommand::Remove { task_ids } => {

--- a/daemon/instructions.rs
+++ b/daemon/instructions.rs
@@ -36,7 +36,13 @@ pub fn handle_message(message: Message, sender: &Sender<Message>, state: &Shared
 /// Queues a new task to the state.
 /// If the start_immediately flag is set, send a StartMessage to the task handler
 fn add_task(message: AddMessage, sender: &Sender<Message>, state: &SharedState) -> Message {
-    let task = Task::new(message.command, message.path);
+    let starting_status = if message.create_stashed {
+        TaskStatus::Stashed
+    } else {
+        TaskStatus::Queued
+    };
+
+    let task = Task::new(message.command, message.path, starting_status);
     let task_id: usize;
     {
         let mut state = state.lock().unwrap();

--- a/shared/message.rs
+++ b/shared/message.rs
@@ -42,6 +42,7 @@ pub struct AddMessage {
     pub command: String,
     pub path: String,
     pub start_immediately: bool,
+    pub create_stashed: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -35,13 +35,13 @@ pub struct Task {
 }
 
 impl Task {
-    pub fn new(command: String, path: String) -> Task {
+    pub fn new(command: String, path: String, starting_status: TaskStatus) -> Task {
         Task {
             id: 0,
             command: command,
             path: path,
-            status: TaskStatus::Queued,
-            prev_status: TaskStatus::Queued,
+            status: starting_status.clone(),
+            prev_status: starting_status,
             exit_code: None,
             stdout: None,
             stderr: None,


### PR DESCRIPTION
Based on our discussion in !72, I added a `--stash` flag to `stash add`. It seemed like a good way to get my feet wet. I have been running this for a few hours locally and I haven't seen anything unexpected.

Since it does not make sense to specify both `--immediate` and `--stash`, I marked the options as conflicting.

This is my first Rust PR, so I probably did some dumb things. Add that to my already thick skin and it is almost impossible to offend me with any requested changes. So, hold the quality of the code up to your highest standard.