### PR TITLE
Add --lines to follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - When calling `pueue` without a subcommand, the `status` command will be called by default [#247](https://github.com/Nukesor/pueue/issues/247).
 - Add the `--group` parameter to the `pueue clean` command [#248](https://github.com/Nukesor/pueue/issues/248)
 - Add `stdout_path` and `stderr_path` as template parameters for callbacks [#269](https://github.com/Nukesor/issues/269)
+- Add `--lines` parameter to `pueue follow` to only show specified number of lines from stdout before following [#270](https://github.com/Nukesor/pueue/issues/270)
 
 ### Changed
 

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -329,6 +329,10 @@ pub enum SubCommand {
         /// Show stderr instead of stdout.
         #[clap(short, long)]
         err: bool,
+
+        /// Only print the last X lines of the output before following
+        #[clap(short, long)]
+        lines: Option<usize>,
     },
 
     /// Wait until tasks are finished. This can be quite useful for scripting.

--- a/client/client.rs
+++ b/client/client.rs
@@ -215,7 +215,11 @@ impl Client {
                 Ok(true)
             }
 
-            SubCommand::Follow { task_id, err } => {
+            SubCommand::Follow {
+                task_id,
+                err,
+                lines,
+            } => {
                 // Simple log output follows for local logs don't need any communication with the daemon.
                 // Thereby we handle this separately over here.
                 if self.settings.client.read_local_logs {
@@ -224,6 +228,7 @@ impl Client {
                         &self.settings.shared.pueue_directory(),
                         task_id,
                         *err,
+                        *lines,
                     )
                     .await?;
                     return Ok(true);
@@ -499,10 +504,15 @@ impl Client {
                 };
                 Ok(Message::Log(message))
             }
-            SubCommand::Follow { task_id, err } => {
+            SubCommand::Follow {
+                task_id,
+                err,
+                lines,
+            } => {
                 let message = StreamRequestMessage {
                     task_id: *task_id,
                     err: *err,
+                    lines: *lines,
                 };
                 Ok(Message::StreamRequest(message))
             }

--- a/client/commands/local_follow.rs
+++ b/client/commands/local_follow.rs
@@ -12,6 +12,7 @@ pub async fn local_follow(
     pueue_directory: &Path,
     task_id: &Option<usize>,
     err: bool,
+    lines: Option<usize>,
 ) -> Result<()> {
     // The user can specify the id of the task they want to follow
     // If the id isn't specified and there's only a single running task, this task will be used.
@@ -46,7 +47,7 @@ pub async fn local_follow(
         }
     };
 
-    follow_local_task_logs(pueue_directory, task_id, err);
+    follow_local_task_logs(pueue_directory, task_id, err, lines);
 
     Ok(())
 }

--- a/daemon/network/follow_log.rs
+++ b/daemon/network/follow_log.rs
@@ -73,6 +73,14 @@ pub async fn handle_follow(
     let (out_path, err_path) = get_log_paths(task_id, pueue_directory);
     let handle_path = if message.err { err_path } else { out_path };
 
+    // If lines is passed as an option, seek the output file handle to the start of
+    // the line corresponding to the `lines` number of lines from the end of the file.
+    // The loop following this section will copy those lines to stdout
+    if let Some(lines) = message.lines {
+        if let Err(err) = seek_to_last_lines(&mut handle, lines) {
+            println!("Error seeking to last lines from log: {}", err);
+        }
+    }
     loop {
         // Check whether the file still exists. Exit if it doesn't.
         if !handle_path.exists() {

--- a/lib/src/network/message.rs
+++ b/lib/src/network/message.rs
@@ -209,6 +209,7 @@ pub enum Shutdown {
 pub struct StreamRequestMessage {
     pub task_id: Option<usize>,
     pub err: bool,
+    pub lines: Option<usize>,
 }
 
 /// Request logs for specific tasks.


### PR DESCRIPTION
This adds a `--lines` option to the follow command. I also added a more efficient implementation of read_last_lines to `pueue-lib` (compared to the simple one in there now). I branched off `pueue-lib` off of `0.18.1` because it was the quickest way for me to test it since I wasn't sure if you've made any breaking changes in the work towards the new version. I'll make a separate PR for `pueue-lib` for visibility (Nukesor/pueue-lib#18). If you're interested in merging these PR's, let me know the preferred method of getting it incorporated with respect to which branch to use as the base and how to coordinate `pueue` and `pueue-lib` changes. I also see you're working on a new version so maybe this should just target that release? Let me know