### PR TITLE
client: add support dark colors via settings file (dark_mode variable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Managing two crates in a single repository in combination with `cargo release` t
 ### Added
 
 - `--all-failed` flag for `restart`. This will restart all tasks that didn't finish with a `Success` status.
+- New config option `client.dark_mode` by [Mephistophiles](https://github.com/Mephistophiles). Default: `false`. Adds the ability to switch to dark colors instead of regular colors. 
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "pueue-lib"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbde4949922bc8e6e783f66fbd322ab9f68fa4aa6e2c97ef9d19b9b20f6cbef"
+checksum = "efaf3d7c6ca2958d334db59e981dcac98d2c893f681876b05c5e95b671288933"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "pueued"
 path = "daemon/main.rs"
 
 [dependencies]
-pueue-lib = "0.12"
+pueue-lib = "0.12.1"
 #pueue-lib = { path = "../pueue-lib" }
 
 anyhow = "1"

--- a/client/display/colors.rs
+++ b/client/display/colors.rs
@@ -1,0 +1,53 @@
+use crossterm::style::Color;
+use pueue_lib::settings::Settings;
+
+/// Color wrapper for actual colors depending on settings
+/// Using dark colors if dark_mode is enabled
+pub struct Colors {
+    /// red color
+    red: Color,
+    /// green color
+    green: Color,
+    /// white color
+    white: Color,
+    /// yellow color
+    yellow: Color,
+}
+
+impl Colors {
+    /// init color-scheme depending on settings
+    pub const fn new(settings: &Settings) -> Self {
+        if settings.client.dark_mode {
+            Self {
+                green: Color::DarkGreen,
+                red: Color::DarkRed,
+                yellow: Color::DarkYellow,
+                white: Color::White,
+            }
+        } else {
+            Self {
+                green: Color::Green,
+                red: Color::Red,
+                yellow: Color::Yellow,
+                white: Color::White,
+            }
+        }
+    }
+
+    /// return green color
+    pub const fn green(&self) -> Color {
+        self.green
+    }
+    /// return red color
+    pub const fn red(&self) -> Color {
+        self.red
+    }
+    /// return yellow color
+    pub const fn yellow(&self) -> Color {
+        self.yellow
+    }
+    /// return white color
+    pub const fn white(&self) -> Color {
+        self.white
+    }
+}

--- a/client/display/group.rs
+++ b/client/display/group.rs
@@ -1,13 +1,13 @@
 use pueue_lib::network::message::GroupResponseMessage;
 
-use super::helper::*;
+use super::{colors::Colors, helper::*};
 
-pub fn print_groups(message: GroupResponseMessage) {
+pub fn print_groups(message: GroupResponseMessage, colors: &Colors) {
     let mut text = String::new();
     let mut group_iter = message.groups.iter().peekable();
     while let Some((name, status)) = group_iter.next() {
         let parallel = *message.settings.get(name).unwrap();
-        let styled = get_group_headline(name, &status, parallel);
+        let styled = get_group_headline(name, &status, parallel, colors);
 
         text.push_str(&styled);
         if group_iter.peek().is_some() {

--- a/client/display/helper.rs
+++ b/client/display/helper.rs
@@ -7,6 +7,8 @@ use crossterm::tty::IsTty;
 use pueue_lib::state::GroupStatus;
 use pueue_lib::task::Task;
 
+use super::colors::Colors;
+
 /// This is a simple small helper function with the purpose of easily styling text,
 /// while also prevent styling if we're printing to a non-tty output.
 /// If there's any kind of styling in the code, it should be done with the help of this function.
@@ -50,14 +52,19 @@ pub fn has_special_columns(tasks: &BTreeMap<usize, Task>) -> (bool, bool, bool) 
 }
 
 /// Return a nicely formatted headline that's displayed above group tables
-pub fn get_group_headline(name: &str, status: &GroupStatus, parallel: usize) -> String {
+pub fn get_group_headline(
+    name: &str,
+    status: &GroupStatus,
+    parallel: usize,
+    colors: &Colors,
+) -> String {
     // Style group name
     let name = style(format!("Group \"{}\"", name)).attribute(Attribute::Bold);
 
     // Print the current state of the group.
     let status = match status {
-        GroupStatus::Running => style_text("running", Some(Color::Green), None),
-        GroupStatus::Paused => style_text("paused", Some(Color::Yellow), None),
+        GroupStatus::Running => style_text("running", Some(colors.green()), None),
+        GroupStatus::Paused => style_text("paused", Some(colors.yellow()), None),
     };
 
     format!("{} ({} parallel): {}", name, parallel, status)

--- a/client/display/mod.rs
+++ b/client/display/mod.rs
@@ -1,12 +1,11 @@
-use comfy_table::Color;
-
+pub mod colors;
 mod follow;
 mod group;
 pub mod helper;
 mod log;
 mod state;
 
-use self::helper::style_text;
+use self::{colors::Colors, helper::style_text};
 
 // Re-exports
 pub use self::follow::follow_local_task_logs;
@@ -15,12 +14,12 @@ pub use self::log::print_logs;
 pub use self::state::print_state;
 
 /// Used to style any generic success message from the daemon.
-pub fn print_success(message: &str) {
+pub fn print_success(_colors: &Colors, message: &str) {
     println!("{}", message);
 }
 
 /// Used to style any generic failure message from the daemon.
-pub fn print_error(message: &str) {
-    let styled = style_text(message, Some(Color::Red), None);
+pub fn print_error(colors: &Colors, message: &str) {
+    let styled = style_text(message, Some(colors.red()), None);
     println!("{}", styled);
 }


### PR DESCRIPTION
This commit adds the ability to choose  dark colors instead of regular colors . It may
was  useful  for solarized-like themes (green seems weird). By default
the client is using dark_mode = false.

Closes #171
