### PR TITLE
Preliminary filter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Recover tasks from `Locked` state if editing fails [#267](https://github.com/Nukesor/pueue/issues/267)
 - `pueue log` now behaves the same for local and remote logs.
      Remote logs previously showed more lines under some circumstances.
+- panic due to rogue `.unwrap()` when filtering for a non-existing group in `pueue status`.
 
 ## [1.0.5] - 2022-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `XDG_DATA_HOME` is used if the `pueue_directory` config isn't explicitly set [#243](https://github.com/Nukesor/pueue/issues/243).
 - `XDG_RUNTIME_DIR` is used if the new `runtime_directory` config isn't explicitly set [#243](https://github.com/Nukesor/pueue/issues/243).
 - The unix socket is now located in the `runtime_directory` by default [#243](https://github.com/Nukesor/pueue/issues/243).
+- The `format-status` subcommand [#213](https://github.com/Nukesor/pueue/issues/213).
+    This is a preliminary feature, which allows users to use external tools, such as `jq`, to filter Pueue's `state -j` output and pipe them back into `format-status` to display it.
+    This feature will probably be removed once a proper internal filter logic has been added. \
+    The simplest usage looks like this: `pueue status -j | pueue format-status
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The `format-status` subcommand [#213](https://github.com/Nukesor/pueue/issues/213).
     This is a preliminary feature, which allows users to use external tools, such as `jq`, to filter Pueue's `state -j` output and pipe them back into `format-status` to display it.
     This feature will probably be removed once a proper internal filter logic has been added. \
-    The simplest usage looks like this: `pueue status -j | pueue format-status
+    The simplest usage looks like this: `pueue status --json | jq -c '.tasks' | pueue format-status`
 
 ### Changed
 

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -282,7 +282,7 @@ pub enum SubCommand {
         group: Option<String>,
     },
 
-    /// Accept a map of JSON pueue tasks via stdin and display it just like "status".
+    /// Accept a list or map of JSON pueue tasks via stdin and display it just like "status".
     /// A simple example might look like this:
     /// pueue status --json | jq -c '.tasks' | pueue format-status
     #[clap(after_help = "DISCLAIMER:

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -282,10 +282,9 @@ pub enum SubCommand {
         group: Option<String>,
     },
 
-    /// Accept a JSON pueue state via stdin and display it.
-    /// The state will then be displayed as usual.
-    /// The most simple example would look like this:
-    /// pueue status -j | pueue format-status
+    /// Accept a map of JSON pueue tasks via stdin and display it just like "status".
+    /// A simple example might look like this:
+    /// pueue status --json | jq -c '.tasks' | pueue format-status
     #[clap(after_help = "DISCLAIMER:
     This command is a temporary workaround until a proper filtering language for \"status\" has
     been implemented. It might be removed in the future.")]

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -282,6 +282,19 @@ pub enum SubCommand {
         group: Option<String>,
     },
 
+    /// Accept a JSON pueue state via stdin and display it.
+    /// The state will then be displayed as usual.
+    /// The most simple example would look like this:
+    /// pueue status -j | pueue format-status
+    #[clap(after_help = "DISCLAIMER:
+    This command is a temporary workaround until a proper filtering language for \"status\" has
+    been implemented. It might be removed in the future.")]
+    FormatStatus {
+        #[clap(short, long)]
+        /// Only show tasks of a specific group
+        group: Option<String>,
+    },
+
     /// Display the log output of finished tasks.
     /// When looking at multiple logs, only the last few lines will be shown.
     /// If you want to "follow" the output of a task, please use the "follow" subcommand.

--- a/client/client.rs
+++ b/client/client.rs
@@ -14,11 +14,7 @@ use pueue_lib::settings::Settings;
 use pueue_lib::state::PUEUE_DEFAULT_GROUP;
 
 use crate::cli::{CliArguments, GroupCommand, SubCommand};
-use crate::commands::edit::edit;
-use crate::commands::get_state;
-use crate::commands::local_follow::local_follow;
-use crate::commands::restart::restart;
-use crate::commands::wait::wait;
+use crate::commands::*;
 use crate::display::*;
 
 /// This struct contains the base logic for the client.
@@ -213,7 +209,6 @@ impl Client {
                 .await?;
                 Ok(true)
             }
-
             SubCommand::Follow {
                 task_id,
                 err,
@@ -234,7 +229,10 @@ impl Client {
                 }
                 Ok(false)
             }
-
+            SubCommand::FormatStatus { group } => {
+                format_state(group, &self.colors, &self.settings).await?;
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
@@ -544,6 +542,7 @@ impl Client {
                 }
                 None => Ok(Message::Group(GroupMessage::List)),
             },
+            SubCommand::FormatStatus { .. } => bail!("FormatStatus has to be handled earlier"),
             SubCommand::Completions { .. } => bail!("Completions have to be handled earlier"),
             SubCommand::Restart { .. } => bail!("Restarts have to be handled earlier"),
             SubCommand::Edit { .. } => bail!("Edits have to be handled earlier"),

--- a/client/client.rs
+++ b/client/client.rs
@@ -229,8 +229,14 @@ impl Client {
                 }
                 Ok(false)
             }
-            SubCommand::FormatStatus { group } => {
-                format_state(group, &self.colors, &self.settings).await?;
+            SubCommand::FormatStatus { .. } => {
+                format_state(
+                    &mut self.stream,
+                    &self.subcommand,
+                    &self.colors,
+                    &self.settings,
+                )
+                .await?;
                 Ok(true)
             }
             _ => Ok(false),

--- a/client/commands/format_state.rs
+++ b/client/commands/format_state.rs
@@ -1,0 +1,39 @@
+use std::io::{self, prelude::*};
+
+use anyhow::{Context, Result};
+
+use pueue_lib::{settings::Settings, state::State};
+
+use crate::{
+    cli::SubCommand,
+    display::{colors::Colors, print_state},
+};
+
+/// This function tries to read a JSON serialized [State] from `stdin`.
+/// The JSON document will then get deserialized and displayed as usual.
+pub async fn format_state(
+    group: &Option<String>,
+    colors: &Colors,
+    settings: &Settings,
+) -> Result<()> {
+    let mut stdin = io::stdin();
+    let mut buffer = Vec::new();
+    stdin
+        .read_to_end(&mut buffer)
+        .context("Failed to read json from stdin.")?;
+
+    let json = String::from_utf8(buffer).context("Failed to convert stdin input to UTF8")?;
+    let state: State =
+        serde_json::from_str(&json).context("Failed to deserialize State from JSON input.")?;
+
+    print_state(
+        state,
+        &SubCommand::FormatStatus {
+            group: group.clone(),
+        },
+        colors,
+        settings,
+    );
+
+    Ok(())
+}

--- a/client/commands/format_state.rs
+++ b/client/commands/format_state.rs
@@ -12,7 +12,7 @@ use crate::{
     display::{colors::Colors, print_state},
 };
 
-/// This function tries to read a list of JSON serialized [Task]s from `stdin`.
+/// This function tries to read a map or list of JSON serialized [Task]s from `stdin`.
 /// The tasks will then get deserialized and displayed as a normal `status` command.
 /// The current group information is pulled from the daemon in a new `status` call.
 pub async fn format_state(
@@ -21,16 +21,27 @@ pub async fn format_state(
     colors: &Colors,
     settings: &Settings,
 ) -> Result<()> {
+    // Read the raw input to a buffer
     let mut stdin = io::stdin();
     let mut buffer = Vec::new();
     stdin
         .read_to_end(&mut buffer)
         .context("Failed to read json from stdin.")?;
 
-    // Get the
+    // Convert it to a valid utf8 stream. If this fails, it cannot be valid JSON.
     let json = String::from_utf8(buffer).context("Failed to convert stdin input to UTF8")?;
-    let tasks: BTreeMap<usize, Task> =
-        serde_json::from_str(&json).context("Failed to deserialize State from JSON input.")?;
+
+    // Try to deserialize the input as a map of tasks first.
+    // If this doesn't work, try a list of tasks.
+    let map_deserialize = serde_json::from_str::<BTreeMap<usize, Task>>(&json);
+    let tasks: BTreeMap<usize, Task> = match map_deserialize {
+        Ok(tasks) => tasks,
+        Err(_) => {
+            let task_list: Vec<Task> =
+                serde_json::from_str(&json).context("Failed to deserialize from JSON input.")?;
+            task_list.into_iter().map(|task| (task.id, task)).collect()
+        }
+    };
 
     let mut state = super::get_state(stream)
         .await

--- a/client/commands/format_state.rs
+++ b/client/commands/format_state.rs
@@ -1,18 +1,23 @@
-use std::io::{self, prelude::*};
+use std::{
+    collections::BTreeMap,
+    io::{self, prelude::*},
+};
 
 use anyhow::{Context, Result};
 
-use pueue_lib::{settings::Settings, state::State};
+use pueue_lib::{network::protocol::GenericStream, settings::Settings, task::Task};
 
 use crate::{
     cli::SubCommand,
     display::{colors::Colors, print_state},
 };
 
-/// This function tries to read a JSON serialized [State] from `stdin`.
-/// The JSON document will then get deserialized and displayed as usual.
+/// This function tries to read a list of JSON serialized [Task]s from `stdin`.
+/// The tasks will then get deserialized and displayed as a normal `status` command.
+/// The current group information is pulled from the daemon in a new `status` call.
 pub async fn format_state(
-    group: &Option<String>,
+    stream: &mut GenericStream,
+    command: &SubCommand,
     colors: &Colors,
     settings: &Settings,
 ) -> Result<()> {
@@ -22,18 +27,18 @@ pub async fn format_state(
         .read_to_end(&mut buffer)
         .context("Failed to read json from stdin.")?;
 
+    // Get the
     let json = String::from_utf8(buffer).context("Failed to convert stdin input to UTF8")?;
-    let state: State =
+    let tasks: BTreeMap<usize, Task> =
         serde_json::from_str(&json).context("Failed to deserialize State from JSON input.")?;
 
-    print_state(
-        state,
-        &SubCommand::FormatStatus {
-            group: group.clone(),
-        },
-        colors,
-        settings,
-    );
+    let mut state = super::get_state(stream)
+        .await
+        .context("Failed to get the current state from daemon")?;
+
+    state.tasks = tasks;
+
+    print_state(state, command, colors, settings);
 
     Ok(())
 }

--- a/client/commands/mod.rs
+++ b/client/commands/mod.rs
@@ -4,10 +4,17 @@ use pueue_lib::network::message::Message;
 use pueue_lib::network::protocol::*;
 use pueue_lib::state::State;
 
-pub mod edit;
-pub mod local_follow;
-pub mod restart;
-pub mod wait;
+mod edit;
+mod format_state;
+mod local_follow;
+mod restart;
+mod wait;
+
+pub use edit::edit;
+pub use format_state::format_state;
+pub use local_follow::local_follow;
+pub use restart::restart;
+pub use wait::wait;
 
 // This is a helper function for easy retrieval of the current daemon state.
 // The current daemon state is often needed in more complex commands.

--- a/client/display/helper.rs
+++ b/client/display/helper.rs
@@ -75,18 +75,18 @@ pub fn get_group_headline(name: &str, group: &Group, colors: &Colors) -> String 
 /// Sort given tasks by their groups
 /// This is needed to print a table for each group
 pub fn sort_tasks_by_group(
-    tasks: &BTreeMap<usize, Task>,
+    tasks: BTreeMap<usize, Task>,
 ) -> BTreeMap<String, BTreeMap<usize, Task>> {
     // We use a BTreeMap, since groups should be ordered alphabetically by their name
     let mut sorted_task_groups = BTreeMap::new();
-    for (id, task) in tasks.iter() {
+    for (id, task) in tasks.into_iter() {
         if !sorted_task_groups.contains_key(&task.group) {
             sorted_task_groups.insert(task.group.clone(), BTreeMap::new());
         }
         sorted_task_groups
             .get_mut(&task.group)
             .unwrap()
-            .insert(*id, task.clone());
+            .insert(id, task);
     }
 
     sorted_task_groups

--- a/client/display/state.rs
+++ b/client/display/state.rs
@@ -26,24 +26,18 @@ pub fn print_state(state: State, cli_command: &SubCommand, colors: &Colors, sett
         return;
     }
 
-    // Sort all tasks by their respective group;
-    let sorted_tasks = sort_tasks_by_group(&state.tasks);
-
     if let Some(group) = group_only {
-        print_single_group(state, settings, colors, sorted_tasks, group);
+        print_single_group(state, settings, colors, group);
         return;
     }
 
-    print_all_groups(state, settings, colors, sorted_tasks);
+    print_all_groups(state, settings, colors);
 }
 
-fn print_single_group(
-    state: State,
-    settings: &Settings,
-    colors: &Colors,
-    mut sorted_tasks: BTreeMap<String, BTreeMap<usize, Task>>,
-    group_name: String,
-) {
+fn print_single_group(state: State, settings: &Settings, colors: &Colors, group_name: String) {
+    // Sort all tasks by their respective group;
+    let mut sorted_tasks = sort_tasks_by_group(state.tasks);
+
     let group = if let Some(group) = state.groups.get(&group_name) {
         group
     } else {
@@ -64,12 +58,7 @@ fn print_single_group(
     print_table(tasks, colors, settings);
 }
 
-fn print_all_groups(
-    state: State,
-    settings: &Settings,
-    colors: &Colors,
-    sorted_tasks: BTreeMap<String, BTreeMap<usize, Task>>,
-) {
+fn print_all_groups(state: State, settings: &Settings, colors: &Colors) {
     // Early exit and hint if there are no tasks in the queue
     // Print the state of the default group anyway, since this is information one wants to
     // see most of the time anyway.
@@ -83,6 +72,9 @@ fn print_all_groups(
         println!("Task list is empty. Add tasks with `pueue add -- [cmd]`");
         return;
     }
+
+    // Sort all tasks by their respective group;
+    let sorted_tasks = sort_tasks_by_group(state.tasks);
 
     // Always print the default queue at the very top, if no specific group is requested.
     if sorted_tasks.get(PUEUE_DEFAULT_GROUP).is_some() {


### PR DESCRIPTION
related to #213

This PR implements the `format-status` subcommand, which takes a state json string from `stdin` and displays it just like `status`

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.