### PR TITLE
Generic sockets && Unix Socket support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [0.8.0]
 
 This version adds breaking changes:
-- The configuration file structure has been changed.
+
+- The configuration file structure has been changed. There's now a `shared` section.
 - The configuration files have been moved to a dedicated `pueue` subdirectory.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.7.3]
+## [0.8.0]
+
+This version adds breaking changes:
+- The configuration file structure has been changed.
+- The configuration files have been moved to a dedicated `pueue` subdirectory.
+
+### Added
+
+- Unix socket support
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,9 +17,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
 
 [[package]]
 name = "arc-swap"
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21279cfaa4f47df10b1816007e738ca3747ef2ee53ffc51cdbf57a8bb266fee3"
+checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf20dd2c6d20ef09876e189b44f213e66e846972cb303eef28d9dfbe790928"
+checksum = "d54bc4c1c7292475efb2253227dbcfad8fe1ca4c02bc62c510cc2f3da5c4704e"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -255,16 +255,16 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2640778f8053e72c11f621b0a5175a0560a269282aa98ed85107773ab8e2a556"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
 dependencies = [
  "async-channel",
+ "async-task",
  "atomic-waker",
  "fastrand",
  "futures-lite",
  "once_cell",
- "waker-fn",
 ]
 
 [[package]]
@@ -299,9 +299,9 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
 
 [[package]]
 name = "cfg-if"
@@ -546,30 +546,30 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
 
 [[package]]
 name = "futures-lite"
