### PR TITLE
Better last lines logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
-- Improved memory footprint for reading partial remote logs.
+- Improved memory footprint for reading partial logs.
 - The configuration for groups can no longer be done via configuration file.
     This means, that groups can only be edited, created or deleted via the commandline interface.
 - **Breaking changes:** The amount of parallel tasks will be reset to `1` for all groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Improved memory footprint for reading partial remote logs.
 - The configuration for groups can no longer be done via configuration file.
     This means, that groups can only be edited, created or deleted via the commandline interface.
 - **Breaking changes:** The amount of parallel tasks will be reset to `1` for all groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Improved memory footprint for reading partial logs.
+- Always only show the last X lines of output when using `pueue log` without additional parameters.
 - The configuration for groups can no longer be done via configuration file.
     This means, that groups can only be edited, created or deleted via the commandline interface.
 - **Breaking changes:** The amount of parallel tasks will be reset to `1` for all groups.
 - **Breaking changes:** The `pueue group` command won't work, unless the daemon is restarted.
+
+### Fixed
+
+- `pueue log` now behaves the same for local and remote logs.
+     Remote logs previously showed more lines under some circumstances.
 
 ## [1.0.5] - 2022-01-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.8.4",
  "rcgen",
- "rev_lines",
+ "rev_buf_reader",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -1186,10 +1186,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "rev_lines"
-version = "0.2.1"
+name = "rev_buf_reader"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18eb52b6664d331053136fcac7e4883bdc6f5fc04a6aab3b0f75eafb80ab88b3"
+checksum = "5be7eaf8415a214da18dcf43c4db1c70394f68d77a0c6a20f33e95e7eba4f741"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ring"

