### PR TITLE
Avoid repeatedly cloning large output strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ strum_macros = "^0.18"
 
 bytes = "^0.5"
 byteorder = "^1"
-serde = "^1.0"
+serde = { version = "^1.0", features = ["rc"] }
 serde_json = "^1.0"
 serde_yaml = "^0.8"
 serde_derive = "^1.0"

--- a/daemon/instructions.rs
+++ b/daemon/instructions.rs
@@ -348,7 +348,7 @@ fn reset(sender: &Sender<Message>) -> Message {
     return create_success_message("Everything is being reset right now.");
 }
 
-/// Return the current state without any stdou/stderr to the client
+/// Return the current state without any stdout/stderr to the client
 /// Invoked when calling `pueue status`
 fn get_status(state: &SharedState) -> Message {
     let mut state = { state.lock().unwrap().clone() };

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -2,6 +2,7 @@ use ::std::collections::BTreeMap;
 use ::std::io::Write;
 use ::std::process::Stdio;
 use ::std::process::{Child, Command};
+use ::std::sync::Arc;
 use ::std::sync::mpsc::Receiver;
 use ::std::time::Duration;
 
@@ -163,7 +164,7 @@ impl TaskHandler {
                 error!("{}", error);
                 clean_log_handles(task_id, &self.settings);
                 task.status = TaskStatus::Failed;
-                task.stderr = Some(error);
+                task.stderr = Some(Arc::new(error));
 
                 // Pause the daemon, if the settings say so
                 if self.settings.daemon.pause_on_failure {
@@ -229,7 +230,7 @@ impl TaskHandler {
 
             // Get the stdout and stderr of this task from the output files
             let (stdout, stderr) = match read_log_files(*task_id, &self.settings) {
-                Ok((stdout, stderr)) => (Some(stdout), Some(stderr)),
+                Ok((stdout, stderr)) => (Some(Arc::new(stdout)), Some(Arc::new(stderr))),
                 Err(err) => {
                     error!(
                         "Failed reading log files for task {} with error {:?}",

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -1,5 +1,6 @@
 use ::chrono::prelude::*;
 use ::serde_derive::{Deserialize, Serialize};
+use ::std::sync::Arc;
 use ::strum_macros::{Display, EnumIter};
 
 #[derive(Clone, Display, Debug, Serialize, Deserialize, PartialEq, EnumIter)]
@@ -29,8 +30,11 @@ pub struct Task {
     pub status: TaskStatus,
     pub prev_status: TaskStatus,
     pub exit_code: Option<i32>,
-    pub stdout: Option<String>,
-    pub stderr: Option<String>,
+    // stdout and stderr are serialized with the serde `rc` flag. Serialization
+    // won't deduplicate shared pointers, but this is OK because we don't expect
+    // pointers to be shared across tasks.
+    pub stdout: Option<Arc<String>>,
+    pub stderr: Option<Arc<String>>,
     pub start: Option<DateTime<Local>>,
     pub end: Option<DateTime<Local>>,
 }


### PR DESCRIPTION
Hold stdout and stderr in Arc refcounts so that the task can be cloned
or sent between threads without cloning the potentially-large
buffers.

In particular, because the logs were previously held inline in the
`State`, this makes manipulation of the BTree faster because the nodes
are (much) smaller.

Helps with https://github.com/Nukesor/pueue/issues/82.