### PR TITLE
Group subcommand ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Improved memory footprint for reading partial logs.
 - Always only show the last X lines of output when using `pueue log` without additional parameters.
+- **Breaking changes:** The `group` subcommand now has `group add [-p $count] $name` and `group remove $name` subcommands.
+    The old `group [-a,-p,-r]` flags have been removed.
 - **Breaking changes:** The configuration for groups can no longer be done via configuration file.
     This means, that groups can only be edited, created or deleted via the commandline interface.
     The amount of parallel tasks will also be reset to `1` when upgrading.

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -265,18 +265,8 @@ pub enum SubCommand {
     /// Use this to add or remove groups.
     /// By default, this will simply display all known groups.
     Group {
-        /// Add a group by name.
-        #[clap(short, long, conflicts_with = "remove")]
-        add: Option<String>,
-
-        /// Set the amount of parallel tasks this group can do
-        #[clap(short, long, validator = min_one, conflicts_with = "remove")]
-        parallel: Option<usize>,
-
-        /// Remove a group by name.
-        /// This will move all tasks in this group to the default group!
-        #[clap(short, long)]
-        remove: Option<String>,
+        #[clap(subcommand)]
+        cmd: Option<GroupCommand>,
     },
 
     /// Display the current status of all tasks.
@@ -403,6 +393,22 @@ pub enum SubCommand {
         /// The output directory to which the file should be written.
         output_directory: PathBuf,
     },
+}
+
+#[derive(Parser, Debug)]
+pub enum GroupCommand {
+    /// Add a group by name.
+    Add {
+        name: String,
+
+        /// Set the amount of parallel tasks this group can have.
+        #[clap(short, long, validator = min_one, conflicts_with = "remove")]
+        parallel: Option<usize>,
+    },
+
+    /// Remove a group by name.
+    /// This will move all tasks in this group to the default group!
+    Remove { name: String },
 }
 
 #[derive(Parser, ArgEnum, Debug, Clone, PartialEq)]

--- a/client/client.rs
+++ b/client/client.rs
@@ -13,7 +13,7 @@ use pueue_lib::network::secret::read_shared_secret;
 use pueue_lib::settings::Settings;
 use pueue_lib::state::PUEUE_DEFAULT_GROUP;
 
-use crate::cli::{CliArguments, SubCommand};
+use crate::cli::{CliArguments, GroupCommand, SubCommand};
 use crate::commands::edit::edit;
 use crate::commands::get_state;
 use crate::commands::local_follow::local_follow;
@@ -468,22 +468,18 @@ impl Client {
                 };
                 Ok(Message::Send(message))
             }
-            SubCommand::Group {
-                add,
-                parallel,
-                remove,
-            } => {
-                if let Some(group) = add {
+            SubCommand::Group { cmd } => match cmd {
+                Some(GroupCommand::Add { name, parallel }) => {
                     Ok(Message::Group(GroupMessage::Add {
-                        name: group.to_owned(),
+                        name: name.to_owned(),
                         parallel_tasks: parallel.to_owned(),
                     }))
-                } else if let Some(group) = remove {
-                    Ok(Message::Group(GroupMessage::Remove(group.to_owned())))
-                } else {
-                    Ok(Message::Group(GroupMessage::List))
                 }
-            }
+                Some(GroupCommand::Remove { name }) => {
+                    Ok(Message::Group(GroupMessage::Remove(name.to_owned())))
+                }
+                None => Ok(Message::Group(GroupMessage::List)),
+            },
             SubCommand::Status { .. } => Ok(Message::Status),
             SubCommand::Log {
                 task_ids,


### PR DESCRIPTION
Improves ergonomics for the `pueue group` subcommand

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.