### PR TITLE
fix zsh completion hang

### DIFF
--- a/client/cli.rs
+++ b/client/cli.rs
@@ -252,7 +252,7 @@ pub enum SubCommand {
     },
 
     /// Follow the output of a currently running task.
-    /// This command works like `tail -f`.
+    /// This command works like tail -f.
     Follow {
         /// The id of the task you want to watch.
         /// If no or multiple tasks are running, you have to specify the id.


### PR DESCRIPTION
This PR fixes the issue of the zsh completion script hanging when executing.

The doc-comment in the cli will be part of the completion string which would result in this scenario
    "This command works like \`tail -f\`"
At the time of evaluation zsh will call tail -f, which will then do its job 

Removing the \` \` will prevent this from happening
    "This command works like tail -f"

This will fix #57 