### PR TITLE
Add times to callback parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,3 +232,9 @@ This version adds breaking changes:
 
 - Replace prettytables-rs with comfy-table.
 - Replace termion with crossterm.
+
+## [0.8.1] -
+
+### Added
+
+- Add `start`, `end` and `enqueue` time paramters to callback hooks

--- a/daemon/task_handler.rs
+++ b/daemon/task_handler.rs
@@ -741,6 +741,15 @@ impl TaskHandler {
         parameters.insert("command", task.command.clone());
         parameters.insert("path", task.path.clone());
         parameters.insert("result", task.result.clone().unwrap().to_string());
+
+        let print_time = |time: Option<DateTime<Local>>| {
+            time.map(|time| time.timestamp().to_string())
+                .unwrap_or_else(String::new)
+        };
+        parameters.insert("enqueue", print_time(task.enqueue_at));
+        parameters.insert("start", print_time(task.start));
+        parameters.insert("end", print_time(task.end));
+
         if let Some(group) = &task.group {
             parameters.insert("group", group.clone());
         } else {


### PR DESCRIPTION
This adds the start, end and enqueue time to the callback parameters or the empty string if they are not present.