### PR TITLE
A few clippy fixes on Windows

### DIFF
--- a/daemon/platform/windows/process_helper.rs
+++ b/daemon/platform/windows/process_helper.rs
@@ -239,8 +239,10 @@ pub fn process_exists(pid: u32) -> bool {
     unsafe {
         let handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
 
-        let mut process_entry = PROCESSENTRY32::default();
-        process_entry.dwSize = std::mem::size_of::<PROCESSENTRY32>() as u32;
+        let mut process_entry = PROCESSENTRY32 {
+            dwSize: std::mem::size_of::<PROCESSENTRY32>() as u32,
+            ..Default::default()
+        };
 
         loop {
             if process_entry.th32ProcessID == pid {

--- a/lib/src/network/platform/windows/socket.rs
+++ b/lib/src/network/platform/windows/socket.rs
@@ -62,7 +62,7 @@ pub async fn get_client_stream(settings: &Shared) -> Result<GenericStream, Error
     })?;
 
     // Get the configured rustls TlsConnector
-    let tls_connector = get_tls_connector(&settings)
+    let tls_connector = get_tls_connector(settings)
         .await
         .map_err(|err| Error::Connection(format!("Failed to initialize tls connector {err}.")))?;
 
@@ -84,7 +84,7 @@ pub async fn get_listener(settings: &Shared) -> Result<GenericListener, Error> {
     })?;
 
     // This is the TLS acceptor, which initializes the TLS layer
-    let tls_acceptor = get_tls_listener(&settings)?;
+    let tls_acceptor = get_tls_listener(settings)?;
 
     // Create a struct, which accepts connections and initializes a TLS layer in one go.
     let tls_listener = TlsTcpListener {


### PR DESCRIPTION
This just fixes up clippy warnings on Windows that I noticed when working on another PR. They don't seem essential, but useful to just clear the warnings. 
