### PR TITLE
Add Alpine Linux to list of distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Use your system's package manager.
 This will usually deploy service files and completions automatically.  
 Pueue has been packaged for:
 
+- Alpine Linux (since 3.13)
 - Arch Linux's AUR: e.g. `yay -S pueue`.
 - NixOS
 - Homebrew


### PR DESCRIPTION
Note: Alpine 3.13 has not been released yet, it should be till the end of this year.