### PR TITLE
Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ It provides functionality for:
 - Scheduling commands that will be executed in their respective working directories
 - Easy output inspection.
 - Interaction with running processes
-- Pausing/Resuming tasks, when you need some processing power right NOW!
+- Pause/Resume resume tasks, when you need some processing power right NOW!
 - Manipulation of the scheduled task order
 - Running multiple tasks at once (You can decide how many concurrent tasks you want to run)
+- Group. Each group acts as their own queue.
 - Works on Linux and MacOS and partially on Windows.
 
 **Disclaimer:** Windows support isn't fully there yet. This means:
@@ -219,6 +220,17 @@ If you want to dig right into it, you can compile and run it yourself with a deb
 This would help me a lot!
 
 ## Utilities
+
+### Groups
+
+Grouping tasks can be useful, whenever your tasks utilize different system resources.  
+For example, it could be very useful to have an `io` group for tasks that copy large files, while your cpu-heavy reencoding tasks are in group `cpu`.
+The parallelism setting of `io` could then be set to `1` and `cpu` be set to `2`.  
+
+As a result, there'll always be a single task that copies stuff, while two tasks try to utilize your cpu as good as possible.
+
+This removes the problem of scheduling tasks in a way that the system might get slow.
+At the same time, you're able to maximize resource utilization.
 
 ### Callbacks 
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ These are the available variables that can be used to create a command:
 - `{{ command }}`
 - `{{ path }}`
 - `{{ result }}` (Success, Killed, etc.)
