### PR TITLE
Add warnings when removing/killing tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This version adds breaking changes:
 ### Added
 
 - Unix socket support (#90)
+- Warning messages for removing/killing tasks (#111) by [Julian Kaindl](https://github.com/kaindljulian)
 
 ### Fixed
 
@@ -34,7 +35,7 @@ This version adds breaking changes:
 ### Changed
 
 - Linux process handling now always sends signals to it's direct children, if the root process is a `sh -c` process.
-    Previously, this behavior was somewhat ambiguous and inconsistent. (#109)
+  Previously, this behavior was somewhat ambiguous and inconsistent. (#109)
 
 ### Added
 
@@ -86,8 +87,8 @@ This version adds breaking changes:
 ### Added
 
 - `--children/-c` flag for `start` and `stop`.
-    This sends the `SIGSTOP`/`SIGSTART` signal not only to the main process of a task, but also to direct children.
-    This is, for instance, useful if you're starting tasks via a shell script.
+  This sends the `SIGSTOP`/`SIGSTART` signal not only to the main process of a task, but also to direct children.
+  This is, for instance, useful if you're starting tasks via a shell script.
 
 ### Fixed
 
@@ -98,8 +99,8 @@ This version adds breaking changes:
 ### Added
 
 - Groups! Tasks can now be assigned to a group.
-    Each group acts as their own queue and each group has their own setting for parallel task execution.
-    Groups can also be paused/resumed individually.
+  Each group acts as their own queue and each group has their own setting for parallel task execution.
+  Groups can also be paused/resumed individually.
 - Added `--group` flag for `status`. This will only print tasks of a specific group
 - Add new flags `--default` to `kill`. With this flag only tasks in the default queue will be affected.
 - Users can now specify a custom callback that'll be called whenever tasks finish.
@@ -117,14 +118,14 @@ This version adds breaking changes:
 ### Added
 
 - Dependencies! This adds the `--after [ids]` option. Implemented by [tinou98](https://github.com/tinou98).  
-    Task with this option will only be started, if all specified dependencies successfully finish.
-    Tasks with failed dependencies will fail as well.
+   Task with this option will only be started, if all specified dependencies successfully finish.
+  Tasks with failed dependencies will fail as well.
 - New state `FailedToStart`. Used if the process cannot be started.
 - New state `DependencyFailed`. Used if any dependency of a task fails.
 - New config option `read_local_logs`. Default: `true`
-    We assume that the daemon and client run on the same machine by default.
-    This removes the need to send logs via socket, since the client can directly read the log files.  
-    Set to `false` if you, for instance, use Pueue in combination with SSH port forwarding.
+  We assume that the daemon and client run on the same machine by default.
+  This removes the need to send logs via socket, since the client can directly read the log files.  
+   Set to `false` if you, for instance, use Pueue in combination with SSH port forwarding.
 
 ### Changed
 
@@ -160,13 +161,13 @@ This version adds breaking changes:
 ### Added
 
 - New `--delay` flag, which delays enqueueing of a task. Can be used on `start` and `enqueue`. Implemented by [taylor1791](https://github.com/taylor1791).
-- `--stashed` flag for `pueue add` to add a task in stashed mode.  Implemented by [taylor1791](https://github.com/taylor1791).
+- `--stashed` flag for `pueue add` to add a task in stashed mode. Implemented by [taylor1791](https://github.com/taylor1791).
 
 ### Changed
 
 - Generating completion files moved away from build.rs to the new `pueue completions {shell} {output_dir}` subcommand.
-This seems to be the proper way to generate completion files with clap.
-There is a `build_completions.sh` script to build all completion files to the known location for your convenience.
+  This seems to be the proper way to generate completion files with clap.
+  There is a `build_completions.sh` script to build all completion files to the known location for your convenience.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 [![Downloads](https://img.shields.io/github/downloads/nukesor/pueue/total.svg)](https://github.com/nukesor/pueue/releases)
 [![Patreon](https://github.com/Nukesor/images/blob/master/patreon-donate-blue.svg)](https://www.patreon.com/nukesor)
 [![Paypal](https://github.com/Nukesor/images/blob/master/paypal-donate-blue.svg)](https://www.paypal.me/arnebeer/)
+
 <!---[![dependency status](https://deps.rs/repo/github/nukesor/pueue/status.svg)](https://deps.rs/repo/github/nukesor/pueue) --->
 
 ![Pueue](https://raw.githubusercontent.com/Nukesor/images/master/pueue.gif)
 
-Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.  
+Pueue is a command-line task management tool for sequential and parallel execution of long-running tasks.
 
 Simply put, it's a tool that processes a queue of shell commands.
 On top of that, there are a lot of convenience features and abstractions.
@@ -62,7 +63,7 @@ Consider this scenario: You have to unpack large amounts of data into various di
 Usually something like this ends with 10+ open terminals/tmux sessions and an over-challenged hard drive.
 
 Another scenario might be, that you want to re-encode 10 movies and each re-encode takes 10+ hours.
-Creating a chained command with `&&`s isn't ergonomic at all and running that many re-encodes in parallel will break your CPU.  
+Creating a chained command with `&&`s isn't ergonomic at all and running that many re-encodes in parallel will break your CPU.
 
 Pueue is specifically designed for these situations.
 
@@ -99,7 +100,7 @@ Use your system's package manager.
 This will usually deploy service files and completions automatically.  
 Pueue has been packaged for:
 
-- Arch Linux's AUR: e.g. `yay -S pueue`.  
+- Arch Linux's AUR: e.g. `yay -S pueue`.
 - NixOS
 - Homebrew
 
@@ -109,7 +110,7 @@ Statically linked (if possible) binaries for Linux (incl. ARM), Mac OS and Windo
 
 You can download the binaries for the client and the daemon (`pueue` and `pueued`) for each release on the [release page](https://github.com/Nukesor/pueue/releases).
 
-Just download both binaries for your system, rename them to `pueue` and `pueued` and place them in your $PATH/program folder.
+Just download both binaries for your system, rename them to `pueue` and `pueued` and place them in your \$PATH/program folder.
 
 #### Via Cargo
 
@@ -147,13 +148,12 @@ The daemon can be then shut down using the client: `pueue shutdown`
 ### Systemd
 
 If you use Systemd and don't install Pueue with a package manager, place `pueued.service` in `/etc/systemd/user/`.  
-Afterward, every user can start/enable their own session with:  
+Afterward, every user can start/enable their own session with:
 
 ```bash
 systemctl --user start pueued.service
 systemctl --user enable pueued.service
 ```
-
 
 ## How to use it
 
@@ -188,7 +188,6 @@ Most commands can be executed on multiple tasks.
 For instance, you can look at specific logs like this `pueue log 0 1 2 3 15 19`.
 
 This also works with your shell's range parameter, e.g. `pueue log {0..3} 15 19`.
-
 
 **Pitfalls:**
 
@@ -256,6 +255,7 @@ client:
   daemon_port: "6924"
   secret: "your_secret"
   read_local_logs: true
+  print_remove_warnings: false
 
 daemon:
   pueue_directory: /home/$USER/.local/share/pueue
@@ -270,16 +270,17 @@ daemon:
 
 **Client**:
 
-- `daemon_port` The port the client tries to connect to.  
+- `daemon_port` The port the client tries to connect to.
 - `secret` The secret, that's used for authentication
 - `read_local_logs` If the client runs as the same user (and on the same machine) as the daemon, logs don't have to be sent via the socket but rather read directly.
+- `print_remove_warnings` The client will print warnings that require confirmation for different critical commands.
 
 **Daemon**:
 
 - `pueue_directory` The location Pueue uses for its intermediate files and logs.
-- `default_parallel_tasks` Determines how many tasks should be processed concurrently.  
+- `default_parallel_tasks` Determines how many tasks should be processed concurrently.
 - `pause_on_failure` If set to `true`, the daemon stops starting new task as soon as a single task fails. Already running tasks will continue.
-- `port` The port the daemon should listen to.  
+- `port` The port the daemon should listen to.
 - `secret` The secret, that's used for authentication
 - `callback` The command that will be called after a task finishes. Can be parameterized
 - `groups` This is a list of the groups with their amount of allowed parallel tasks. It's advised to not manipulate this manually, but rather use the `group` subcommand to create and remove groups.
@@ -300,7 +301,7 @@ This would help me a lot!
 
 Grouping tasks can be useful, whenever your tasks utilize different system resources.  
 A possible scenario would be to have an `io` group for tasks that copy large files, while your cpu-heavy (e.g. reencoding) tasks are in a `cpu` group.
-The parallelism setting of `io` could then be set to `1` and `cpu` be set to `2`.  
+The parallelism setting of `io` could then be set to `1` and `cpu` be set to `2`.
 
 As a result, there'll always be a single task that copies stuff, while two tasks try to utilize your cpu as good as possible.
 
@@ -313,8 +314,8 @@ To get basic aliasing, simply put a `pueue_aliases.yml` besides your `pueue.yml`
 Its contents should look something like this:
 
 ```yaml
-ls: "ls -ahl"
-rsync: "rsync --recursive --partial --perms --progress"
+ls: 'ls -ahl'
+rsync: 'rsync --recursive --partial --perms --progress'
 ```
 
 When adding a command to pueue, the **first** word will then be checked for the alias.
@@ -325,7 +326,7 @@ If you want multiple aliases in a single task, it's probably best to either crea
 ### Callbacks
 
 You can specify a callback that will be called every time a task finishes.
-The callback can be parameterized with some variables.  
+The callback can be parameterized with some variables.
 
 These are the available variables that can be used to create a command:
 
@@ -338,7 +339,7 @@ These are the available variables that can be used to create a command:
 Example callback:
 
 ```yaml
-    callback: "notify-send \"Task {{ id }}\nCommand: {{ command }}\nPath: {{ path }}\nFinished with status '{{ result }}'\""
+callback: "notify-send \"Task {{ id }}\nCommand: {{ command }}\nPath: {{ path }}\nFinished with status '{{ result }}'\""
 ```
 
 ### Shell completion files

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ SUBCOMMANDS:
 
 The configuration file of Pueue is located in these directories:
 
-- Linux: `$HOME/.config/pueue/pueue.yml`.  
+- Linux: `$HOME/.config/pueue/pueue.yml`.
 - MacOs: `$HOME/Library/Preferences/pueue/pueue.yml`
 - Windows: `%APPDATA%\Local\pueue`
 
@@ -262,9 +262,10 @@ shared:
   pueue_directory: /home/$USER/.local/share/pueue
   use_unix_sockets: false
   unix_sockets_path: /home/$USER/.local/share/pueue/pueue_$USER.socket
+
 client:
   read_local_logs: true
-  print_remove_warnings: false
+  show_confirmation_questions: false
 
 daemon:
   default_parallel_tasks: 1
@@ -276,7 +277,7 @@ daemon:
 
 ### Shared
 
-- `port` The port the daemon listens on and the client connects to in TCP mode.  
+- `port` The port the daemon listens on and the client connects to in TCP mode.
 - `secret` The secret, that's used for authentication
 - `pueue_directory` The location Pueue uses for its intermediate files and logs.
 - `use_unix_sockets` Whether the daemon should listen on a Unix- or a TCP-socket.
@@ -285,12 +286,11 @@ daemon:
 ### Client
 
 - `read_local_logs` If the client runs as the same user (and on the same machine) as the daemon, logs don't have to be sent via the socket but rather read directly.
-- `print_remove_warnings` The client will print warnings that require confirmation for different critical commands.
+- `show_confirmation_questions` The client will print warnings that require confirmation for different critical commands.
 
 ### Daemon
 
-
-- `default_parallel_tasks` Determines how many tasks should be processed concurrently.  
+- `default_parallel_tasks` Determines how many tasks should be processed concurrently.
 - `pause_on_failure` If set to `true`, the daemon stops starting new task as soon as a single task fails. Already running tasks will continue.
 - `callback` The command that will be called after a task finishes. Can be parameterized
 - `groups` This is a list of the groups with their amount of allowed parallel tasks. It's advised to not manipulate this manually, but rather use the `group` subcommand to create and remove groups.

--- a/client/client.rs
+++ b/client/client.rs
@@ -185,13 +185,13 @@ impl Client {
 
     /// Prints a warning and prompt for given action and tasks.
     /// Returns `Ok(())` if the action was confirmed.
-    fn handle_user_confirmation(&self, action: &str, task_ids: &Vec<usize>) -> Result<()> {
+    fn handle_user_confirmation(&self, action: &str, task_ids: &[usize]) -> Result<()> {
         // printing warning and prompt
         println!(
             "You are trying to {}: {}",
             action,
             task_ids
-                .into_iter()
+                .iter()
                 .map(|t| format!("task{}", t.to_string()))
                 .collect::<Vec<String>>()
                 .join(", ")
@@ -202,7 +202,7 @@ impl Client {
         io::stdout().flush().unwrap();
         io::stdin().read_line(&mut input)?;
 
-        if input.starts_with("n") || input.starts_with("N") {
+        if input.starts_with('n') || input.starts_with('N') {
             bail!("User did not confirm");
         }
 

--- a/client/client.rs
+++ b/client/client.rs
@@ -196,17 +196,26 @@ impl Client {
                 .collect::<Vec<String>>()
                 .join(", ")
         );
-        print!("\nDo you want to continue [Y/n]: ");
 
         let mut input = String::new();
-        io::stdout().flush().unwrap();
-        io::stdin().read_line(&mut input)?;
 
-        if input.starts_with('n') || input.starts_with('N') {
-            bail!("User did not confirm");
+        loop {
+            print!("Do you want to continue [Y/n]: ");
+            io::stdout().flush().unwrap();
+            input.clear();
+            io::stdin().read_line(&mut input)?;
+
+            match input.chars().next().unwrap_or("y") {
+                'N' | 'n' => { 
+                    println!("Aborted!");
+                    std::process::exit(1);
+                },
+                '\n' | 'Y' | 'y' => {
+                    return Ok(());
+                },
+                _ => { continue; }
+            }
         }
-
-        Ok(())
     }
 
     /// Convert the cli command into the message that's being sent to the server,
@@ -246,10 +255,7 @@ impl Client {
             }
             SubCommand::Remove { task_ids } => {
                 if self.settings.client.print_remove_warnings {
-                    match self.handle_user_confirmation("remove", task_ids) {
-                        Ok(_) => (),
-                        Err(_) => std::process::exit(1),
-                    }
+                    self.handle_user_confirmation("remove", task_ids);
                 }
                 Ok(Message::Remove(task_ids.clone()))
             }
@@ -312,10 +318,7 @@ impl Client {
                 children,
             } => {
                 if self.settings.client.print_remove_warnings {
-                    match self.handle_user_confirmation("kill", task_ids) {
-                        Ok(_) => (),
-                        Err(_) => std::process::exit(1),
-                    }
+                    self.handle_user_confirmation("kill", task_ids);
                 }
                 let message = KillMessage {
                     task_ids: task_ids.clone(),

--- a/client/client.rs
+++ b/client/client.rs
@@ -205,17 +205,21 @@ impl Client {
             input.clear();
             io::stdin().read_line(&mut input)?;
 
-            match input.chars().next().unwrap_or("y") {
-                'N' | 'n' => { 
+            match input.chars().next().unwrap() {
+                'N' | 'n' => {
                     println!("Aborted!");
                     std::process::exit(1);
-                },
+                }
                 '\n' | 'Y' | 'y' => {
-                    return Ok(());
-                },
-                _ => { continue; }
+                    break;
+                }
+                _ => {
+                    continue;
+                }
             }
         }
+
+        Ok(())
     }
 
     /// Convert the cli command into the message that's being sent to the server,
@@ -255,7 +259,7 @@ impl Client {
             }
             SubCommand::Remove { task_ids } => {
                 if self.settings.client.print_remove_warnings {
-                    self.handle_user_confirmation("remove", task_ids);
+                    self.handle_user_confirmation("remove", task_ids)?;
                 }
                 Ok(Message::Remove(task_ids.clone()))
             }
@@ -318,7 +322,7 @@ impl Client {
                 children,
             } => {
                 if self.settings.client.print_remove_warnings {
-                    self.handle_user_confirmation("kill", task_ids);
+                    self.handle_user_confirmation("kill", task_ids)?;
                 }
                 let message = KillMessage {
                     task_ids: task_ids.clone(),

--- a/client/client.rs
+++ b/client/client.rs
@@ -258,7 +258,7 @@ impl Client {
                 }))
             }
             SubCommand::Remove { task_ids } => {
-                if self.settings.client.print_remove_warnings {
+                if self.settings.client.show_confirmation_questions {
                     self.handle_user_confirmation("remove", task_ids)?;
                 }
                 Ok(Message::Remove(task_ids.clone()))
@@ -321,7 +321,7 @@ impl Client {
                 all,
                 children,
             } => {
-                if self.settings.client.print_remove_warnings {
+                if self.settings.client.show_confirmation_questions {
                     self.handle_user_confirmation("kill", task_ids)?;
                 }
                 let message = KillMessage {

--- a/client/client.rs
+++ b/client/client.rs
@@ -185,13 +185,16 @@ impl Client {
 
     /// Prints a warning and prompt for given action and tasks.
     /// Returns `Ok(())` if the action was confirmed.
-    fn handle_user_confirmation(&self, action :&str, task_ids: &Vec<usize>) -> Result<()> {
+    fn handle_user_confirmation(&self, action: &str, task_ids: &Vec<usize>) -> Result<()> {
         // printing warning and prompt
-        println!("You are trying to {}: {}", action, task_ids
-            .into_iter()
-            .map(|t| format!("task{}", t.to_string()))
-            .collect::<Vec<String>>()
-            .join(", ")
+        println!(
+            "You are trying to {}: {}",
+            action,
+            task_ids
+                .into_iter()
+                .map(|t| format!("task{}", t.to_string()))
+                .collect::<Vec<String>>()
+                .join(", ")
         );
         print!("\nDo you want to continue [Y/n]: ");
 
@@ -245,11 +248,11 @@ impl Client {
                 if self.settings.client.print_remove_warnings {
                     match self.handle_user_confirmation("remove", task_ids) {
                         Ok(_) => (),
-                        Err(_) => std::process::exit(1)
+                        Err(_) => std::process::exit(1),
                     }
                 }
                 Ok(Message::Remove(task_ids.clone()))
-            },
+            }
             SubCommand::Stash { task_ids } => Ok(Message::Stash(task_ids.clone())),
             SubCommand::Switch {
                 task_id_1,
@@ -311,7 +314,7 @@ impl Client {
                 if self.settings.client.print_remove_warnings {
                     match self.handle_user_confirmation("kill", task_ids) {
                         Ok(_) => (),
-                        Err(_) => std::process::exit(1)
+                        Err(_) => std::process::exit(1),
                     }
                 }
                 let message = KillMessage {

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -24,7 +24,7 @@ pub struct Shared {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Client {
     pub read_local_logs: bool,
-    pub print_remove_warnings: bool,
+    pub show_confirmation_questions: bool,
 }
 
 /// All settings which are used by the daemon
@@ -62,7 +62,7 @@ impl Settings {
 
         // Client specific config
         config.set_default("client.read_local_logs", true)?;
-        config.set_default("client.print_remove_warnings", false)?;
+        config.set_default("client.show_confirmation_questions", false)?;
 
         // Daemon specific config
         config.set_default("daemon.default_parallel_tasks", 1)?;

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -23,6 +23,7 @@ pub struct Shared {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Client {
     pub read_local_logs: bool,
+    pub print_remove_warnings: bool,
 }
 
 /// All settings which are used by the daemon
@@ -63,6 +64,7 @@ impl Settings {
 
         // Client specific config
         config.set_default("client.read_local_logs", true)?;
+        config.set_default("client.read_local_logs", false)?;
 
         // Daemon specific config
         config.set_default("daemon.default_parallel_tasks", 1)?;

--- a/shared/settings.rs
+++ b/shared/settings.rs
@@ -64,7 +64,7 @@ impl Settings {
 
         // Client specific config
         config.set_default("client.read_local_logs", true)?;
-        config.set_default("client.read_local_logs", false)?;
+        config.set_default("client.print_remove_warnings", false)?;
 
         // Daemon specific config
         config.set_default("daemon.default_parallel_tasks", 1)?;


### PR DESCRIPTION
Like how it is described in #111 this adds completely optional user confirmations for removing and killing tasks.

The config file flag is `print_remove_warnings` which is false by default. (not too fond of the naming tbh ^^, maybe someone can suggest a better one)

With `print_remove_warnings: true`:
![image](https://user-images.githubusercontent.com/22956190/96357456-4f1c7480-10fc-11eb-9929-de7bf63c1bc4.png)

![image](https://user-images.githubusercontent.com/22956190/96357463-678c8f00-10fc-11eb-80f6-f0e0558f91e2.png)


Resolves #111 