--- a/client/client.rs
+++ b/client/client.rs
@@ -488,9 +488,9 @@ impl Client {
                 task_ids,
                 lines,
                 full,
-                json,
+                ..
             } => {
-                let lines = determine_log_line_amount(*full, lines, *json, task_ids.len());
+                let lines = determine_log_line_amount(*full, lines);
 
                 let message = LogRequestMessage {
                     task_ids: task_ids.clone(),

--- a/client/display/log/local.rs
+++ b/client/display/log/local.rs
@@ -3,7 +3,7 @@ use std::io::{self, Stdout};
 
 use comfy_table::*;
 
-use pueue_lib::log::{get_log_file_handles, read_last_lines};
+use pueue_lib::log::{get_log_file_handles, seek_to_last_lines};
 use pueue_lib::settings::Settings;
 
 use crate::display::{colors::Colors, helper::*};
@@ -48,8 +48,10 @@ fn print_local_file(stdout: &mut Stdout, file: &mut File, lines: &Option<usize>,
 
             // Only print the last lines if requested
             if let Some(lines) = lines {
-                println!("{}", read_last_lines(file, *lines));
-                return;
+                if let Err(err) = seek_to_last_lines(file, *lines) {
+                    println!("Failed reading local log file: {}", err);
+                    return;
+                }
             }
 
             // Print everything

--- a/client/display/log/mod.rs
+++ b/client/display/log/mod.rs
@@ -26,24 +26,14 @@ use remote::*;
 ///
 /// `full` always forces the full log output
 /// `lines` force a specific amount of lines
-pub fn determine_log_line_amount(
-    full: bool,
-    lines: &Option<usize>,
-    json: bool,
-    task_amount: usize,
-) -> Option<usize> {
+pub fn determine_log_line_amount(full: bool, lines: &Option<usize>) -> Option<usize> {
     if full {
         None
     } else if let Some(lines) = lines {
         Some(*lines)
     } else {
-        // By default, only some lines are shown per task, if multiple tasks exist or
-        // json ouput is requested.
-        if task_amount > 1 || json {
-            Some(15)
-        } else {
-            None
-        }
+        // By default, only some lines are shown per task
+        Some(15)
     }
 }
 
@@ -71,7 +61,7 @@ pub fn print_logs(
         ),
     };
 
-    let lines = determine_log_line_amount(full, &lines, json, task_logs.len());
+    let lines = determine_log_line_amount(full, &lines);
 
     // Return the server response in json representation.
     if json {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version="1", features=["macros", "net", "rt-multi-thread", "io-util"] 
 tokio-rustls = "0.23"
 rustls = "0.20"
 rustls-pemfile = "0.2"
-rev_lines = "0.2"
+rev_buf_reader = "0.2"
 rcgen = "0.8"
 byteorder = "1"
 snap = "1"

--- a/tests/fixtures/daemon.rs
+++ b/tests/fixtures/daemon.rs
@@ -70,7 +70,7 @@ async fn run_and_handle_error(pueue_dir: PathBuf, test: bool) -> Result<()> {
 }
 
 /// Spawn the daemon by calling the actual pueued binary.
-/// This function also checks for the pid file and the unix socket to pop-up.
+/// This function also checks for the pid file and the unix socket to appear.
 pub async fn standalone_daemon(pueue_dir: &Path) -> Result<Child> {
     let child = Command::cargo_bin("pueued")?
         .arg("--config")

--- a/tests/unix/log.rs
+++ b/tests/unix/log.rs
@@ -1,0 +1,155 @@
+use std::fs::read_to_string;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use pueue_lib::network::message::*;
+use snap::read::FrameDecoder;
+use tempfile::TempDir;
+
+use crate::fixtures::*;
+use crate::helper::*;
+
+/// This function creates files `[1-20]` in the specified directory.
+/// The return value is the expected output.
+///
+/// If `partial == true`, the expected output are only the last 5 lines.
+fn create_test_files(path: &Path, partial: bool) -> Result<String> {
+    // Convert numbers from 1 to 01, so they're correctly ordered when using `ls`.
+    let names: Vec<String> = (0..20)
+        .map(|number| {
+            if number < 10 {
+                let mut name = "0".to_string();
+                name.push_str(&number.to_string());
+                name
+            } else {
+                number.to_string()
+            }
+        })
+        .collect();
+
+    for name in &names {
+        File::create(path.join(name.to_string()))?;
+    }
+
+    // Only return the last 5 lines if partial output is requested.
+    if partial {
+        return Ok((15..20).fold(String::new(), |mut full, name| {
+            full.push_str(&name.to_string());
+            full.push('\n');
+            full
+        }));
+    }
+
+    // Create the full expected output.
+    let mut expected_output = names.join("\n");
+    expected_output.push('\n');
+    Ok(expected_output)
+}
+
+// Log output is send in a compressed form from the daemon.
+// We have to unpack it first.
+fn decompress_log(bytes: Vec<u8>) -> Result<String> {
+    let mut decoder = FrameDecoder::new(&bytes[..]);
+    let mut stdout = String::new();
+    decoder
+        .read_to_string(&mut stdout)
+        .context("Failed to decompress remote log output")?;
+
+    Ok(stdout)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// Make sure that receiving partial output from the daemon works.
+async fn test_full_log() -> Result<()> {
+    let daemon = daemon().await?;
+    let shared = &daemon.settings.shared;
+
+    // Create a temporary directory and put some files into it.
+    let tempdir = TempDir::new().unwrap();
+    let tempdir_path = tempdir.path();
+    let expected_output =
+        create_test_files(tempdir_path, false).context("Failed to create test files.")?;
+
+    // Add a task that lists those files and wait for it to finish.
+    let command = format!("ls {:?}", tempdir_path);
+    assert_success(add_task(shared, &command, false).await?);
+    wait_for_task_condition(shared, 0, |task| task.is_done()).await?;
+
+    // Request all log lines
+    let log_message = LogRequestMessage {
+        task_ids: vec![0],
+        send_logs: true,
+        lines: None,
+    };
+    let response = send_message(shared, Message::Log(log_message)).await?;
+    let logs = match response {
+        Message::LogResponse(logs) => logs,
+        _ => bail!("Received non LogResponse: {:#?}", response),
+    };
+
+    // Get the received stdout output
+    let logs = logs.get(&0).unwrap();
+    let stdout = logs
+        .stdout
+        .clone()
+        .context("Didn't find stdout on log output")?;
+    let stdout = decompress_log(stdout)?;
+
+    // Make sure it's the same
+    assert_eq!(stdout, expected_output);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// Make sure that receiving partial output from the daemon works.
+async fn test_partial_log() -> Result<()> {
+    let daemon = daemon().await?;
+    let shared = &daemon.settings.shared;
+
+    // Create a temporary directory and put some files into it.
+    let tempdir = TempDir::new().unwrap();
+    let tempdir_path = tempdir.path();
+    let expected_output =
+        create_test_files(tempdir_path, true).context("Failed to create test files.")?;
+
+    // Add a task that lists those files and wait for it to finish.
+    let command = format!("ls {:?}", tempdir_path);
+    assert_success(add_task(shared, &command, false).await?);
+    wait_for_task_condition(shared, 0, |task| task.is_done()).await?;
+
+    // Debug output to see what the file actually looks like:
+    let real_log_path = shared
+        .pueue_directory()
+        .join("task_logs")
+        .join("0_stdout.log");
+    let content = read_to_string(real_log_path).context("Failed to read actual file")?;
+    println!("Actual log file contents: \n{}", content);
+
+    // Request a partial log for task 0
+    let log_message = LogRequestMessage {
+        task_ids: vec![0],
+        send_logs: true,
+        lines: Some(5),
+    };
+    let response = send_message(shared, Message::Log(log_message)).await?;
+    let logs = match response {
+        Message::LogResponse(logs) => logs,
+        _ => bail!("Received non LogResponse: {:#?}", response),
+    };
+
+    // Get the received stdout output
+    let logs = logs.get(&0).unwrap();
+    let stdout = logs
+        .stdout
+        .clone()
+        .context("Didn't find stdout on log output")?;
+    let stdout = decompress_log(stdout)?;
+
+    // Make sure it's the same
+    assert_eq!(stdout, expected_output);
+
+    Ok(())
+}

--- a/tests/unix/mod.rs
+++ b/tests/unix/mod.rs
@@ -3,6 +3,7 @@ mod clean;
 mod edit;
 mod group;
 mod kill;
+mod log;
 mod parallel_tasks;
 mod pause;
 mod remove;


### PR DESCRIPTION
Fixes several issues with the remote and local log implementation.
This reduces the memory footprint on partial log reads, and streamlines the behavior of remote and local log reads.

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.