+- `{{ group }}`
 
 Example callback:
 ```

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -154,6 +154,17 @@ pub enum SubCommand {
         #[structopt(short, long)]
         path: bool,
     },
+    /// Manage groups.
+    /// Without any flags, this will simply display all known groups.
+    Groups {
+        /// Add a group
+        #[structopt(short, long)]
+        add: Option<String>,
+        /// Remove a group.
+        /// This will move all tasks in this group to the default group!
+        #[structopt(short, long)]
+        remove: Option<String>,
+    },
 
     /// Display the current status of all tasks.
     Status {

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -27,6 +27,12 @@ pub enum SubCommand {
         #[structopt(name = "delay", short, long, conflicts_with = "immediate", parse(try_from_str=parse_delay_until))]
         delay_until: Option<DateTime<Local>>,
 
+        /// Assign the task to a group. Groups kind of act as separate queues.
+        /// I.e. all groups run in parallel and you can specify the amount of parallel tasks for each group
+        /// If no group is specified, the default group will be used.
+        #[structopt(name = "group", short, long)]
+        group: Option<String>,
+
         /// Start the task once all specified tasks have successfully finished.
         /// As soon as one of the dependencies fails, this task will fail as well
         #[structopt(name = "after", short, long)]
@@ -188,8 +194,13 @@ pub enum SubCommand {
 
     /// Set the amount of allowed parallel tasks
     Parallel {
-        /// The amount of allowed paralel tasks
+        /// The amount of allowed parallel tasks
+        #[structopt(validator=min_one)]
         parallel_tasks: usize,
+
+        /// Specify the amount of parallel tasks for this group
+        #[structopt(name = "group", short, long)]
+        group: Option<String>,
     },
     /// Generates shell completion files.
     /// Ingore for normal operations
@@ -237,4 +248,19 @@ fn parse_delay_until(src: &str) -> Result<DateTime<Local>, String> {
     Err(String::from(
         "could not parse as seconds or date expression",
     ))
+}
+
+
+fn min_one(value: String) -> Result<(), String> {
+    match value.parse::<i32>() {
+        Ok(value) => {
+            if value < 1 {
+                return Err("You must provide a value thats bigger than 1".into());
+            }
+            return Ok(())
+        },
+        Err(_) => {
+            return Err("Failed to parse integer".into());
+        },
+    }
 }

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -8,13 +8,13 @@ use ::structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
 pub enum SubCommand {
-    /// Enqueue a task for execution
+    /// Enqueue a task for execution.
     Add {
         /// The command that should be added.
         #[structopt()]
         command: Vec<String>,
 
-        /// Start the task immediately
+        /// Start the task immediately.
         #[structopt(name = "immediate", short, long, conflicts_with = "stash")]
         start_immediately: bool,
 
@@ -28,33 +28,33 @@ pub enum SubCommand {
         delay_until: Option<DateTime<Local>>,
 
         /// Assign the task to a group. Groups kind of act as separate queues.
-        /// I.e. all groups run in parallel and you can specify the amount of parallel tasks for each group
+        /// I.e. all groups run in parallel and you can specify the amount of parallel tasks for each group.
         /// If no group is specified, the default group will be used.
         #[structopt(name = "group", short, long)]
         group: Option<String>,
 
         /// Start the task once all specified tasks have successfully finished.
-        /// As soon as one of the dependencies fails, this task will fail as well
+        /// As soon as one of the dependencies fails, this task will fail as well.
         #[structopt(name = "after", short, long)]
         dependencies: Vec<usize>,
     },
     /// Remove tasks from the list.
     /// Running or paused tasks need to be killed first.
     Remove {
-        /// The task ids to be removed
+        /// The task ids to be removed.
         task_ids: Vec<usize>,
     },
     /// Switches the queue position of two commands. Only works on queued and stashed commands.
     Switch {
-        /// The first task id
+        /// The first task id.
         task_id_1: usize,
-        /// The second task id
+        /// The second task id.
         task_id_2: usize,
     },
     /// Stashed tasks won't be automatically started.
     /// Either `enqueue` them, to be normally handled or explicitly `start` them.
     Stash {
-        /// The id(s) of the tasks you want to stash
+        /// The id(s) of the tasks you want to stash.
         task_ids: Vec<usize>,
     },
     /// Enqueue stashed tasks. They'll be handled normally afterwards.
@@ -81,10 +81,10 @@ pub enum SubCommand {
     3600s                 // 3600 seconds from now
 ")]
     Enqueue {
-        /// The id(s) of the tasks you want to enqueue
+        /// The id(s) of the tasks you want to enqueue.
         task_ids: Vec<usize>,
 
-        /// Delay enqueuing the tasks until <delay> elapses. See DELAY FORMAT below
+        /// Delay enqueuing the tasks until <delay> elapses. See DELAY FORMAT below.
         #[structopt(name = "delay", short, long, parse(try_from_str=parse_delay_until))]
         delay_until: Option<DateTime<Local>>,
     },
@@ -103,7 +103,7 @@ pub enum SubCommand {
         #[structopt()]
         task_ids: Vec<usize>,
 
-        /// Start the task(s) immediately
+        /// Start the task(s) immediately.
         #[structopt(name = "immediate", short, long)]
         start_immediately: bool,
 
@@ -137,51 +137,51 @@ pub enum SubCommand {
         task_ids: Vec<usize>,
     },
 
-    /// Send something to a task. Useful for sending confirmations ('y\n')
+    /// Send something to a task. Useful for sending confirmations ('y\n').
     Send {
-        /// The id of the task
+        /// The id of the task.
         task_id: usize,
 
-        /// The input that should be sent to the process
+        /// The input that should be sent to the process.
         input: String,
     },
     /// Edit the command or the path of a stashed or queued task.
     Edit {
-        /// The id of the task
+        /// The id of the task.
         task_id: usize,
 
-        /// Edit the path of the task
+        /// Edit the path of the task.
         #[structopt(short, long)]
         path: bool,
     },
 
-    /// Display the current status of all tasks
+    /// Display the current status of all tasks.
     Status {
-        /// Print the current state as json to stdout
+        /// Print the current state as json to stdout.
         /// This doesn't include stdout/stderr of tasks.
-        /// Use `log -j` if you want everything
+        /// Use `log -j` if you want everything.
         #[structopt(short, long)]
         json: bool,
     },
-    /// Display the log output of finished tasks
+    /// Display the log output of finished tasks.
     Log {
-        /// Specify for which specific tasks you want to see the output
+        /// Specify for which specific tasks you want to see the output.
         #[structopt()]
         task_ids: Vec<usize>,
-        /// Print the current state as json
-        /// Includes EVERYTHING
+        /// Print the current state as json.
+        /// Includes EVERYTHING.
         #[structopt(short, long)]
         json: bool,
     },
-    /// Show the output of a currently running task
-    /// This command allows following (like `tail -f`)
+    /// Show the output of a currently running task.
+    /// This command allows following (like `tail -f`).
     Show {
-        /// The id of the task
+        /// The id of the task.
         task_id: usize,
-        /// Continuously print stdout (like `tail -f`)
+        /// Continuously print stdout (like `tail -f`).
         #[structopt(short, long)]
         follow: bool,
-        /// Like -f, but shows stderr instead of stdeout.
+        /// Like -f, but shows stderr instead of stdout.
         #[structopt(short, long)]
         err: bool,
     },
@@ -192,22 +192,22 @@ pub enum SubCommand {
     /// Remotely shut down the daemon. Should only be used if the daemon isn't started by a service manager.
     Shutdown,
 
-    /// Set the amount of allowed parallel tasks
+    /// Set the amount of allowed parallel tasks.
     Parallel {
-        /// The amount of allowed parallel tasks
+        /// The amount of allowed parallel tasks.
         #[structopt(validator=min_one)]
         parallel_tasks: usize,
 
-        /// Specify the amount of parallel tasks for this group
+        /// Specify the amount of parallel tasks for this group.
         #[structopt(name = "group", short, long)]
         group: Option<String>,
     },
     /// Generates shell completion files.
-    /// Ingore for normal operations
+    /// Ingore for normal operations.
     Completions {
         /// The target shell. Can be `bash`, `fish`, `powershell`, `elvish` and `zsh`.
         shell: Shell,
-        /// The output directory to which the file should be written
+        /// The output directory to which the file should be written.
         output_directory: PathBuf,
     },
 }
@@ -219,7 +219,7 @@ pub enum SubCommand {
     author = "Arne Beer <contact@arne.beer>"
 )]
 pub struct Opt {
-    // The number of occurrences of the `v/verbose` flag
+    // The number of occurrences of the `v/verbose` flag.
     /// Verbose mode (-v, -vv, -vvv)
     #[structopt(short, long, parse(from_occurrences))]
     pub verbose: u8,
@@ -227,7 +227,7 @@ pub struct Opt {
     //    /// The url for the daemon. Overwrites the address in the config file
     //    #[structopt(short, long)]
     //    pub address: Option<String>,
-    /// The port for the daemon. Overwrites the port in the config file
+    /// The port for the daemon. Overwrites the port in the config file.
     #[structopt(short, long)]
     pub port: Option<String>,
 
@@ -250,17 +250,17 @@ fn parse_delay_until(src: &str) -> Result<DateTime<Local>, String> {
     ))
 }
 
-
+/// Validator function. The input string has to be parsable as int and bigger than 0
 fn min_one(value: String) -> Result<(), String> {
-    match value.parse::<i32>() {
+    match value.parse::<usize>() {
         Ok(value) => {
             if value < 1 {
-                return Err("You must provide a value thats bigger than 1".into());
+                return Err("You must provide a value that's bigger than 0".into());
             }
-            return Ok(())
-        },
+            return Ok(());
+        }
         Err(_) => {
             return Err("Failed to parse integer".into());
-        },
+        }
     }
 }

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -268,10 +268,10 @@ fn min_one(value: String) -> Result<(), String> {
             if value < 1 {
                 return Err("You must provide a value that's bigger than 0".into());
             }
-            return Ok(());
+            Ok(())
         }
         Err(_) => {
-            return Err("Failed to parse integer".into());
+            Err("Failed to parse integer".into())
         }
     }
 }

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -156,7 +156,7 @@ pub enum SubCommand {
     },
     /// Manage groups.
     /// Without any flags, this will simply display all known groups.
-    Groups {
+    Group {
         /// Add a group
         #[structopt(short, long)]
         add: Option<String>,

--- a/client/client.rs
+++ b/client/client.rs
@@ -10,13 +10,13 @@ use ::pueue::message::*;
 use ::pueue::protocol::*;
 use ::pueue::settings::Settings;
 
-/// Representation of a client
-/// For convenience purposes this logic has been wrapped in a struct
+/// Representation of a client.
+/// For convenience purposes this logic has been wrapped in a struct.
 /// The client is responsible for connecting to the daemon, sending an instruction
-/// and interpreting the response
+/// and interpreting the response.
 ///
 /// Most commands are a simple ping-pong. Though, some commands require a more complex
-/// communication pattern (e.g. `show -f`, which contiuously streams the output of a task)
+/// communication pattern (e.g. `show -f`, which contiuously streams the output of a task).
 pub struct Client {
     opt: Opt,
     daemon_address: String,

--- a/client/client.rs
+++ b/client/client.rs
@@ -48,7 +48,7 @@ impl Client {
             opt,
             daemon_address: address,
             message,
-            settings: settings,
+            settings,
         })
     }
 

--- a/client/edit.rs
+++ b/client/edit.rs
@@ -7,10 +7,10 @@ use ::pueue::message::*;
 
 use crate::cli::SubCommand;
 
-/// This function allows the user to edit a task's command or path
-/// Save the string to a temporary file, which is the edited by the user with $EDITOR
+/// This function allows the user to edit a task's command or path.
+/// Save the string to a temporary file, which is the edited by the user with $EDITOR.
 /// As soon as the editor is closed, read the file content and return the
-/// final edit message with the updated command to the daemon
+/// final edit message with the updated command to the daemon.
 pub fn edit(message: EditResponseMessage, cli_command: &SubCommand) -> Message {
     let edit_path = match cli_command {
         SubCommand::Edit { task_id: _, path } => *path,
@@ -28,18 +28,18 @@ pub fn edit(message: EditResponseMessage, cli_command: &SubCommand) -> Message {
         command.clone()
     };
 
-    // Create a temporary file with the command, vim can edit
+    // Create a temporary file with the command so we can edit it with the editor.
     let mut file = NamedTempFile::new().expect("Failed to create a temporary file");
     writeln!(file, "{}", to_edit).expect("Failed writing to temporary file");
 
-    // Start the editor on this file
+    // Start the editor on this file.
     let editor = &env::var("EDITOR").unwrap_or_else(|_e| "vi".to_string());
     Command::new(editor)
         .arg(file.path())
         .status()
         .expect("Failed to start editor");
 
-    // Read the file
+    // Read the file.
     let mut file = file.into_file();
     file.seek(SeekFrom::Start(0))
         .expect("Couldn't seek to start of file. Aborting.");
@@ -47,7 +47,7 @@ pub fn edit(message: EditResponseMessage, cli_command: &SubCommand) -> Message {
     file.read_to_string(&mut to_edit)
         .expect("Failed to read Command after editing");
 
-    // Remove any trailing newlines from the command
+    // Remove any trailing newlines from the command.
     while to_edit.ends_with('\n') || to_edit.ends_with('\r') {
         to_edit.pop();
     }

--- a/client/edit.rs
+++ b/client/edit.rs
@@ -13,7 +13,7 @@ use crate::cli::SubCommand;
 /// final edit message with the updated command to the daemon.
 pub fn edit(message: EditResponseMessage, cli_command: &SubCommand) -> Message {
     let edit_path = match cli_command {
-        SubCommand::Edit { task_id: _, path } => *path,
+        SubCommand::Edit { path, .. } => *path,
         _ => panic!(
             "Got wrong Subcommand {:?} in edit. This shouldn't happen",
             cli_command

--- a/client/main.rs
+++ b/client/main.rs
@@ -23,10 +23,10 @@ async fn main() -> Result<()> {
         println!("{:?}", save_result.err());
     }
 
-    // Parse commandline options
+    // Parse commandline options.
     let opt = Opt::from_args();
 
-    // Set the verbosity level for the client app
+    // Set the verbosity level for the client app.
     if opt.verbose >= 3 {
         SimpleLogger::init(LevelFilter::Debug, Config::default())?;
     } else if opt.verbose == 2 {
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     }
 
     // Create the message that should be sent to the daemon
-    // depending on the given commandline options
+    // depending on the given commandline options.
     let message = get_message_from_opt(&opt, &settings)?;
     let mut client = Client::new(settings, message, opt)?;
     client.run().await?;

--- a/client/message.rs
+++ b/client/message.rs
@@ -89,7 +89,7 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             };
             Ok(Message::Send(message))
         }
-        SubCommand::Edit { task_id, path: _ } => Ok(Message::EditRequest(*task_id)),
+        SubCommand::Edit { task_id, .. } => Ok(Message::EditRequest(*task_id)),
         SubCommand::Group { add, remove } => {
             let message = GroupMessage {
                 add: add.clone(),
@@ -97,8 +97,8 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             };
             Ok(Message::Group(message))
         }
-        SubCommand::Status { json: _ } => Ok(Message::Status),
-        SubCommand::Log { task_ids, json: _ } => {
+        SubCommand::Status { .. } => Ok(Message::Status),
+        SubCommand::Log { task_ids, .. } => {
             let message = LogRequestMessage {
                 task_ids: task_ids.clone(),
                 send_logs: !settings.client.read_local_logs,
@@ -130,9 +130,6 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             };
             Ok(Message::Parallel(message))
         }
-        SubCommand::Completions {
-            shell: _,
-            output_directory: _,
-        } => Err(anyhow!("Completions have to be handled earlier")),
+        SubCommand::Completions { .. } => Err(anyhow!("Completions have to be handled earlier")),
     }
 }

--- a/client/message.rs
+++ b/client/message.rs
@@ -90,7 +90,7 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             Ok(Message::Send(message))
         }
         SubCommand::Edit { task_id, path: _ } => Ok(Message::EditRequest(*task_id)),
-        SubCommand::Groups { add, remove } => {
+        SubCommand::Group { add, remove } => {
             let message = GroupMessage {
                 add: add.clone(),
                 remove: remove.clone(),

--- a/client/message.rs
+++ b/client/message.rs
@@ -7,7 +7,7 @@ use ::pueue::settings::Settings;
 use crate::cli::{Opt, SubCommand};
 
 // Convert and pre-process the sub-command into a valid message
-// that can be understood by the daemon
+// that can be understood by the daemon.
 pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
     match &opt.cmd {
         SubCommand::Add {
@@ -114,13 +114,16 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
         SubCommand::Clean => Ok(Message::Clean),
         SubCommand::Reset => Ok(Message::Reset),
         SubCommand::Shutdown => Ok(Message::DaemonShutdown),
-        SubCommand::Parallel { parallel_tasks, group } => {
+        SubCommand::Parallel {
+            parallel_tasks,
+            group,
+        } => {
             let message = ParallelMessage {
                 parallel_tasks: *parallel_tasks,
                 group: group.clone(),
             };
             Ok(Message::Parallel(message))
-        },
+        }
         SubCommand::Completions {
             shell: _,
             output_directory: _,

--- a/client/message.rs
+++ b/client/message.rs
@@ -90,7 +90,13 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             Ok(Message::Send(message))
         }
         SubCommand::Edit { task_id, path: _ } => Ok(Message::EditRequest(*task_id)),
-
+        SubCommand::Groups { add, remove } => {
+            let message = GroupMessage {
+                add: add.clone(),
+                remove: remove.clone(),
+            };
+            Ok(Message::Group(message))
+        }
         SubCommand::Status { json: _ } => Ok(Message::Status),
         SubCommand::Log { task_ids, json: _ } => {
             let message = LogRequestMessage {

--- a/client/message.rs
+++ b/client/message.rs
@@ -14,6 +14,7 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
             command,
             start_immediately,
             stashed,
+            group,
             delay_until,
             dependencies,
         } => {
@@ -26,6 +27,7 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
                 path: cwd.to_string(),
                 start_immediately: *start_immediately,
                 stashed: *stashed,
+                group: group.clone(),
                 enqueue_at: *delay_until,
                 dependencies: dependencies.to_vec(),
             }))
@@ -112,8 +114,13 @@ pub fn get_message_from_opt(opt: &Opt, settings: &Settings) -> Result<Message> {
         SubCommand::Clean => Ok(Message::Clean),
         SubCommand::Reset => Ok(Message::Reset),
         SubCommand::Shutdown => Ok(Message::DaemonShutdown),
-
-        SubCommand::Parallel { parallel_tasks } => Ok(Message::Parallel(*parallel_tasks)),
+        SubCommand::Parallel { parallel_tasks, group } => {
+            let message = ParallelMessage {
+                parallel_tasks: *parallel_tasks,
+                group: group.clone(),
+            };
+            Ok(Message::Parallel(message))
+        },
         SubCommand::Completions {
             shell: _,
             output_directory: _,

--- a/client/output.rs
+++ b/client/output.rs
@@ -234,7 +234,7 @@ pub fn print_log(task_log: &mut TaskLogMessage, settings: &Settings) {
     // Print task id and exit code.
     let task_text = style(format!("Task {} ", task.id)).attribute(Attribute::Bold);
     let exit_status = match &task.result {
-        Some(TaskResult::Success) => style(format!("with exit code 0")).with(Color::Green),
+        Some(TaskResult::Success) => style("with exit code 0".into()).with(Color::Green),
         Some(TaskResult::Failed(exit_code)) => {
             style(format!("with exit code {}", exit_code)).with(Color::Red)
         }

--- a/client/output.rs
+++ b/client/output.rs
@@ -24,7 +24,7 @@ pub fn print_error(message: String) {
     println!("{}", styled);
 }
 
-/// Print the current state of the daemon in a nicely formatted table
+/// Print the current state of the daemon in a nicely formatted table.
 pub fn print_state(state: State, cli_command: &SubCommand) {
     let json = match cli_command {
         SubCommand::Status { json } => *json,
@@ -34,13 +34,13 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
         ),
     };
 
-    // If the json flag is specified, print the state as json and exit
+    // If the json flag is specified, print the state as json and exit.
     if json {
         println!("{}", serde_json::to_string(&state).unwrap());
         return;
     }
 
-    // Print the current daemon state
+    // Print the current daemon state.
     if state.running {
         println!("{}", style("Daemon status: running").with(Color::Green));
     } else {
@@ -54,21 +54,21 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
     }
 
     // Check whether there are any delayed tasks.
-    // In case there are, we need to add another column to the table
+    // In case there are, we need to add another column to the table.
     let has_delayed_tasks = state
         .tasks
         .iter()
         .any(|(_id, task)| task.enqueue_at.is_some());
 
     // Check whether there are any tasks with dependencies.
-    // In case there are, we need to add another column to the table
+    // In case there are, we need to add another column to the table.
     let has_dependencies = state
         .tasks
         .iter()
         .any(|(_id, task)| !task.dependencies.is_empty());
 
-    // Check whether there are any tasks with dependencies.
-    // In case there are, we need to add another column to the table
+    // Check whether there are any tasks with a custom group.
+    // In case there are, we need to add another column to the table.
     let has_group = state.tasks.iter().any(|(_id, task)| task.group.is_some());
 
     // Create table header row
@@ -90,19 +90,19 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
         Cell::new("End"),
     ]);
 
-    // Initialize comfy table
+    // Initialize comfy table.
     let mut table = Table::new();
     table
         .set_content_arrangement(ContentArrangement::Dynamic)
         .load_preset(UTF8_HORIZONTAL_BORDERS_ONLY)
         .set_header(headers);
 
-    // Add rows one by one
+    // Add rows one by one.
     for (id, task) in state.tasks {
         let mut row = Row::new();
         row.add_cell(Cell::new(&id.to_string()));
 
-        // Determine the human readable task status representation and the respective color
+        // Determine the human readable task status representation and the respective color.
         let status_string = task.status.to_string();
         let (status_text, color) = match task.status {
             TaskStatus::Running => (status_string, Color::Green),
@@ -144,7 +144,7 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
             }
         }
 
-        // Match the color of the exit code
+        // Match the color of the exit code.
         // If the exit_code is none, it has been killed by the task handler.
         let exit_code_cell = match task.result {
             Some(TaskResult::Success) => Cell::new("0").fg(Color::Green),
@@ -153,11 +153,11 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
         };
         row.add_cell(exit_code_cell);
 
-        // Add command and path
+        // Add command and path.
         row.add_cell(Cell::new(&task.command));
         row.add_cell(Cell::new(&task.path));
 
-        // Add start time, if already set
+        // Add start time, if already set.
         if let Some(start) = task.start {
             let formatted = start.format("%H:%M").to_string();
             row.add_cell(Cell::new(&formatted));
@@ -165,7 +165,7 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
             row.add_cell(Cell::new(""));
         }
 
-        // Add finish time, if already set
+        // Add finish time, if already set.
         if let Some(end) = task.end {
             let formatted = end.format("%H:%M").to_string();
             row.add_cell(Cell::new(&formatted));
@@ -176,7 +176,7 @@ pub fn print_state(state: State, cli_command: &SubCommand) {
         table.add_row(row);
     }
 
-    // Print the table
+    // Print the table.
     println!("{}", table);
 }
 
@@ -214,7 +214,7 @@ pub fn print_logs(
     while let Some((_, mut task_log)) = task_iter.next() {
         print_log(&mut task_log, settings);
 
-        // Add a newline if there is another task that's going to be printed
+        // Add a newline if there is another task that's going to be printed.
         if let Some((_, task_log)) = task_iter.peek() {
             if task_log.task.status == TaskStatus::Done {
                 println!();
@@ -226,12 +226,12 @@ pub fn print_logs(
 /// Print the log of a single task.
 pub fn print_log(task_log: &mut TaskLogMessage, settings: &Settings) {
     let task = &task_log.task;
-    // We only show logs of finished tasks
+    // We only show logs of finished tasks.
     if task.status != TaskStatus::Done {
         return;
     }
 
-    // Print task id and exit code
+    // Print task id and exit code.
     let task_text = style(format!("Task {} ", task.id)).attribute(Attribute::Bold);
     let exit_status = match &task.result {
         Some(TaskResult::Success) => style(format!("with exit code 0")).with(Color::Green),
@@ -249,7 +249,7 @@ pub fn print_log(task_log: &mut TaskLogMessage, settings: &Settings) {
     };
     print!("{} {}", task_text, exit_status);
 
-    // Print command and path
+    // Print command and path.
     println!("Command: {}", task.command);
     println!("Path: {}", task.path);
 
@@ -281,7 +281,7 @@ pub fn print_local_log_output(task_id: usize, settings: &Settings) {
             }
         };
     // Stdout handler to directly write log file output to io::stdout
-    // without having to load anything into memory
+    // without having to load anything into memory.
     let mut stdout = io::stdout();
 
     if let Ok(metadata) = stdout_log.metadata() {
@@ -315,9 +315,9 @@ pub fn print_local_log_output(task_id: usize, settings: &Settings) {
     }
 }
 
-/// Prints log output received from the daemon
+/// Prints log output received from the daemon.
 /// We can safely call .unwrap() on stdout and stderr in here, since this
-/// branch is always called after ensuring that both are `Some`
+/// branch is always called after ensuring that both are `Some`.
 pub fn print_task_output_from_daemon(task_log: &TaskLogMessage) {
     if !task_log.stdout.as_ref().unwrap().is_empty() {
         if let Err(err) = print_remote_task_output(&task_log, true) {

--- a/daemon/cli.rs
+++ b/daemon/cli.rs
@@ -11,17 +11,13 @@ pub struct Opt {
     #[structopt(short, long, parse(from_occurrences))]
     pub verbose: u8,
 
-    /// If this flag is set, the daemon will start and fork itself
-    /// into the background. Closing the terminal won't kill the
-    /// daemon any longer. This should be avoided and rather be
-    /// properly done using a service manager.
+    /// If this flag is set, the daemon will start and fork itself into the background.
+    /// Closing the terminal won't kill the daemon any longer.
+    /// This should be avoided and rather be properly done using a service manager.
     #[structopt(short, long)]
     pub daemonize: bool,
 
-    //    /// The ip the daemon listens on. Overwrites the address in the config file
-    //    #[structopt(short, long)]
-    //    pub address: Option<String>,
-    /// The port the daemon listens on. Overwrites the port in the config file
+    /// The port the daemon listens on. Overwrites the port in the config file.
     #[structopt(short, long)]
     pub port: Option<String>,
 }

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -32,14 +32,14 @@ async fn main() -> Result<()> {
         Ok(()) => {}
     };
 
-    // Parse commandline options
+    // Parse commandline options.
     let opt = Opt::from_args();
 
     if opt.daemonize {
         fork_daemon(&opt)?;
     }
 
-    // Set the verbosity level for the client app
+    // Set the verbosity level for the client app.
     if opt.verbose >= 3 {
         SimpleLogger::init(LevelFilter::Debug, Config::default())?;
     } else if opt.verbose == 2 {
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Initialize all directories needed for normal operation
+/// Initialize all directories needed for normal operation.
 fn init_directories(path: &String) {
     let pueue_dir = Path::new(path);
     if !pueue_dir.exists() {
@@ -99,8 +99,8 @@ fn init_directories(path: &String) {
     }
 }
 
-/// This is a simple and cheap custom fork method
-/// Simply spawn a new child with identical arguments and exit right away
+/// This is a simple and cheap custom fork method.
+/// Simply spawn a new child with identical arguments and exit right away.
 fn fork_daemon(opt: &Opt) -> Result<()> {
     let mut arguments = Vec::<String>::new();
 

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -1,4 +1,4 @@
-use ::anyhow::{bail, Error, Result};
+use ::anyhow::{bail, Result};
 use ::simplelog::{Config, LevelFilter, SimpleLogger};
 use ::std::fs::create_dir_all;
 use ::std::path::Path;
@@ -26,7 +26,6 @@ async fn main() -> Result<()> {
     let settings = Settings::new()?;
     match settings.save() {
         Err(error) => {
-            let error: Error = From::from(error);
             bail!(error.context("Failed saving the config file"));
         }
         Ok(()) => {}
@@ -68,7 +67,7 @@ async fn main() -> Result<()> {
 }
 
 /// Initialize all directories needed for normal operation.
-fn init_directories(path: &String) {
+fn init_directories(path: &str) {
     let pueue_dir = Path::new(path);
     if !pueue_dir.exists() {
         if let Err(error) = create_dir_all(&pueue_dir) {

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -56,13 +56,13 @@ async fn main() -> Result<()> {
     let state = Arc::new(Mutex::new(state));
 
     let (sender, receiver) = channel();
-    let mut task_handler = TaskHandler::new(settings.clone(), state.clone(), receiver);
+    let mut task_handler = TaskHandler::new(state.clone(), receiver);
 
     thread::spawn(move || {
         task_handler.run();
     });
 
-    accept_incoming(settings, sender, state.clone(), opt).await?;
+    accept_incoming(sender, state.clone(), opt).await?;
 
     Ok(())
 }

--- a/daemon/response_helper.rs
+++ b/daemon/response_helper.rs
@@ -7,7 +7,7 @@ pub fn task_response_helper(
     statuses: Vec<TaskStatus>,
     state: &SharedState,
 ) -> String {
-    // Get all matching/mismatching task_ids for all given ids and statuses
+    // Get all matching/mismatching task_ids for all given ids and statuses.
     let (matching, mismatching) = {
         let mut state = state.lock().unwrap();
         state.tasks_in_statuses(statuses, Some(task_ids))
@@ -28,7 +28,7 @@ pub fn compile_task_response(
     let mismatching: Vec<String> = mismatching.iter().map(|id| id.to_string()).collect();
     let matching_string = matching.join(", ");
 
-    // We don't have any mismatching ids, return the simple message
+    // We don't have any mismatching ids, return the simple message.
     if mismatching.is_empty() {
         return format!("{}: {}", message, matching_string);
     }
@@ -36,12 +36,12 @@ pub fn compile_task_response(
     let mismatched_message = "The command couldn't be executed for these tasks";
     let mismatching_string = mismatching.join(", ");
 
-    // All given ids are invalid
+    // All given ids are invalid.
     if matching.is_empty() {
         return format!("{}: {}", mismatched_message, mismatching_string);
     }
 
-    // Some ids were valid, some were invalid
+    // Some ids were valid, some were invalid.
     format!(
         "{}: {}\n{}: {}",
         message, matching_string, mismatched_message, mismatching_string

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -47,7 +47,7 @@ async fn handle_incoming(
     let payload_bytes = receive_bytes(&mut socket).await?;
 
     // Didn't receive any bytes. The client disconnected.
-    if payload_bytes.len() == 0 {
+    if payload_bytes.is_empty() {
         info!("Client went away");
         return Ok(());
     }

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -9,29 +9,17 @@ use crate::instructions::handle_message;
 use crate::streaming::handle_show;
 use ::pueue::message::*;
 use ::pueue::protocol::*;
-use ::pueue::settings::Settings;
 use ::pueue::state::SharedState;
 
 /// Poll the unix listener and accept new incoming connections
 /// Create a new future to handle the message and spawn it
-pub async fn accept_incoming(
-    settings: Settings,
-    sender: Sender<Message>,
-    state: SharedState,
-    opt: Opt,
-) -> Result<()> {
-    //    // Commandline argument overwrites the configuration files values for address
-    //    let address = if let Some(address) = opt.address.clone() {
-    //        address
-    //    } else {
-    //        settings.daemon.address.clone()
-    //    };
-
+pub async fn accept_incoming(sender: Sender<Message>, state: SharedState, opt: Opt) -> Result<()> {
     // Commandline argument overwrites the configuration files values for port
     let port = if let Some(port) = opt.port.clone() {
         port
     } else {
-        settings.daemon.port.clone()
+        let state = state.lock().unwrap();
+        state.settings.daemon.port.clone()
     };
     //    let address = format!("{}:{}", address, port);
     let address = format!("127.0.0.1:{}", port);
@@ -42,9 +30,8 @@ pub async fn accept_incoming(
         let (socket, _) = listener.accept().await?;
         let sender_clone = sender.clone();
         let state_clone = state.clone();
-        let settings_clone = settings.clone();
         task::spawn(async move {
-            let _result = handle_incoming(socket, sender_clone, state_clone, settings_clone).await;
+            let _result = handle_incoming(socket, sender_clone, state_clone).await;
         });
     }
 }
@@ -56,7 +43,6 @@ async fn handle_incoming(
     mut socket: TcpStream,
     sender: Sender<Message>,
     state: SharedState,
-    settings: Settings,
 ) -> Result<()> {
     // Receive the secret once and check, whether the client is allowed to connect
     let payload_bytes = receive_bytes(&mut socket).await?;
@@ -68,10 +54,22 @@ async fn handle_incoming(
     }
 
     let secret = String::from_utf8(payload_bytes)?;
-    if secret != settings.daemon.secret {
-        warn!("Received invalid secret: {}", secret);
-        bail!("Received invalid secret");
+
+    // Return immediately, if we got a wrong secret from the client
+    {
+        let state = state.lock().unwrap();
+        if secret != state.settings.daemon.secret {
+            warn!("Received invalid secret: {}", secret);
+            bail!("Received invalid secret");
+        }
     }
+
+    // Save the directory for convenience purposes and to prevent continuously
+    // locking the state in the streaming loop.
+    let pueue_directory = {
+        let state = state.lock().unwrap();
+        state.settings.daemon.pueue_directory.clone()
+    };
 
     loop {
         // Receive the actual instruction from the client
@@ -81,7 +79,7 @@ async fn handle_incoming(
         let response = if let Message::StreamRequest(message) = message {
             // The client requested the output of a task
             // Since we allow streaming, this needs to be handled seperately
-            handle_show(&settings, &mut socket, message).await?
+            handle_show(&pueue_directory, &mut socket, message).await?
         } else if let Message::DaemonShutdown = message {
             // Simply shut down the daemon right after sending a success response
             let response = create_success_message("Daemon is shutting down");

--- a/daemon/streaming.rs
+++ b/daemon/streaming.rs
@@ -12,7 +12,7 @@ use ::pueue::protocol::send_message;
 
 /// Handle the continuous stream of a message.
 pub async fn handle_show(
-    pueue_directory: &String,
+    pueue_directory: &str,
     socket: &mut TcpStream,
     message: StreamRequestMessage,
 ) -> Result<Message> {

--- a/daemon/streaming.rs
+++ b/daemon/streaming.rs
@@ -10,14 +10,14 @@ use ::pueue::log::*;
 use ::pueue::message::*;
 use ::pueue::protocol::send_message;
 
-/// Handle the continuous stream of a message
+/// Handle the continuous stream of a message.
 pub async fn handle_show(
     pueue_directory: &String,
     socket: &mut TcpStream,
     message: StreamRequestMessage,
 ) -> Result<Message> {
     if message.follow || message.err {
-        // The client requested streaming of stdout
+        // The client requested streaming of stdout.
         let mut handle: File;
         match get_log_file_handles(message.task_id, pueue_directory) {
             Err(_) => {
@@ -34,20 +34,20 @@ pub async fn handle_show(
             }
         }
 
-        // Get the stdout/stderr path
+        // Get the stdout/stderr path.
         // We need to check continuously, whether the file still exists,
-        // since the file can go away (e.g. due to finishing a task)
+        // since the file can go away (e.g. due to finishing a task).
         let (out_path, err_path) = get_log_paths(message.task_id, pueue_directory);
         let handle_path = if message.err { err_path } else { out_path };
 
         loop {
-            // Check whether the file still exists. Exit if it doesn't
+            // Check whether the file still exists. Exit if it doesn't.
             if !handle_path.exists() {
                 return Ok(create_success_message(
                     "File has gone away. The task probably just finished",
                 ));
             }
-            // Read the next chunk of text from the last position
+            // Read the next chunk of text from the last position.
             let mut buffer = Vec::new();
 
             if let Err(err) = handle.read_to_end(&mut buffer) {
@@ -55,15 +55,15 @@ pub async fn handle_show(
             };
             let text = String::from_utf8_lossy(&buffer).to_string();
 
-            // Send the new chunk and wait for 1 second
+            // Send the new chunk and wait for 1 second.
             let response = Message::Stream(text);
             send_message(response, socket).await?;
             let wait = future::ready(1).delay(Duration::from_millis(1000));
             wait.await;
         }
     } else {
-        // The client requested a one-shot execution
-        // Simply read the file and send the current stdout/stderr once
+        // The client requested a one-shot execution.
+        // Simply read the file and send the current stdout/stderr once.
         let (stdout, stderr) = match read_log_files(message.task_id, pueue_directory) {
             Err(_) => {
                 return Ok(create_failure_message(

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -670,6 +670,11 @@ impl TaskHandler {
         parameters.insert("command", task.command.clone());
         parameters.insert("path", task.path.clone());
         parameters.insert("result", task.result.clone().unwrap().to_string());
+        if let Some(group) = &task.group {
+            parameters.insert("group", group.clone());
+        } else {
+            parameters.insert("group", "default".into());
+        }
         let callback_command = match handlebars.render_template(&callback, &parameters) {
             Ok(command) => command,
             Err(err) => {

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -128,7 +128,7 @@ impl TaskHandler {
             }
         }
 
-        return state
+        state
             .tasks
             .iter()
             .filter(|(_, task)| task.status == TaskStatus::Queued)
@@ -161,15 +161,14 @@ impl TaskHandler {
                     running < &state.settings.daemon.default_parallel_tasks
                 }
             })
-            .filter(|(_, task)| {
+            .find(|(_, task)| {
                 // Check whether all dependencies for this task are fulfilled.
                 task.dependencies
                     .iter()
                     .flat_map(|id| state.tasks.get(id))
                     .all(|task| task.status == TaskStatus::Done)
             })
-            .next()
-            .map(|(id, _)| *id);
+            .map(|(id, _)| *id)
     }
 
     /// See if we can start a new queued task.
@@ -424,9 +423,8 @@ impl TaskHandler {
         //match self.receiver.recv_timeout(timeout) {
         std::thread::sleep(timeout);
 
-        match self.receiver.try_recv() {
-            Ok(message) => self.handle_message(message),
-            Err(_) => {}
+        if let Ok(message) = self.receiver.try_recv() {
+            self.handle_message(message);
         };
     }
 

--- a/shared/log.rs
+++ b/shared/log.rs
@@ -7,7 +7,7 @@ use ::std::io::prelude::*;
 use ::std::path::{Path, PathBuf};
 
 /// Return the paths to temporary stdout and stderr files for a task.
-pub fn get_log_paths(task_id: usize, path: &String) -> (PathBuf, PathBuf) {
+pub fn get_log_paths(task_id: usize, path: &str) -> (PathBuf, PathBuf) {
     let pueue_dir = Path::new(path).join("task_logs");
     let out_path = pueue_dir.join(format!("{}_stdout.log", task_id));
     let err_path = pueue_dir.join(format!("{}_stderr.log", task_id));
@@ -15,7 +15,7 @@ pub fn get_log_paths(task_id: usize, path: &String) -> (PathBuf, PathBuf) {
 }
 
 /// Create and return the file handle for temporary stdout and stderr files for a task.
-pub fn create_log_file_handles(task_id: usize, path: &String) -> Result<(File, File)> {
+pub fn create_log_file_handles(task_id: usize, path: &str) -> Result<(File, File)> {
     let (out_path, err_path) = get_log_paths(task_id, path);
     let stdout = File::create(out_path)?;
     let stderr = File::create(err_path)?;
@@ -24,7 +24,7 @@ pub fn create_log_file_handles(task_id: usize, path: &String) -> Result<(File, F
 }
 
 /// Return the file handle for temporary stdout and stderr files for a task.
-pub fn get_log_file_handles(task_id: usize, path: &String) -> Result<(File, File)> {
+pub fn get_log_file_handles(task_id: usize, path: &str) -> Result<(File, File)> {
     let (out_path, err_path) = get_log_paths(task_id, path);
     let stdout = File::open(out_path)?;
     let stderr = File::open(err_path)?;
@@ -33,7 +33,7 @@ pub fn get_log_file_handles(task_id: usize, path: &String) -> Result<(File, File
 }
 
 /// Return the content of temporary stdout and stderr files for a task.
-pub fn read_log_files(task_id: usize, path: &String) -> Result<(String, String)> {
+pub fn read_log_files(task_id: usize, path: &str) -> Result<(String, String)> {
     let (mut stdout_handle, mut stderr_handle) = get_log_file_handles(task_id, path)?;
     let mut stdout_buffer = Vec::new();
     let mut stderr_buffer = Vec::new();
@@ -48,7 +48,7 @@ pub fn read_log_files(task_id: usize, path: &String) -> Result<(String, String)>
 }
 
 /// Remove temporary stdout and stderr files for a task.
-pub fn clean_log_handles(task_id: usize, path: &String) {
+pub fn clean_log_handles(task_id: usize, path: &str) {
     let (out_path, err_path) = get_log_paths(task_id, path);
     if let Err(err) = remove_file(out_path) {
         error!(
@@ -66,7 +66,7 @@ pub fn clean_log_handles(task_id: usize, path: &String) {
 
 /// Return stdout and stderr of a finished process.
 /// Task output is compressed using snap to save some memory and bandwidth.
-pub fn read_and_compress_log_files(task_id: usize, path: &String) -> Result<(Vec<u8>, Vec<u8>)> {
+pub fn read_and_compress_log_files(task_id: usize, path: &str) -> Result<(Vec<u8>, Vec<u8>)> {
     let (mut stdout_handle, mut stderr_handle) = match get_log_file_handles(task_id, path) {
         Ok((stdout, stderr)) => (stdout, stderr),
         Err(err) => {

--- a/shared/log.rs
+++ b/shared/log.rs
@@ -6,7 +6,7 @@ use ::std::io;
 use ::std::io::prelude::*;
 use ::std::path::{Path, PathBuf};
 
-/// Return the paths to temporary stdout and stderr files for a task
+/// Return the paths to temporary stdout and stderr files for a task.
 pub fn get_log_paths(task_id: usize, path: &String) -> (PathBuf, PathBuf) {
     let pueue_dir = Path::new(path).join("task_logs");
     let out_path = pueue_dir.join(format!("{}_stdout.log", task_id));
@@ -14,7 +14,7 @@ pub fn get_log_paths(task_id: usize, path: &String) -> (PathBuf, PathBuf) {
     (out_path, err_path)
 }
 
-/// Create and return the file handle for temporary stdout and stderr files for a task
+/// Create and return the file handle for temporary stdout and stderr files for a task.
 pub fn create_log_file_handles(task_id: usize, path: &String) -> Result<(File, File)> {
     let (out_path, err_path) = get_log_paths(task_id, path);
     let stdout = File::create(out_path)?;
@@ -23,7 +23,7 @@ pub fn create_log_file_handles(task_id: usize, path: &String) -> Result<(File, F
     Ok((stdout, stderr))
 }
 
-/// Return the file handle for temporary stdout and stderr files for a task
+/// Return the file handle for temporary stdout and stderr files for a task.
 pub fn get_log_file_handles(task_id: usize, path: &String) -> Result<(File, File)> {
     let (out_path, err_path) = get_log_paths(task_id, path);
     let stdout = File::open(out_path)?;
@@ -32,7 +32,7 @@ pub fn get_log_file_handles(task_id: usize, path: &String) -> Result<(File, File
     Ok((stdout, stderr))
 }
 
-/// Return the content of temporary stdout and stderr files for a task
+/// Return the content of temporary stdout and stderr files for a task.
 pub fn read_log_files(task_id: usize, path: &String) -> Result<(String, String)> {
     let (mut stdout_handle, mut stderr_handle) = get_log_file_handles(task_id, path)?;
     let mut stdout_buffer = Vec::new();
@@ -47,7 +47,7 @@ pub fn read_log_files(task_id: usize, path: &String) -> Result<(String, String)>
     Ok((stdout.to_string(), stderr.to_string()))
 }
 
-/// Remove temporary stdout and stderr files for a task
+/// Remove temporary stdout and stderr files for a task.
 pub fn clean_log_handles(task_id: usize, path: &String) {
     let (out_path, err_path) = get_log_paths(task_id, path);
     if let Err(err) = remove_file(out_path) {
@@ -64,8 +64,8 @@ pub fn clean_log_handles(task_id: usize, path: &String) {
     };
 }
 
-/// Return stdout and stderr of a finished process
-/// Everything is compressed using Brotli and then encoded to Base64
+/// Return stdout and stderr of a finished process.
+/// Task output is compressed using snap to save some memory and bandwidth.
 pub fn read_and_compress_log_files(task_id: usize, path: &String) -> Result<(Vec<u8>, Vec<u8>)> {
     let (mut stdout_handle, mut stderr_handle) = match get_log_file_handles(task_id, path) {
         Ok((stdout, stderr)) => (stdout, stderr),

--- a/shared/message.rs
+++ b/shared/message.rs
@@ -102,7 +102,7 @@ pub struct EditResponseMessage {
     pub path: String,
 }
 
-// The booleans decides, whether the stream should be continuous or a oneshot
+// The booleans decides, whether the stream should be continuous or a oneshot.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamRequestMessage {
     pub task_id: usize,
@@ -120,7 +120,7 @@ pub struct LogRequestMessage {
     pub send_logs: bool,
 }
 
-/// Helper struct for sending tasks and their log output to the client
+/// Helper struct for sending tasks and their log output to the client.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskLogMessage {
     pub task: Task,

--- a/shared/message.rs
+++ b/shared/message.rs
@@ -6,7 +6,7 @@ use crate::state::State;
 use crate::task::Task;
 
 /// The Message used to add a new command to the daemon.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message {
     Add(AddMessage),
     Remove(Vec<usize>),
@@ -37,64 +37,65 @@ pub enum Message {
     Success(String),
     Failure(String),
 
-    Parallel(usize),
+    Parallel(ParallelMessage),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct AddMessage {
     pub command: String,
     pub path: String,
     pub start_immediately: bool,
     pub stashed: bool,
+    pub group: Option<String>,
     pub enqueue_at: Option<DateTime<Local>>,
     pub dependencies: Vec<usize>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SwitchMessage {
     pub task_id_1: usize,
     pub task_id_2: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnqueueMessage {
     pub task_ids: Vec<usize>,
     pub enqueue_at: Option<DateTime<Local>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RestartMessage {
     pub task_ids: Vec<usize>,
     pub start_immediately: bool,
     pub stashed: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PauseMessage {
     pub wait: bool,
     pub task_ids: Vec<usize>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KillMessage {
     pub all: bool,
     pub task_ids: Vec<usize>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SendMessage {
     pub task_id: usize,
     pub input: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EditMessage {
     pub task_id: usize,
     pub command: String,
     pub path: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EditResponseMessage {
     pub task_id: usize,
     pub command: String,
@@ -102,29 +103,35 @@ pub struct EditResponseMessage {
 }
 
 // The booleans decides, whether the stream should be continuous or a oneshot
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamRequestMessage {
     pub task_id: usize,
     pub follow: bool,
     pub err: bool,
 }
 
-// Request logs for specific tasks.
-// An empty task_id vector will return logs of all tasks.
-// If send_logs is false, the daemon won't send the logs
-// and the client will read logs from the local disk.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// Request logs for specific tasks.
+/// An empty task_id vector will return logs of all tasks.
+/// If send_logs is false, the daemon won't send the logs
+/// and the client will read logs from the local disk.
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct LogRequestMessage {
     pub task_ids: Vec<usize>,
     pub send_logs: bool,
 }
 
 /// Helper struct for sending tasks and their log output to the client
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskLogMessage {
     pub task: Task,
     pub stdout: Option<Vec<u8>>,
     pub stderr: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ParallelMessage {
+    pub parallel_tasks: usize,
+    pub group: Option<String>,
 }
 
 pub fn create_success_message<T: ToString>(text: T) -> Message {

--- a/shared/message.rs
+++ b/shared/message.rs
@@ -23,6 +23,7 @@ pub enum Message {
     EditRequest(usize),
     EditResponse(EditResponseMessage),
     Edit(EditMessage),
+    Group(GroupMessage),
 
     Status,
     StatusResponse(State),
@@ -100,6 +101,12 @@ pub struct EditResponseMessage {
     pub task_id: usize,
     pub command: String,
     pub path: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct GroupMessage {
+    pub add: Option<String>,
+    pub remove: Option<String>,
 }
 
 // The booleans decides, whether the stream should be continuous or a oneshot.

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -30,8 +30,7 @@ pub async fn send_bytes(payload: Vec<u8>, socket: &mut TcpStream) -> Result<()> 
     socket.write_all(&header).await?;
 
     // Split the payload into 1.5kbyte chunks (MUT for TCP)
-    let mut iter = payload.chunks(1500);
-    while let Some(chunk) = iter.next() {
+    for chunk in payload.chunks(1500) {
         socket.write_all(chunk).await?;
     }
 

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -7,8 +7,8 @@ use ::std::io::Cursor;
 
 use crate::message::*;
 
-/// Convenience wrapper around send_bytes
-/// Deserialize a message and feed the bytes into send_bytes
+/// Convenience wrapper around send_bytes.
+/// Deserialize a message and feed the bytes into send_bytes.
 pub async fn send_message(message: Message, socket: &mut TcpStream) -> Result<()> {
     debug!("Sending message: {:?}", message);
     // Prepare command for transfer and determine message byte size
@@ -38,8 +38,8 @@ pub async fn send_bytes(payload: Vec<u8>, socket: &mut TcpStream) -> Result<()> 
     Ok(())
 }
 
-/// Receive a byte stream depending on a given header
-/// This is the basic protocol beneath all pueue communication
+/// Receive a byte stream depending on a given header.
+/// This is the basic protocol beneath all pueue communication.
 pub async fn receive_bytes(socket: &mut TcpStream) -> Result<Vec<u8>> {
     // Receive the header with the overall message size
     let mut header = vec![0; 8];
@@ -75,11 +75,11 @@ pub async fn receive_bytes(socket: &mut TcpStream) -> Result<Vec<u8>> {
     Ok(payload_bytes)
 }
 
-/// Convenience wrapper that receives a message and converts it into a Message
+/// Convenience wrapper that receives a message and converts it into a Message.
 pub async fn receive_message(socket: &mut TcpStream) -> Result<Message> {
     let payload_bytes = receive_bytes(socket).await?;
 
-    // Deserialize the message
+    // Deserialize the message.
     let message: Message = bincode::deserialize(&payload_bytes).context(
         "In case you updated Pueue, try restarting the daemon. Otherwise please report this",
     )?;

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -74,7 +74,7 @@ impl Settings {
         let config_path = default_config_path()?;
         let config_dir = config_path
             .parent()
-            .ok_or(anyhow!("Couldn't resolve config dir"))?;
+            .ok_or_else(|| anyhow!("Couldn't resolve config dir"))?;
 
         // Create the config dir, if it doesn't exist yet
         if !config_dir.exists() {
@@ -106,7 +106,7 @@ fn parse_config(settings: &mut Config) -> Result<()> {
 }
 
 fn get_home_dir() -> Result<PathBuf> {
-    dirs::home_dir().ok_or(anyhow!("Couldn't resolve home dir"))
+    dirs::home_dir().ok_or_else(|| anyhow!("Couldn't resolve home dir"))
 }
 
 fn gen_random_secret() -> String {

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -1,31 +1,30 @@
 use ::anyhow::{anyhow, Result};
+use ::config::Config;
 use ::log::info;
 use ::rand::Rng;
 use ::serde_derive::{Deserialize, Serialize};
+use ::std::collections::HashMap;
 use ::std::fs::{create_dir_all, File};
 use ::std::io::prelude::*;
 use ::std::path::{Path, PathBuf};
 
-use ::config::Config;
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Client {
-    //    pub daemon_address: String,
     pub daemon_port: String,
     pub secret: String,
     pub read_local_logs: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Daemon {
     pub pueue_directory: String,
-    //    pub address: String,
     pub port: String,
     pub secret: String,
     pub default_parallel_tasks: usize,
     #[serde(default = "pause_on_failure_default")]
     pub pause_on_failure: bool,
     pub callback: Option<String>,
+    pub groups: HashMap<String, usize>,
 }
 
 fn pause_on_failure_default() -> bool {
@@ -33,7 +32,7 @@ fn pause_on_failure_default() -> bool {
 }
 
 /// The struct representation of a full configuration.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub client: Client,
     pub daemon: Daemon,
@@ -47,21 +46,20 @@ impl Settings {
     /// The local config is located at "~/.config/pueue.yml".
     pub fn new() -> Result<Settings> {
         let mut config = Config::new();
-
         let random_secret = gen_random_secret();
+
+        config.set_default("client.daemon_port", "6924")?;
+        config.set_default("client.secret", random_secret.clone())?;
+        config.set_default("client.read_local_logs", true)?;
+
         // Set pueue config defaults
         config.set_default("daemon.pueue_directory", default_pueue_path()?)?;
-        //        config.set_default("daemon.address", "127.0.0.1")?;
         config.set_default("daemon.port", "6924")?;
         config.set_default("daemon.default_parallel_tasks", 1)?;
         config.set_default("daemon.pause_on_failure", false)?;
-        config.set_default("daemon.secret", random_secret.clone())?;
+        config.set_default("daemon.secret", random_secret)?;
         config.set_default("daemon.callback", None::<String>)?;
-
-        //        config.set_default("client.daemon_address", "127.0.0.1")?;
-        config.set_default("client.daemon_port", "6924")?;
-        config.set_default("client.secret", random_secret)?;
-        config.set_default("client.read_local_logs", true)?;
+        config.set_default("daemon.groups", HashMap::<String, i64>::new())?;
 
         // Add in the home config file
         parse_config(&mut config)?;

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -69,7 +69,7 @@ impl Settings {
     }
 
     /// Save the current configuration as a file to the configuration path.
-    /// The file is written to the main configuration directory of the respective OS
+    /// The file is written to the main configuration directory of the respective OS.
     pub fn save(&self) -> Result<()> {
         let config_path = default_config_path()?;
         let config_dir = config_path

--- a/shared/state.rs
+++ b/shared/state.rs
@@ -26,7 +26,7 @@ pub struct State {
 
 impl State {
     pub fn new(settings: &Settings) -> State {
-        // Create a default group state
+        // Create a default group state.
         let mut groups = HashMap::new();
         for group in settings.daemon.groups.keys() {
             groups.insert(group.into(), true);
@@ -65,11 +65,14 @@ impl State {
         }
     }
 
-    /// Check if the given group already exists
-    /// If it doesn't exist yet, create a state entry and a new settings entry
+    /// Check if the given group already exists.
+    /// If it doesn't exist yet, create a state entry and a new settings entry.
     pub fn create_group(&mut self, group: &String) {
         if let None = self.settings.daemon.groups.get(group) {
-            self.settings.daemon.groups.insert(group.into(), self.settings.daemon.default_parallel_tasks);
+            self.settings
+                .daemon
+                .groups
+                .insert(group.into(), self.settings.daemon.default_parallel_tasks);
         }
         if let None = self.groups.get(group) {
             self.groups.insert(group.into(), true);
@@ -97,14 +100,14 @@ impl State {
 
         // Filter all task id's that match the provided statuses.
         for task_id in task_ids.iter() {
-            // Check whether the task exists
+            // Check whether the task exists and save all non-existing task ids.
             match self.tasks.get(&task_id) {
                 None => {
                     mismatching.push(*task_id);
                     continue;
                 }
                 Some(task) => {
-                    // Check whether the task status matches the specified statuses
+                    // Check whether the task status matches the specified statuses.
                     if statuses.contains(&task.status) {
                         matching.push(*task_id);
                     } else {
@@ -125,14 +128,14 @@ impl State {
         self.save();
     }
 
-    /// Convenience wrapper around save_to_file
+    /// Convenience wrapper around save_to_file.
     pub fn save(&mut self) {
         self.save_to_file(false);
     }
 
-    /// Save the current current state in a file with a timestamp
-    /// At the same time remove old state logs from the log directory
-    /// This function is called, when large changes to the state are applied, e.g. clean/reset
+    /// Save the current current state in a file with a timestamp.
+    /// At the same time remove old state logs from the log directory.
+    /// This function is called, when large changes to the state are applied, e.g. clean/reset.
     pub fn backup(&mut self) {
         self.save_to_file(true);
         if let Err(error) = self.rotate() {
@@ -141,11 +144,11 @@ impl State {
     }
 
     /// Save the current state to disk.
-    /// We do this to restore in case of a crash
-    /// If log == true, the file will be saved with a time stamp
+    /// We do this to restore in case of a crash.
+    /// If log == true, the file will be saved with a time stamp.
     ///
     /// In comparison to the daemon -> client communication, the state is saved
-    /// as JSON for better readability and debug purposes
+    /// as JSON for better readability and debug purposes.
     fn save_to_file(&mut self, log: bool) {
         let serialized = serde_json::to_string(&self);
         if let Err(error) = serialized {
@@ -169,7 +172,7 @@ impl State {
             real = path.join("state.json");
         }
 
-        // Write to temporary log file first, to prevent loss due to crashes
+        // Write to temporary log file first, to prevent loss due to crashes.
         if let Err(error) = fs::write(&temp, serialized) {
             error!(
                 "Failed to write log to directory. File permissions? Error: {:?}",
@@ -178,7 +181,7 @@ impl State {
             return;
         }
 
-        // Overwrite the original with the temp file, if everything went fine
+        // Overwrite the original with the temp file, if everything went fine.
         if let Err(error) = fs::rename(&temp, real) {
             error!(
                 "Failed to overwrite old log file. File permissions? Error: {:?}",
@@ -188,8 +191,8 @@ impl State {
         }
     }
 
-    /// Restore the last state from a previous session
-    /// The state is stored as json in the log directory
+    /// Restore the last state from a previous session.
+    /// The state is stored as json in the log directory.
     fn restore(&mut self) {
         let path = Path::new(&self.settings.daemon.pueue_directory).join("state.json");
 
@@ -203,7 +206,7 @@ impl State {
         }
         info!("Start restoring state");
 
-        // Try to load the file
+        // Try to load the file.
         let data = fs::read_to_string(&path);
         if let Err(error) = data {
             error!("Failed to read previous state log: {:?}", error);
@@ -211,7 +214,7 @@ impl State {
         }
         let data = data.unwrap();
 
-        // Try to deserialize the state file
+        // Try to deserialize the state file.
         let deserialized: Result<State, serde_json::error::Error> = serde_json::from_str(&data);
         if let Err(error) = deserialized {
             error!("Failed to deserialize previous state log: {:?}", error);
@@ -265,7 +268,7 @@ impl State {
         self.max_id = state.max_id;
     }
 
-    /// Remove old logs that aren't needed any longer
+    /// Remove old logs that aren't needed any longer.
     fn rotate(&mut self) -> Result<()> {
         let path = Path::new(&self.settings.daemon.pueue_directory);
         let path = path.join("log");

--- a/shared/state.rs
+++ b/shared/state.rs
@@ -264,6 +264,16 @@ impl State {
             }
         }
 
+        // Go trough all tasks and set all groups that are no longer
+        // listed in the configuration file to the default.
+        for (_, task) in self.tasks.iter_mut() {
+            if let Some(group) = &task.group {
+                if !self.groups.contains_key(group) {
+                    task.group = None;
+                }
+            }
+        }
+
         self.running = state.running;
         self.max_id = state.max_id;
     }

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -103,8 +103,8 @@ impl Task {
         return self.status == TaskStatus::Done;
     }
 
-    // Check if the task errored
-    // The only case when it didn't error is if it didn't run yet or if the task exited successfully
+    // Check if the task errored.
+    // The only case when it didn't error is if it didn't run yet or if the task exited successfully.
     pub fn failed(&self) -> bool {
         match self.result {
             None => false,

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -68,7 +68,7 @@ impl Task {
             id: 0,
             command,
             path,
-            group: group,
+            group,
             enqueue_at,
             dependencies,
             status: starting_status.clone(),
@@ -96,11 +96,11 @@ impl Task {
     }
 
     pub fn is_running(&self) -> bool {
-        return self.status == TaskStatus::Running || self.status == TaskStatus::Paused;
+        self.status == TaskStatus::Running || self.status == TaskStatus::Paused
     }
 
     pub fn is_done(&self) -> bool {
-        return self.status == TaskStatus::Done;
+        self.status == TaskStatus::Done
     }
 
     // Check if the task errored.
@@ -114,6 +114,6 @@ impl Task {
     }
 
     pub fn is_queued(&self) -> bool {
-        return self.status == TaskStatus::Queued || self.status == TaskStatus::Stashed;
+        self.status == TaskStatus::Queued || self.status == TaskStatus::Stashed
     }
 }

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -4,7 +4,7 @@ use ::strum_macros::Display;
 
 /// This enum represents the status of the internal task handling of Pueue.
 /// They basically represent the internal task life-cycle.
-#[derive(Clone, Display, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
 pub enum TaskStatus {
     /// The task is queued and waiting for a free slot
     Queued,
@@ -21,7 +21,7 @@ pub enum TaskStatus {
 }
 
 /// This enum represents the exit status of the actually spawned program.
-#[derive(Clone, Display, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
 pub enum TaskResult {
     /// Task exited with 0
     Success,
@@ -40,11 +40,12 @@ pub enum TaskResult {
 /// exit_code, output and end won't be initialized, until the task has finished.
 /// The output of the task is written into seperate files.
 /// Upon task completion, the output is read from the files and put into the struct.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Task {
     pub id: usize,
     pub command: String,
     pub path: String,
+    pub group: Option<String>,
     pub enqueue_at: Option<DateTime<Local>>,
     pub dependencies: Vec<usize>,
     pub status: TaskStatus,
@@ -58,6 +59,7 @@ impl Task {
     pub fn new(
         command: String,
         path: String,
+        group: Option<String>,
         starting_status: TaskStatus,
         enqueue_at: Option<DateTime<Local>>,
         dependencies: Vec<usize>,
@@ -66,6 +68,7 @@ impl Task {
             id: 0,
             command,
             path,
+            group: group,
             enqueue_at,
             dependencies,
             status: starting_status.clone(),
@@ -81,6 +84,7 @@ impl Task {
             id: 0,
             command: task.command.clone(),
             path: task.path.clone(),
+            group: None,
             enqueue_at: None,
             dependencies: Vec::new(),
             status: TaskStatus::Queued,


### PR DESCRIPTION
This PR aims to enable users to utilize groups for better system utilization.

For instance:
One could create several groups for each system component. E.g.:
- `cpu`
- `hdd`
- `network`

Each group is handled as if it has their own queue. With this, one could schedule several tasks that completely utilize the CPU while also running some tasks in parallel, that utilize disk and network capacities.