-version = "1.8.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db18c5f58083b54b0c416638ea73066722c2815c1e54dd8ba85ee3def593c3a"
+checksum = "381a7ad57b1bad34693f63f6f377e1abded7a9c85c9d3eb6771e11c60aaadab9"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
+checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libflate"
@@ -780,9 +780,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "mio"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5fc35678fa91ff960494e4bd72a0e1f8e72e035460887a2005de51915993cd"
+checksum = "e53a6ea5f38c0a48ca42159868c6d8e1bd56c0451238856cc08d58563643bdc3"
 dependencies = [
  "libc",
  "log",
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
  "winapi",
@@ -829,6 +829,18 @@ name = "nix"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85db2feff6bf70ebc3a4793191517d5f0331100a2f10f9bf93b5e5214f32b7b7"
 dependencies = [
  "bitflags",
  "cc",
@@ -990,9 +1002,9 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "polling"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7215a098a80ab8ebd6349db593dc5faf741781bad0c4b7c5701fea6af548d52c"
+checksum = "ab773feb154f12c49ffcfd66ab8bdcf9a1843f950db48b0d8be9d4393783b058"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1112,7 +1124,7 @@ dependencies = [
  "dirs",
  "handlebars",
  "log",
- "nix 0.18.0",
+ "nix 0.19.0",
  "procfs",
  "proptest",
  "psutil",
@@ -1221,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
 name = "remove_dir_all"
@@ -1284,15 +1296,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1301,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -1409,9 +1421,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1420,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1433,15 +1445,15 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.19.2"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3924a58d165da3b7b2922c667ab0673c7b5fd52b5c19ea3442747bcb3cd15abe"
+checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
 
 [[package]]
 name = "strum_macros"
-version = "0.19.2"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2ab682ecdcae7f5f45ae85cd7c1e6c8e68ea42c8a612d47fedf831c037146a"
+checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1451,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1485,18 +1497,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1552,9 +1564,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "users"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57a92e9749e10f25a171adcebfafe72991d45e7ec2dcb853e8f83d9dafaeb08"
+dependencies = [
+ "nix 0.18.0",
+ "winapi",
+]
+
+[[package]]
 name = "darwin-libproc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1108,7 @@ dependencies = [
  "comfy-table",
  "config",
  "crossterm",
+ "ctrlc",
  "dirs",
  "handlebars",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab27c1aa62945039e44edaeee1dc23c74cc0c303dd5fe0fb462a184f1c3a518"
 
 [[package]]
+name = "async-trait"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1089,7 @@ version = "0.7.3-alpha.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "async-trait",
  "bincode",
  "byteorder",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ path = "shared/lib.rs"
 [dependencies]
 anyhow = "1"
 async-std = { version = "1", features = ["attributes", "std"] }
+async-trait = "0.1"
 dirs = "3"
 chrono = { version = "^0.4", features = ["serde"] }
 chrono-english = "^0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ comfy-table= "^1"
 tempfile = "^3"
 
 [target.'cfg(not(windows))'.dependencies]
-users = "^0.10"
-nix = "^0.18"
+users = "^0.11"
+nix = "^0.19"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 procfs = { version = "0.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ async-trait = "0.1"
 dirs = "3"
 chrono = { version = "^0.4", features = ["serde"] }
 chrono-english = "^0.1.0"
+ctrlc = "3"
 rand = "^0.7"
 strum = "^0.19"
 strum_macros = "^0.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ async-trait = "0.1"
 dirs = "3"
 chrono = { version = "^0.4", features = ["serde"] }
 chrono-english = "^0.1.0"
-ctrlc = "3"
+ctrlc = { version = "3", features = ["termination"] }
 rand = "^0.7"
 strum = "^0.19"
 strum_macros = "^0.19"

--- a/client/client.rs
+++ b/client/client.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env::{current_dir, vars};
-use std::io::{self, Write};
+use std::io::{self, Write as std_Write};
 
 use anyhow::{bail, Context, Result};
 use async_std::net::TcpStream;
@@ -25,7 +25,7 @@ use crate::output::*;
 pub struct Client {
     opt: Opt,
     settings: Settings,
-    socket: TcpStream,
+    socket: Box<dyn GenericSocket>,
 }
 
 impl Client {
@@ -50,10 +50,12 @@ impl Client {
         let address = format!("127.0.0.1:{}", port);
 
         // Connect to socket
-        let mut socket = TcpStream::connect(&address)
+        let socket = TcpStream::connect(&address)
             .await
             .context("Failed to connect to the daemon. Did you start it?")?;
         let secret = settings.client.secret.clone().into_bytes();
+
+        let mut socket: SocketBox = Box::new(socket);
         send_bytes(secret, &mut socket).await?;
 
         Ok(Client {
@@ -68,7 +70,7 @@ impl Client {
     /// we can finally start doing stuff.
     ///
     /// The command handling is splitted into "simple" and "complex" commands.
-    pub async fn start(&self) -> Result<()> {
+    pub async fn start(&mut self) -> Result<()> {
         // Return early, if the command has already been handled.
         if self.handle_complex_command().await? {
             return Ok(());
@@ -88,12 +90,11 @@ impl Client {
     ///
     /// Returns `true`, if the current command has been handled by this function.
     /// This indicates that the client can now shut down.
-    async fn handle_complex_command(&self) -> Result<bool> {
-        let mut socket = self.socket.clone();
+    async fn handle_complex_command(&mut self) -> Result<bool> {
         // This match handles all "complex" commands.
         match &self.opt.cmd {
             SubCommand::Edit { task_id, path } => {
-                let message = edit(&mut socket, *task_id, *path).await?;
+                let message = edit(&mut self.socket, *task_id, *path).await?;
                 self.handle_response(message);
                 Ok(true)
             }
@@ -105,7 +106,7 @@ impl Client {
                 path,
             } => {
                 restart(
-                    &mut socket,
+                    &mut self.socket,
                     task_ids.clone(),
                     *start_immediately,
                     *stashed,
@@ -120,7 +121,7 @@ impl Client {
                 // Thereby we handle this separately over here.
                 if self.settings.client.read_local_logs {
                     local_follow(
-                        &mut socket,
+                        &mut self.socket,
                         self.settings.daemon.pueue_directory.clone(),
                         task_id,
                         *err,
@@ -137,22 +138,20 @@ impl Client {
     /// Handle logic that's super generic on the client-side.
     /// This always follows a singular ping-pong pattern.
     /// One message to the daemon, one response, Done.
-    async fn handle_simple_command(&self) -> Result<()> {
-        let mut socket = self.socket.clone();
-
+    async fn handle_simple_command(&mut self) -> Result<()> {
         // Create the message that should be sent to the daemon
         // depending on the given commandline options.
         let message = self.get_message_from_opt()?;
 
         // Create the message payload and send it to the daemon.
-        send_message(message, &mut socket).await?;
+        send_message(message, &mut self.socket).await?;
 
         // Check if we can receive the response from the daemon
-        let mut response = receive_message(&mut socket).await?;
+        let mut response = receive_message(&mut self.socket).await?;
 
         // Check if we can receive the response from the daemon
         while self.handle_response(response) {
-            response = receive_message(&mut socket).await?;
+            response = receive_message(&mut self.socket).await?;
         }
 
         Ok(())

--- a/client/client.rs
+++ b/client/client.rs
@@ -42,7 +42,7 @@ impl Client {
         let port = if let Some(port) = opt.port.clone() {
             port
         } else {
-            settings.client.daemon_port.clone()
+            settings.shared.port.clone()
         };
 
         // Don't allow anything else than loopback until we have proper crypto
@@ -53,7 +53,7 @@ impl Client {
         let socket = TcpStream::connect(&address)
             .await
             .context("Failed to connect to the daemon. Did you start it?")?;
-        let secret = settings.client.secret.clone().into_bytes();
+        let secret = settings.shared.secret.clone().into_bytes();
 
         let mut socket: SocketBox = Box::new(socket);
         send_bytes(secret, &mut socket).await?;
@@ -122,7 +122,7 @@ impl Client {
                 if self.settings.client.read_local_logs {
                     local_follow(
                         &mut self.socket,
-                        self.settings.daemon.pueue_directory.clone(),
+                        self.settings.shared.pueue_directory.clone(),
                         task_id,
                         *err,
                     )

--- a/client/client.rs
+++ b/client/client.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::env::{current_dir, vars};
-use std::io::{self, Write as std_Write};
+use std::io::{self, Write};
 
 use anyhow::{bail, Context, Result};
 use log::error;
@@ -25,7 +25,7 @@ use crate::output::*;
 pub struct Client {
     opt: Opt,
     settings: Settings,
-    socket: Box<dyn GenericSocket>,
+    socket: Socket,
 }
 
 impl Client {

--- a/client/commands/edit.rs
+++ b/client/commands/edit.rs
@@ -3,7 +3,6 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::process::Command;
 
 use anyhow::{Context, Result};
-use async_std::net::TcpStream;
 use tempfile::NamedTempFile;
 
 use pueue::message::*;
@@ -16,7 +15,7 @@ use pueue::protocol::*;
 ///
 /// After receiving the task information, the user can then edit it in their editor.
 /// Upon exiting the text editor, the line will then be read and sent to the server
-pub async fn edit(socket: &mut TcpStream, task_id: usize, edit_path: bool) -> Result<Message> {
+pub async fn edit(socket: &mut SocketBox, task_id: usize, edit_path: bool) -> Result<Message> {
     // Request the data to edit from the server and issue a task-lock while doing so.
     let init_message = Message::EditRequest(task_id);
     send_message(init_message, socket).await?;

--- a/client/commands/edit.rs
+++ b/client/commands/edit.rs
@@ -15,7 +15,7 @@ use pueue::protocol::*;
 ///
 /// After receiving the task information, the user can then edit it in their editor.
 /// Upon exiting the text editor, the line will then be read and sent to the server
-pub async fn edit(socket: &mut SocketBox, task_id: usize, edit_path: bool) -> Result<Message> {
+pub async fn edit(socket: &mut Socket, task_id: usize, edit_path: bool) -> Result<Message> {
     // Request the data to edit from the server and issue a task-lock while doing so.
     let init_message = Message::EditRequest(task_id);
     send_message(init_message, socket).await?;

--- a/client/commands/local_follow.rs
+++ b/client/commands/local_follow.rs
@@ -1,11 +1,12 @@
 use anyhow::{bail, Result};
-use async_std::net::TcpStream;
+
+use pueue::protocol::SocketBox;
 
 use crate::commands::get_state;
 use crate::output::follow_task_logs;
 
 pub async fn local_follow(
-    socket: &mut TcpStream,
+    socket: &mut SocketBox,
     pueue_directory: String,
     task_id: &Option<usize>,
     err: bool,
@@ -16,7 +17,7 @@ pub async fn local_follow(
     let task_id = match task_id {
         Some(task_id) => *task_id,
         None => {
-            let state = get_state(&mut socket.clone()).await?;
+            let state = get_state(socket).await?;
             let running_ids: Vec<_> = state
                 .tasks
                 .iter()

--- a/client/commands/local_follow.rs
+++ b/client/commands/local_follow.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Result};
 
-use pueue::protocol::SocketBox;
+use pueue::protocol::Socket;
 
 use crate::commands::get_state;
 use crate::output::follow_task_logs;
 
 pub async fn local_follow(
-    socket: &mut SocketBox,
+    socket: &mut Socket,
     pueue_directory: String,
     task_id: &Option<usize>,
     err: bool,

--- a/client/commands/mod.rs
+++ b/client/commands/mod.rs
@@ -10,7 +10,7 @@ pub mod restart;
 
 // This is a helper function for easy retrieval of the current daemon state.
 // The current daemon state is often needed in more complex commands.
-pub async fn get_state(socket: &mut SocketBox) -> Result<State> {
+pub async fn get_state(socket: &mut Socket) -> Result<State> {
     // Create the message payload and send it to the daemon.
     send_message(Message::Status, socket).await?;
 

--- a/client/commands/mod.rs
+++ b/client/commands/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_std::net::TcpStream;
 
 use pueue::message::Message;
 use pueue::protocol::*;
@@ -11,7 +10,7 @@ pub mod restart;
 
 // This is a helper function for easy retrieval of the current daemon state.
 // The current daemon state is often needed in more complex commands.
-pub async fn get_state(socket: &mut TcpStream) -> Result<State> {
+pub async fn get_state(socket: &mut SocketBox) -> Result<State> {
     // Create the message payload and send it to the daemon.
     send_message(Message::Status, socket).await?;
 

--- a/client/commands/restart.rs
+++ b/client/commands/restart.rs
@@ -12,7 +12,7 @@ use crate::commands::get_state;
 ///
 /// This is done on the client-side, so we can easily edit the task before restarting it.
 pub async fn restart(
-    socket: &mut SocketBox,
+    socket: &mut Socket,
     task_ids: Vec<usize>,
     start_immediately: bool,
     stashed: bool,

--- a/client/commands/restart.rs
+++ b/client/commands/restart.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use async_std::net::TcpStream;
 
 use pueue::message::*;
 use pueue::protocol::*;
@@ -13,7 +12,7 @@ use crate::commands::get_state;
 ///
 /// This is done on the client-side, so we can easily edit the task before restarting it.
 pub async fn restart(
-    socket: &mut TcpStream,
+    socket: &mut SocketBox,
     task_ids: Vec<usize>,
     start_immediately: bool,
     stashed: bool,

--- a/client/main.rs
+++ b/client/main.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     }
 
     // Create client to talk with the daemon and connect.
-    let client = Client::new(settings, opt).await?;
+    let mut client = Client::new(settings, opt).await?;
     client.start().await?;
 
     Ok(())

--- a/client/output.rs
+++ b/client/output.rs
@@ -281,7 +281,7 @@ pub fn print_log(task_log: &mut TaskLogMessage, settings: &Settings) {
 /// If that's the case, read the log files from the local pueue directory
 pub fn print_local_log_output(task_id: usize, settings: &Settings, is_tty: bool) {
     let (mut stdout_log, mut stderr_log) =
-        match get_log_file_handles(task_id, &settings.daemon.pueue_directory) {
+        match get_log_file_handles(task_id, &settings.shared.pueue_directory) {
             Ok((stdout, stderr)) => (stdout, stderr),
             Err(err) => {
                 println!("Failed to get log file handles: {}", err);

--- a/daemon/instructions.rs
+++ b/daemon/instructions.rs
@@ -441,7 +441,7 @@ fn clean(state: &SharedState) -> Message {
 
     for task_id in &matching {
         let _ = state.tasks.remove(task_id).unwrap();
-        clean_log_handles(*task_id, &state.settings.daemon.pueue_directory);
+        clean_log_handles(*task_id, &state.settings.shared.pueue_directory);
     }
 
     state.save();
@@ -482,7 +482,7 @@ fn get_log(message: LogRequestMessage, state: &SharedState) -> Message {
             // This isn't as efficient as sending the raw compressed data directly,
             // but it's a lot more convenient for now.
             let (stdout, stderr) = if message.send_logs {
-                match read_and_compress_log_files(*task_id, &state.settings.daemon.pueue_directory)
+                match read_and_compress_log_files(*task_id, &state.settings.shared.pueue_directory)
                 {
                     Ok((stdout, stderr)) => (Some(stdout), Some(stderr)),
                     Err(err) => {

--- a/daemon/main.rs
+++ b/daemon/main.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
         SimpleLogger::init(LevelFilter::Error, Config::default())?;
     }
 
-    init_directories(&settings.daemon.pueue_directory);
+    init_directories(&settings.shared.pueue_directory);
 
     let state = State::new(&settings);
     let state = Arc::new(Mutex::new(state));

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -94,11 +94,6 @@ async fn handle_incoming(
             // The client requested the output of a task.
             // Since we allow streaming, this needs to be handled seperately.
             handle_follow(&pueue_directory, &mut socket, &state, message).await?
-        } else if let Message::DaemonShutdown = message {
-            // Simply shut down the daemon right after sending a success response.
-            let response = create_success_message("Daemon is shutting down");
-            send_message(response, &mut socket).await?;
-            std::process::exit(0);
         } else {
             // Process a normal message.
             handle_message(message, &sender, &state)

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -1,7 +1,7 @@
 use std::sync::mpsc::Sender;
 
 use anyhow::{bail, Result};
-use async_std::net::{TcpListener, TcpStream};
+use async_std::net::TcpListener;
 use async_std::task;
 use log::{debug, info, warn};
 
@@ -29,6 +29,7 @@ pub async fn accept_incoming(sender: Sender<Message>, state: SharedState, opt: O
     loop {
         // Poll if we have a new incoming connection.
         let (socket, _) = listener.accept().await?;
+        let socket: SocketBox = Box::new(socket);
         let sender_clone = sender.clone();
         let state_clone = state.clone();
         task::spawn(async move {
@@ -41,7 +42,7 @@ pub async fn accept_incoming(sender: Sender<Message>, state: SharedState, opt: O
 /// In case we received an instruction, handle it and create a response future.
 /// The response future is added to unix_responses and handled in a separate function.
 async fn handle_incoming(
-    mut socket: TcpStream,
+    mut socket: SocketBox,
     sender: Sender<Message>,
     state: SharedState,
 ) -> Result<()> {

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -54,7 +54,7 @@ pub async fn accept_incoming(sender: Sender<Message>, state: SharedState, opt: O
 /// In case we received an instruction, handle it and create a response future.
 /// The response future is added to unix_responses and handled in a separate function.
 async fn handle_incoming(
-    mut socket: SocketBox,
+    mut socket: Socket,
     sender: Sender<Message>,
     state: SharedState,
 ) -> Result<()> {

--- a/daemon/socket.rs
+++ b/daemon/socket.rs
@@ -21,7 +21,7 @@ pub async fn accept_incoming(sender: Sender<Message>, state: SharedState, opt: O
         port
     } else {
         let state = state.lock().unwrap();
-        state.settings.daemon.port.clone()
+        state.settings.shared.port.clone()
     };
     let address = format!("127.0.0.1:{}", port);
     let listener = TcpListener::bind(address).await?;
@@ -60,7 +60,7 @@ async fn handle_incoming(
     // Return immediately, if we got a wrong secret from the client.
     {
         let state = state.lock().unwrap();
-        if secret != state.settings.daemon.secret {
+        if secret != state.settings.shared.secret {
             warn!("Received invalid secret: {}", secret);
             bail!("Received invalid secret");
         }
@@ -70,7 +70,7 @@ async fn handle_incoming(
     // locking the state in the streaming loop.
     let pueue_directory = {
         let state = state.lock().unwrap();
-        state.settings.daemon.pueue_directory.clone()
+        state.settings.shared.pueue_directory.clone()
     };
 
     loop {

--- a/daemon/streaming.rs
+++ b/daemon/streaming.rs
@@ -3,18 +3,17 @@ use std::io::Read;
 use std::time::Duration;
 
 use anyhow::Result;
-use async_std::net::TcpStream;
 use async_std::task::sleep;
 
 use pueue::log::*;
 use pueue::message::*;
-use pueue::protocol::send_message;
+use pueue::protocol::{send_message, SocketBox};
 use pueue::state::SharedState;
 
 /// Handle the continuous stream of a message.
 pub async fn handle_follow(
     pueue_directory: &str,
-    socket: &mut TcpStream,
+    socket: &mut SocketBox,
     state: &SharedState,
     message: StreamRequestMessage,
 ) -> Result<Message> {

--- a/daemon/streaming.rs
+++ b/daemon/streaming.rs
@@ -7,13 +7,13 @@ use async_std::task::sleep;
 
 use pueue::log::*;
 use pueue::message::*;
-use pueue::protocol::{send_message, SocketBox};
+use pueue::protocol::{send_message, Socket};
 use pueue::state::SharedState;
 
 /// Handle the continuous stream of a message.
 pub async fn handle_follow(
     pueue_directory: &str,
-    socket: &mut SocketBox,
+    socket: &mut Socket,
     state: &SharedState,
     message: StreamRequestMessage,
 ) -> Result<Message> {

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -47,11 +47,10 @@ impl TaskHandler {
         // This prevents locking the State all the time.
         let (pueue_directory, callback, pause_on_failure) = {
             let state = state.lock().unwrap();
-            let settings = &state.settings.daemon;
             (
-                settings.pueue_directory.clone(),
-                settings.callback.clone(),
-                settings.pause_on_failure,
+                state.settings.shared.pueue_directory.clone(),
+                state.settings.daemon.callback.clone(),
+                state.settings.daemon.pause_on_failure,
             )
         };
         TaskHandler {

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -53,6 +53,7 @@ impl TaskHandler {
                 state.settings.daemon.pause_on_failure,
             )
         };
+
         TaskHandler {
             state,
             receiver,
@@ -62,22 +63,6 @@ impl TaskHandler {
             pueue_directory,
             callback,
             pause_on_failure,
-        }
-    }
-}
-
-/// The task handler needs to kill all child processes as soon, as the program exits.
-/// This is needed to prevent detached processes.
-impl Drop for TaskHandler {
-    fn drop(&mut self) {
-        let task_ids: Vec<usize> = self.children.keys().cloned().collect();
-        for task_id in task_ids {
-            let mut child = self
-                .children
-                .remove(&task_id)
-                .expect("Failed killing children");
-            info!("Killing child {}", task_id);
-            kill_child(task_id, &mut child, true);
         }
     }
 }
@@ -434,7 +419,7 @@ impl TaskHandler {
     /// This function is also responsible for waiting
     fn receive_commands(&mut self) {
         // Sleep for a few milliseconds. We don't want to hurt the CPU.
-        let timeout = Duration::from_millis(100);
+        let timeout = Duration::from_millis(200);
         // Don't use recv_timeout for now, until this bug get's fixed.
         // https://github.com/rust-lang/rust/issues/39364
         //match self.receiver.recv_timeout(timeout) {
@@ -452,6 +437,7 @@ impl TaskHandler {
             Message::Kill(message) => self.kill(message),
             Message::Send(message) => self.send(message),
             Message::Reset(children) => self.reset(children),
+            Message::DaemonShutdown => self.shutdown(),
             _ => info!("Received unhandled message {:?}", message),
         }
     }
@@ -799,5 +785,28 @@ impl TaskHandler {
         for id in finished.iter() {
             self.callbacks.remove(*id);
         }
+    }
+
+    /// Gracefully shutdown the task handler.
+    /// This includes killing all child processes
+    ///
+    /// Afterwards we can actually exit the program
+    fn shutdown(&mut self) {
+        info!("Killing all children due to shutdown.");
+
+        let task_ids: Vec<usize> = self.children.keys().cloned().collect();
+        for task_id in task_ids {
+            let child = self.children.remove(&task_id);
+
+            if let Some(mut child) = child {
+                info!("Killing child {}", &task_id);
+                kill_child(task_id, &mut child, true);
+            } else {
+                error!("Fail to get child {} for killing", &task_id);
+            }
+        }
+
+        // Exit pueued
+        std::process::exit(0)
     }
 }

--- a/shared/platform/linux/directories.rs
+++ b/shared/platform/linux/directories.rs
@@ -20,12 +20,11 @@ fn get_home_dir() -> Result<PathBuf> {
 }
 
 pub fn default_config_directory() -> Result<PathBuf> {
-    Ok(get_home_dir()?.join(".config"))
+    Ok(get_home_dir()?.join(".config/pueue"))
 }
 
 pub fn get_config_directories() -> Result<Vec<PathBuf>> {
     Ok(vec![
-        Path::new("/etc").to_path_buf(),
         Path::new("/etc/pueue").to_path_buf(),
         default_config_directory()?,
         Path::new(".").to_path_buf(),
@@ -34,10 +33,10 @@ pub fn get_config_directories() -> Result<Vec<PathBuf>> {
 
 pub fn default_pueue_path() -> Result<String> {
     let path = get_home_dir()?.join(".local/share/pueue");
-    path.to_str().map_or_else(
-        || Err(anyhow!("Failed to parse log path (Weird characters?)")),
-        |v| Ok(v.to_string()),
-    )
+    Ok(path
+        .to_str()
+        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
+        .to_string())
 }
 
 #[cfg(test)]

--- a/shared/platform/linux/directories.rs
+++ b/shared/platform/linux/directories.rs
@@ -43,18 +43,26 @@ pub fn default_pueue_path() -> Result<String> {
 mod tests {
     use super::*;
 
-    use std::fs::File;
+    use std::fs::{remove_file, File};
     use std::io::prelude::*;
 
     use anyhow::Result;
 
     #[test]
-    fn test_spawn_command() -> Result<()> {
-        // Path can be found
+    fn test_create_unix_socket() -> Result<()> {
         let path = get_unix_socket_path()?;
 
-        let mut file = File::create(path)?;
-        file.write_all(b"Hello, world!")?;
+        // If pueue is currently running on the system,
+        // simply accept that we found the correct path
+        if PathBuf::from(&path).exists() {
+            return Ok(());
+        }
+
+        // Otherwise try to create it and write to it
+        let mut file = File::create(&path)?;
+        assert!(file.write_all(b"Hello, world!").is_ok());
+
+        remove_file(&path)?;
 
         Ok(())
     }

--- a/shared/platform/macos/directories.rs
+++ b/shared/platform/macos/directories.rs
@@ -7,7 +7,7 @@ fn get_home_dir() -> Result<PathBuf> {
 }
 
 pub fn default_config_directory() -> Result<PathBuf> {
-    Ok(get_home_dir()?.join("Library/Preferences"))
+    Ok(get_home_dir()?.join("Library/Preferences/pueue"))
 }
 
 pub fn get_config_directories() -> Result<Vec<PathBuf>> {
@@ -19,8 +19,8 @@ pub fn get_config_directories() -> Result<Vec<PathBuf>> {
 
 pub fn default_pueue_path() -> Result<String> {
     let path = get_home_dir()?.join(".local/share/pueue");
-    path.to_str().map_or_else(
-        || Err(anyhow!("Failed to parse log path (Weird characters?)")),
-        |v| Ok(v.to_string()),
-    )
+    Ok(path
+        .to_str()
+        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
+        .to_string())
 }

--- a/shared/platform/macos/directories.rs
+++ b/shared/platform/macos/directories.rs
@@ -1,6 +1,23 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
+use users::{get_current_uid, get_user_by_uid};
+
+/// Get the default unix socket path for the current user
+pub fn get_unix_socket_path() -> Result<String> {
+    // Get the user and their username
+    let user = get_user_by_uid(get_current_uid())
+        .ok_or(anyhow!("Couldn't find username for current user"))?;
+    let username = user.name().to_string_lossy();
+
+    // Create the socket in the default pueue path
+    let pueue_path = PathBuf::from(default_pueue_path()?);
+    let path = pueue_path.join(format!("pueue_{}.socket", username));
+    Ok(path
+        .to_str()
+        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
+        .to_string())
+}
 
 fn get_home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow!("Couldn't resolve home dir"))

--- a/shared/platform/mod.rs
+++ b/shared/platform/mod.rs
@@ -1,10 +1,25 @@
+/// Linux specific stuff
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub mod linux;
+/// MacOs specific stuff
 #[cfg(target_os = "macos")]
 pub mod macos;
+/// Shared unix stuff
+#[cfg(not(target_os = "windows"))]
+pub mod unix;
+/// Windows specific stuff
 #[cfg(target_os = "windows")]
 pub mod windows;
 
+/// Shared unix stuff for sockets
+#[cfg(not(target_os = "windows"))]
+pub use self::unix::socket;
+
+/// Windows specific socket stuff
+#[cfg(target_os = "windows")]
+pub use self::windows::socket;
+
+// The next block is platform specific directory functions
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub use self::linux::directories;
 

--- a/shared/platform/unix/mod.rs
+++ b/shared/platform/unix/mod.rs
@@ -1,0 +1,1 @@
+pub mod socket;

--- a/shared/platform/unix/socket.rs
+++ b/shared/platform/unix/socket.rs
@@ -1,0 +1,66 @@
+use anyhow::{Context, Result};
+use async_std::io::{Read, Write};
+use async_std::net::{TcpListener, TcpStream};
+use async_std::os::unix::net::{UnixListener, UnixStream};
+use async_trait::async_trait;
+
+pub trait GenericSocket: Read + Write + Unpin + Send + Sync {}
+pub type SocketBox = Box<dyn GenericSocket>;
+
+#[async_trait]
+pub trait GenericListener: Sync + Send {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
+}
+
+#[async_trait]
+impl GenericListener for TcpListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+        let (socket, _) = self.accept().await?;
+        Ok(Box::new(socket))
+    }
+}
+
+#[async_trait]
+impl GenericListener for UnixListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+        let (socket, _) = self.accept().await?;
+        Ok(Box::new(socket))
+    }
+}
+
+impl GenericSocket for TcpStream {}
+impl GenericSocket for UnixStream {}
+
+pub async fn get_client(
+    unix_socket_path: Option<String>,
+    port: Option<String>,
+) -> Result<Box<dyn GenericSocket>> {
+    if let Some(socket_path) = unix_socket_path {
+        let stream = UnixStream::connect(socket_path).await?;
+        return Ok(Box::new(stream));
+    }
+
+    // Don't allow anything else than loopback until we have proper crypto
+    // let address = format!("{}:{}", address, port);
+    let address = format!("127.0.0.1:{}", port.unwrap());
+
+    // Connect to socket
+    let socket = TcpStream::connect(&address)
+        .await
+        .context("Failed to connect to the daemon. Did you start it?")?;
+
+    Ok(Box::new(socket))
+}
+
+pub async fn get_listener(
+    unix_socket_path: Option<String>,
+    port: Option<String>,
+) -> Result<Box<dyn GenericListener>> {
+    if let Some(socket_path) = unix_socket_path {
+        return Ok(Box::new(UnixListener::bind(socket_path).await?));
+    }
+
+    let port = port.unwrap();
+    let address = format!("127.0.0.1:{}", port);
+    Ok(Box::new(TcpListener::bind(address).await?))
+}

--- a/shared/platform/unix/socket.rs
+++ b/shared/platform/unix/socket.rs
@@ -6,14 +6,16 @@ use async_std::net::{TcpListener, TcpStream};
 use async_std::os::unix::net::{UnixListener, UnixStream};
 use async_trait::async_trait;
 
+/// A new trait, which can be used to represent Unix- and TcpListeners.
+/// This is necessary to easily write generic functions where both types can be used.
 #[async_trait]
 pub trait GenericListener: Sync + Send {
-    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
+    async fn accept<'a>(&'a self) -> Result<Socket>;
 }
 
 #[async_trait]
 impl GenericListener for TcpListener {
-    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+    async fn accept<'a>(&'a self) -> Result<Socket> {
         let (socket, _) = self.accept().await?;
         Ok(Box::new(socket))
     }
@@ -21,16 +23,19 @@ impl GenericListener for TcpListener {
 
 #[async_trait]
 impl GenericListener for UnixListener {
-    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+    async fn accept<'a>(&'a self) -> Result<Socket> {
         let (socket, _) = self.accept().await?;
         Ok(Box::new(socket))
     }
 }
 
+/// A new trait, which can be used to represent Unix- and TcpStream.
+/// This is necessary to easily write generic functions where both types can be used.
 pub trait GenericSocket: Read + Write + Unpin + Send + Sync {}
 impl GenericSocket for TcpStream {}
 impl GenericSocket for UnixStream {}
 
+/// Two convenient types, so we don't have type write Box<dyn ...> all the time.
 pub type Listener = Box<dyn GenericListener>;
 pub type Socket = Box<dyn GenericSocket>;
 

--- a/shared/platform/windows/directories.rs
+++ b/shared/platform/windows/directories.rs
@@ -2,6 +2,17 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 
+/// Get the default unix socket path for the current user
+pub fn get_unix_socket_path() -> Result<String> {
+    // Create the socket in the default pueue path
+    let pueue_path = PathBuf::from(default_pueue_path()?);
+    let path = pueue_path.join("pueue.socket");
+    Ok(path
+        .to_str()
+        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
+        .to_string())
+}
+
 fn get_home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow!("Couldn't resolve home dir"))
 }

--- a/shared/platform/windows/directories.rs
+++ b/shared/platform/windows/directories.rs
@@ -2,15 +2,9 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
 
-/// Get the default unix socket path for the current user
+/// Windows doesn't have unix sockets
 pub fn get_unix_socket_path() -> Result<String> {
-    // Create the socket in the default pueue path
-    let pueue_path = PathBuf::from(default_pueue_path()?);
-    let path = pueue_path.join("pueue.socket");
-    Ok(path
-        .to_str()
-        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
-        .to_string())
+    Ok(".\\UnixSockets\\are\\not\\available\\on\\Windows".to_string())
 }
 
 fn get_home_dir() -> Result<PathBuf> {

--- a/shared/platform/windows/directories.rs
+++ b/shared/platform/windows/directories.rs
@@ -7,27 +7,27 @@ fn get_home_dir() -> Result<PathBuf> {
 }
 
 pub fn default_config_directory() -> Result<PathBuf> {
-    Ok(get_home_dir()?.join("pueue.yml"))
+    Ok(get_home_dir()?.join("pueue"))
 }
 
 pub fn get_config_directories() -> Result<Vec<PathBuf>> {
     Ok(vec![
         // Windows Terminal stores its config file in the "AppData/Local" directory.
         dirs::data_local_dir()
-            .ok_or_else(|| anyhow!("Couldn't resolve app data directory"))?
-            .join("pueue/pueue.yml"),
+            .ok_or(anyhow!("Couldn't resolve app data directory"))?
+            .join("pueue"),
         default_config_directory()?,
-        Path::new("./pueue.yml").to_path_buf(),
+        Path::new(".").to_path_buf(),
     ])
 }
 
 pub fn default_pueue_path() -> Result<String> {
     // Use local data directory since this data doesn't need to be synced.
     let path = dirs::data_local_dir()
-        .ok_or_else(|| anyhow!("Couldn't resolve app data directory"))?
+        .ok_or(anyhow!("Couldn't resolve app data directory"))?
         .join("pueue");
-    path.to_str().map_or_else(
-        || Err(anyhow!("Failed to parse log path (Weird characters?)")),
-        |v| Ok(v.to_string()),
-    )
+    Ok(path
+        .to_str()
+        .ok_or(anyhow!("Failed to parse log path (Weird characters?)"))?
+        .to_string())
 }

--- a/shared/platform/windows/mod.rs
+++ b/shared/platform/windows/mod.rs
@@ -1,1 +1,2 @@
 pub mod directories;
+pub mod socket;

--- a/shared/platform/windows/socket.rs
+++ b/shared/platform/windows/socket.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_std::io::{Read, Write};
 use async_std::net::{TcpListener, TcpStream};
 use async_trait::async_trait;
@@ -21,8 +21,23 @@ impl GenericListener for TcpListener {
 
 impl GenericSocket for TcpStream {}
 
+pub async fn get_client(
+    _unix_socket_path: Option<String>,
+    port: Option<String>,
+) -> Result<Box<dyn GenericSocket>> {
+    // Don't allow anything else than loopback until we have proper crypto
+    let address = format!("127.0.0.1:{}", port.unwrap());
+
+    // Connect to socket
+    let socket = TcpStream::connect(&address)
+        .await
+        .context("Failed to connect to the daemon. Did you start it?")?;
+
+    Ok(Box::new(socket))
+}
+
 pub async fn get_listener(
-    unix_socket_path: Option<String>,
+    _unix_socket_path: Option<String>,
     port: Option<String>,
 ) -> Result<Box<dyn GenericListener>> {
     let port = port.unwrap();

--- a/shared/platform/windows/socket.rs
+++ b/shared/platform/windows/socket.rs
@@ -5,12 +5,12 @@ use async_trait::async_trait;
 
 #[async_trait]
 pub trait GenericListener: Sync + Send {
-    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
+    async fn accept<'a>(&'a self) -> Result<Socket>;
 }
 
 #[async_trait]
 impl GenericListener for TcpListener {
-    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+    async fn accept<'a>(&'a self) -> Result<Socket> {
         let (socket, _) = self.accept().await?;
         Ok(Box::new(socket))
     }

--- a/shared/platform/windows/socket.rs
+++ b/shared/platform/windows/socket.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use async_std::io::{Read, Write};
+use async_std::net::{TcpListener, TcpStream};
+use async_trait::async_trait;
+
+pub trait GenericSocket: Read + Write + Unpin + Send + Sync {}
+pub type SocketBox = Box<dyn GenericSocket>;
+
+#[async_trait]
+pub trait GenericListener: Sync + Send {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
+}
+
+#[async_trait]
+impl GenericListener for TcpListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+        let (socket, _) = self.accept().await?;
+        Ok(Box::new(socket))
+    }
+}
+
+impl GenericSocket for TcpStream {}
+
+pub async fn get_listener(
+    unix_socket_path: Option<String>,
+    port: Option<String>,
+) -> Result<Box<dyn GenericListener>> {
+    let port = port.unwrap();
+    let address = format!("127.0.0.1:{}", port);
+    Ok(Box::new(TcpListener::bind(address).await?))
+}

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -2,16 +2,42 @@ use std::io::Cursor;
 
 use anyhow::{Context, Result};
 use async_std::io::{Read, Write};
-use async_std::net::TcpStream;
+use async_std::net::{TcpListener, TcpStream};
+#[cfg(not(windows))]
+use async_std::os::unix::net::{UnixListener, UnixStream};
 use async_std::prelude::*;
+use async_trait::async_trait;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use log::debug;
 
 use crate::message::*;
 
+#[async_trait]
+pub trait GenericListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
+}
+
+#[async_trait]
+impl GenericListener for TcpListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+        let (socket, _) = self.accept().await?;
+        Ok((Box::new(socket)))
+    }
+}
+
+#[cfg(not(windows))]
+#[async_trait]
+impl GenericListener for UnixListener {
+    async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>> {
+        let (socket, _) = self.accept().await?;
+        Ok((Box::new(socket)))
+    }
+}
+
 pub trait GenericSocket: Read + Write + Unpin + Send + Sync {}
 pub type SocketBox = Box<dyn GenericSocket>;
 impl GenericSocket for TcpStream {}
+impl GenericSocket for UnixStream {}
 
 /// Convenience wrapper around send_bytes.
 /// Deserialize a message and feed the bytes into send_bytes.

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -13,7 +13,7 @@ use log::debug;
 use crate::message::*;
 
 #[async_trait]
-pub trait GenericListener {
+pub trait GenericListener: Sync + Send {
     async fn accept<'a>(&'a self) -> Result<Box<dyn GenericSocket>>;
 }
 

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -11,7 +11,7 @@ pub use crate::platform::socket::*;
 
 /// Convenience wrapper around send_bytes.
 /// Deserialize a message and feed the bytes into send_bytes.
-pub async fn send_message(message: Message, socket: &mut SocketBox) -> Result<()> {
+pub async fn send_message(message: Message, socket: &mut Socket) -> Result<()> {
     debug!("Sending message: {:?}", message);
     // Prepare command for transfer and determine message byte size
     let payload = bincode::serialize(&message).expect("Failed to serialize message.");
@@ -21,7 +21,7 @@ pub async fn send_message(message: Message, socket: &mut SocketBox) -> Result<()
 
 /// Send a Vec of bytes. Before the actual bytes are send, the size of the message
 /// is transmitted in an header of fixed size (u64).
-pub async fn send_bytes(payload: Vec<u8>, socket: &mut SocketBox) -> Result<()> {
+pub async fn send_bytes(payload: Vec<u8>, socket: &mut Socket) -> Result<()> {
     let message_size = payload.len() as u64;
 
     let mut header = vec![];
@@ -41,7 +41,7 @@ pub async fn send_bytes(payload: Vec<u8>, socket: &mut SocketBox) -> Result<()> 
 
 /// Receive a byte stream depending on a given header.
 /// This is the basic protocol beneath all pueue communication.
-pub async fn receive_bytes(socket: &mut SocketBox) -> Result<Vec<u8>> {
+pub async fn receive_bytes(socket: &mut Socket) -> Result<Vec<u8>> {
     // Receive the header with the overall message size
     let mut header = vec![0; 8];
     socket.read(&mut header).await?;
@@ -77,7 +77,7 @@ pub async fn receive_bytes(socket: &mut SocketBox) -> Result<Vec<u8>> {
 }
 
 /// Convenience wrapper that receives a message and converts it into a Message.
-pub async fn receive_message(socket: &mut SocketBox) -> Result<Message> {
+pub async fn receive_message(socket: &mut Socket) -> Result<Message> {
     let payload_bytes = receive_bytes(socket).await?;
 
     // Deserialize the message.

--- a/shared/protocol.rs
+++ b/shared/protocol.rs
@@ -1,15 +1,21 @@
-use ::anyhow::{Context, Result};
-use ::async_std::net::TcpStream;
-use ::async_std::prelude::*;
-use ::byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use ::log::debug;
-use ::std::io::Cursor;
+use std::io::Cursor;
+
+use anyhow::{Context, Result};
+use async_std::io::{Read, Write};
+use async_std::net::TcpStream;
+use async_std::prelude::*;
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use log::debug;
 
 use crate::message::*;
 
+pub trait GenericSocket: Read + Write + Unpin + Send + Sync {}
+pub type SocketBox = Box<dyn GenericSocket>;
+impl GenericSocket for TcpStream {}
+
 /// Convenience wrapper around send_bytes.
 /// Deserialize a message and feed the bytes into send_bytes.
-pub async fn send_message(message: Message, socket: &mut TcpStream) -> Result<()> {
+pub async fn send_message(message: Message, socket: &mut SocketBox) -> Result<()> {
     debug!("Sending message: {:?}", message);
     // Prepare command for transfer and determine message byte size
     let payload = bincode::serialize(&message).expect("Failed to serialize message.");
@@ -19,7 +25,7 @@ pub async fn send_message(message: Message, socket: &mut TcpStream) -> Result<()
 
 /// Send a Vec of bytes. Before the actual bytes are send, the size of the message
 /// is transmitted in an header of fixed size (u64).
-pub async fn send_bytes(payload: Vec<u8>, socket: &mut TcpStream) -> Result<()> {
+pub async fn send_bytes(payload: Vec<u8>, socket: &mut SocketBox) -> Result<()> {
     let message_size = payload.len() as u64;
 
     let mut header = vec![];
@@ -39,7 +45,7 @@ pub async fn send_bytes(payload: Vec<u8>, socket: &mut TcpStream) -> Result<()> 
 
 /// Receive a byte stream depending on a given header.
 /// This is the basic protocol beneath all pueue communication.
-pub async fn receive_bytes(socket: &mut TcpStream) -> Result<Vec<u8>> {
+pub async fn receive_bytes(socket: &mut SocketBox) -> Result<Vec<u8>> {
     // Receive the header with the overall message size
     let mut header = vec![0; 8];
     socket.read(&mut header).await?;
@@ -75,7 +81,7 @@ pub async fn receive_bytes(socket: &mut TcpStream) -> Result<Vec<u8>> {
 }
 
 /// Convenience wrapper that receives a message and converts it into a Message.
-pub async fn receive_message(socket: &mut TcpStream) -> Result<Message> {
+pub async fn receive_message(socket: &mut SocketBox) -> Result<Message> {
     let payload_bytes = receive_bytes(socket).await?;
 
     // Deserialize the message.

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -56,6 +56,7 @@ impl Settings {
 
         config.set_default("shared.port", "6924")?;
         config.set_default("shared.secret", gen_random_secret())?;
+        config.set_default("shared.pueue_directory", default_pueue_path()?)?;
         config.set_default("shared.use_unix_socket", false)?;
         config.set_default("shared.unix_socket_path", get_unix_socket_path()?)?;
 

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -102,12 +102,12 @@ impl Settings {
 /// configuration files at those locations.
 /// All configs will be merged by importance.
 fn parse_config(settings: &mut Config) -> Result<()> {
-    println!("Parsing config files");
+    //println!("Parsing config files");
     for directory in get_config_directories()?.into_iter() {
         let path = directory.join("pueue.yml");
-        println!("Checking path: {:?}", &path);
+        //println!("Checking path: {:?}", &path);
         if path.exists() {
-            println!("Parsing config file at: {:?}", path);
+            //println!("Parsing config file at: {:?}", path);
             let config_file = config::File::with_name(path.to_str().unwrap());
             settings.merge(config_file)?;
         }

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -4,12 +4,12 @@ use std::io::prelude::*;
 
 use anyhow::{anyhow, Result};
 use config::Config;
-use log::info;
 use rand::Rng;
 use serde_derive::{Deserialize, Serialize};
 
 use crate::platform::directories::*;
 
+/// All settings which are used by both, the client and the daemon
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Shared {
     pub port: String,
@@ -19,11 +19,13 @@ pub struct Shared {
     pub unix_socket_path: String,
 }
 
+/// All settings which are used by the client
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Client {
     pub read_local_logs: bool,
 }
 
+/// All settings which are used by the daemon
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Daemon {
     pub default_parallel_tasks: usize,
@@ -37,7 +39,6 @@ fn pause_on_failure_default() -> bool {
     false
 }
 
-/// The struct representation of a full configuration.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub shared: Shared,
@@ -97,13 +98,16 @@ impl Settings {
     }
 }
 
+/// Get all possible configuration paths and check if there are
+/// configuration files at those locations.
+/// All configs will be merged by importance.
 fn parse_config(settings: &mut Config) -> Result<()> {
-    info!("Parsing config files");
+    println!("Parsing config files");
     for directory in get_config_directories()?.into_iter() {
         let path = directory.join("pueue.yml");
-        info!("Checking path: {:?}", &path);
+        println!("Checking path: {:?}", &path);
         if path.exists() {
-            info!("Parsing config file at: {:?}", path);
+            println!("Parsing config file at: {:?}", path);
             let config_file = config::File::with_name(path.to_str().unwrap());
             settings.merge(config_file)?;
         }
@@ -112,6 +116,7 @@ fn parse_config(settings: &mut Config) -> Result<()> {
     Ok(())
 }
 
+/// Simple helper function to generate a random secret
 fn gen_random_secret() -> String {
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                             abcdefghijklmnopqrstuvwxyz\

--- a/shared/state.rs
+++ b/shared/state.rs
@@ -25,6 +25,17 @@ pub struct State {
     pub groups: HashMap<String, bool>,
 }
 
+/// This is the full representation of the current state of the Pueue daemon.
+/// This includes
+/// - All settings.
+/// - The full task list
+/// - The current status of all tasks
+///
+/// However, the State does NOT include:
+/// - Information about child processes
+/// - Handles to child processes
+///
+/// That information is saved in the TaskHandler.
 impl State {
     pub fn new(settings: &Settings) -> State {
         // Create a default group state.

--- a/shared/state.rs
+++ b/shared/state.rs
@@ -201,7 +201,7 @@ impl State {
 
         let serialized = serialized.unwrap();
 
-        let path = Path::new(&self.settings.daemon.pueue_directory);
+        let path = Path::new(&self.settings.shared.pueue_directory);
         let (temp, real) = if log {
             let path = path.join("log");
             let now: DateTime<Utc> = Utc::now();
@@ -242,7 +242,7 @@ impl State {
     /// Restore the last state from a previous session.
     /// The state is stored as json in the log directory.
     fn restore(&mut self) {
-        let path = Path::new(&self.settings.daemon.pueue_directory).join("state.json");
+        let path = Path::new(&self.settings.shared.pueue_directory).join("state.json");
 
         // Ignore if the file doesn't exist. It doesn't have to.
         if !path.exists() {
@@ -328,7 +328,7 @@ impl State {
 
     /// Remove old logs that aren't needed any longer.
     fn rotate(&mut self) -> Result<()> {
-        let path = Path::new(&self.settings.daemon.pueue_directory);
+        let path = Path::new(&self.settings.shared.pueue_directory);
         let path = path.join("log");
 
         // Get all log files in the directory with their respective system time.

--- a/shared/task.rs
+++ b/shared/task.rs
@@ -22,7 +22,8 @@ pub enum TaskStatus {
     Locked,
 }
 
-/// This enum represents the exit status of the actually spawned program.
+/// This enum represents the exit status of an actually spawned program.
+/// It's only of relevance, once a task actually spawned and somehow finished.
 #[derive(Clone, Debug, Display, PartialEq, Serialize, Deserialize)]
 pub enum TaskResult {
     /// Task exited with 0
@@ -84,6 +85,7 @@ impl Task {
         }
     }
 
+    /// A convenience function, which is used to create a duplicate task.
     pub fn from_task(task: &Task) -> Task {
         Task {
             id: 0,
@@ -109,8 +111,8 @@ impl Task {
         self.status == TaskStatus::Done
     }
 
-    // Check if the task errored.
-    // The only case when it didn't error is if it didn't run yet or if the task exited successfully.
+    /// Check if the task errored.
+    /// The only case when it didn't error is if it didn't run yet or if the task exited successfully.
     pub fn failed(&self) -> bool {
         match self.result {
             None => false,

--- a/tests/test_protocol.rs
+++ b/tests/test_protocol.rs
@@ -30,7 +30,7 @@ async fn test_single_huge_payload() -> Result<()> {
         send_message(message, &mut socket).await.unwrap();
     });
 
-    let mut client: Box<dyn GenericSocket> = Box::new(TcpStream::connect(&addr).await?);
+    let mut client: Socket = Box::new(TcpStream::connect(&addr).await?);
 
     // Create a client that sends a message and instantly receives it
     send_message(message, &mut client).await?;

--- a/tests/test_protocol.rs
+++ b/tests/test_protocol.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use async_std::net::{TcpListener, TcpStream};
-use async_std::prelude::*;
 use async_std::task;
 
 use pueue::message::{create_success_message, Message};
@@ -16,13 +15,14 @@ async fn test_single_huge_payload() -> Result<()> {
     let message = create_success_message(payload);
     let original_bytes = bincode::serialize(&message).expect("Failed to serialize message.");
 
+    let listener: Box<dyn GenericListener> = Box::new(listener);
+
     // Spawn a sub thread that:
     // 1. Accepts a new connection
     // 2. Reads a message
     // 3. Sends the same message back
     task::spawn(async move {
-        let mut incoming = listener.incoming();
-        let mut socket = incoming.next().await.unwrap().unwrap();
+        let mut socket = listener.accept().await.unwrap();
         let message_bytes = receive_bytes(&mut socket).await.unwrap();
 
         let message: Message = bincode::deserialize(&message_bytes).unwrap();
@@ -30,7 +30,8 @@ async fn test_single_huge_payload() -> Result<()> {
         send_message(message, &mut socket).await.unwrap();
     });
 
-    let mut client = TcpStream::connect(&addr).await?;
+    let mut client: Box<dyn GenericSocket> = Box::new(TcpStream::connect(&addr).await?);
+
     // Create a client that sends a message and instantly receives it
     send_message(message, &mut client).await?;
     let response_bytes = receive_bytes(&mut client).await?;


### PR DESCRIPTION
Resolves #90 

This PR adds generic streams/listeners and support for UnixSockets.

What still needs to be done:

- [x] Move the socket code to the platform specific code
- [x] Make a `unix` platform for shared code between linux and macOs
- [x] On daemon start: Check whether he unix socket exists. If it exists, check if you can connect.
      If one can connect, abort and write an error message.
      If we cannot connect, remove the socket and continue normal operations.
- [x] Maybe get those generic Traits better names.