### PR TITLE
Use a single file for task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Allow to set the amount of parallel tasks at group creation by [Spyros Roum](https://github.com/SpyrosRoum) [#245](https://github.com/Nukesor/pueue/issues/249).
 - When calling `pueue` without a subcommand, the `status` command will be called by default [#247](https://github.com/Nukesor/pueue/issues/247).
 - Add the `--group` parameter to the `pueue clean` command [#248](https://github.com/Nukesor/pueue/issues/248).
-- Add `stdout_path` and `stderr_path` as template parameters for callbacks [#269](https://github.com/Nukesor/issues/269).
+- Add `output` for a task's log output as template parameters for callbacks [#269](https://github.com/Nukesor/issues/269).
 - Add `--lines` parameter to `pueue follow` to only show specified number of lines from stdout before following [#270](https://github.com/Nukesor/pueue/issues/270).
 - Notify the user if a task is added to a paused group [#265](https://github.com/Nukesor/pueue/issues/265).
 - Notify the user that when killing whole groups, those groups are also paused [#265](https://github.com/Nukesor/pueue/issues/265).
@@ -33,6 +33,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improved memory footprint for reading partial logs.
 - Always only show the last X lines of output when using `pueue log` without additional parameters.
 - `pueue parallel` without arguments now also shows the groups with their current limit like `pueue group`. (#264)[https://github.com/Nukesor/pueue/issues/264]
+- **Breaking changes:** `stderr` and `stdout` of Pueue's tasks are now combined into a single file.
+    This means a few things.
+    * One doesn't have to filter for stderr any longer.
+    * All logs are now combined in a single chronologically correct log file.
+    * One **can no longer** filter for stderr/stdout specific output.
 - **Breaking changes:** The `group` subcommand now has `group add [-p $count] $name` and `group remove $name` subcommands.
     The old `group [-a,-p,-r]` flags have been removed.
 - **Breaking changes:** The configuration for groups can no longer be done via configuration file.

--- a/client/cli.rs
+++ b/client/cli.rs
@@ -272,7 +272,7 @@ pub enum SubCommand {
     /// Display the current status of all tasks.
     Status {
         /// Print the current state as json to stdout.
-        /// This does not include stdout/stderr of tasks.
+        /// This does not include the output of tasks.
         /// Use `log -j` if you want everything.
         #[clap(short, long)]
         json: bool,
@@ -302,7 +302,7 @@ pub enum SubCommand {
         task_ids: Vec<usize>,
 
         /// Print the resulting tasks and output as json.
-        /// By default only the last stdout/-err lines will be returned unless --full is provided.
+        /// By default only the last lines will be returned unless --full is provided.
         /// Take care, as the json cannot be streamed!
         /// If your logs are really huge, using --full can use all of your machine's RAM.
         #[clap(short, long)]
@@ -313,7 +313,7 @@ pub enum SubCommand {
         #[clap(short, long, conflicts_with = "full")]
         lines: Option<usize>,
 
-        /// Show the whole stdout and stderr output.
+        /// Show the whole output.
         /// This is the default if only a single task is being looked at.
         #[clap(short, long)]
         full: bool,
@@ -327,10 +327,6 @@ pub enum SubCommand {
         /// If no or multiple tasks are running, you have to specify the id.
         /// If only a single task is running, you can omit the id.
         task_id: Option<usize>,
-
-        /// Show stderr instead of stdout.
-        #[clap(short, long)]
-        err: bool,
 
         /// Only print the last X lines of the output before following
         #[clap(short, long)]

--- a/client/client.rs
+++ b/client/client.rs
@@ -209,11 +209,7 @@ impl Client {
                 .await?;
                 Ok(true)
             }
-            SubCommand::Follow {
-                task_id,
-                err,
-                lines,
-            } => {
+            SubCommand::Follow { task_id, lines } => {
                 // Simple log output follows for local logs don't need any communication with the daemon.
                 // Thereby we handle this separately over here.
                 if self.settings.client.read_local_logs {
@@ -221,7 +217,6 @@ impl Client {
                         &mut self.stream,
                         &self.settings.shared.pueue_directory(),
                         task_id,
-                        *err,
                         *lines,
                     )
                     .await?;
@@ -500,14 +495,9 @@ impl Client {
                 };
                 Ok(Message::Log(message))
             }
-            SubCommand::Follow {
-                task_id,
-                err,
-                lines,
-            } => {
+            SubCommand::Follow { task_id, lines } => {
                 let message = StreamRequestMessage {
                     task_id: *task_id,
-                    err: *err,
                     lines: *lines,
                 };
                 Ok(Message::StreamRequest(message))

--- a/client/commands/local_follow.rs
+++ b/client/commands/local_follow.rs
@@ -11,7 +11,6 @@ pub async fn local_follow(
     stream: &mut GenericStream,
     pueue_directory: &Path,
     task_id: &Option<usize>,
-    err: bool,
     lines: Option<usize>,
 ) -> Result<()> {
     // The user can specify the id of the task they want to follow
@@ -46,7 +45,7 @@ pub async fn local_follow(
         }
     };
 
-    follow_local_task_logs(pueue_directory, task_id, err, lines);
+    follow_local_task_logs(pueue_directory, task_id, lines);
 
     Ok(())
 }

--- a/client/display/log/json.rs
+++ b/client/display/log/json.rs
@@ -4,7 +4,7 @@ use std::io::Read;
 use serde_derive::{Deserialize, Serialize};
 use snap::read::FrameDecoder;
 
-use pueue_lib::log::{get_log_file_handles, read_last_lines};
+use pueue_lib::log::{get_log_file_handle, read_last_lines};
 use pueue_lib::network::message::TaskLogMessage;
 use pueue_lib::settings::Settings;
 use pueue_lib::task::Task;
@@ -13,8 +13,7 @@ use pueue_lib::task::Task;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskLog {
     pub task: Task,
-    pub stdout: String,
-    pub stderr: String,
+    pub output: String,
 }
 
 pub fn print_log_json(
@@ -23,7 +22,7 @@ pub fn print_log_json(
     lines: Option<usize>,
 ) {
     let mut tasks: BTreeMap<usize, Task> = BTreeMap::new();
-    let mut task_log: BTreeMap<usize, (String, String)> = BTreeMap::new();
+    let mut task_log: BTreeMap<usize, String> = BTreeMap::new();
     // Convert the TaskLogMessage into a proper JSON serializable format.
     // Output in TaskLogMessages, if it exists, is compressed.
     // We need to decompress and convert to normal strings.
@@ -31,10 +30,10 @@ pub fn print_log_json(
         tasks.insert(id, message.task);
 
         if settings.client.read_local_logs {
-            let output = get_local_logs(settings, id, lines);
+            let output = get_local_log(settings, id, lines);
             task_log.insert(id, output);
         } else {
-            let output = get_remote_logs(message.stdout, message.stderr);
+            let output = get_remote_log(message.output);
             task_log.insert(id, output);
         }
     }
@@ -42,96 +41,55 @@ pub fn print_log_json(
     // Now assemble the final struct that will be returned
     let mut json = BTreeMap::new();
     for (id, mut task) in tasks {
-        let (id, (stdout, stderr)) = task_log.remove_entry(&id).unwrap();
+        let (id, output) = task_log.remove_entry(&id).unwrap();
 
         task.envs = HashMap::new();
-        json.insert(
-            id,
-            TaskLog {
-                task,
-                stdout,
-                stderr,
-            },
-        );
+        json.insert(id, TaskLog { task, output });
     }
 
     println!("{}", serde_json::to_string(&json).unwrap());
 }
 
 /// Read logs directly from local files for a specific task.
-fn get_local_logs(settings: &Settings, id: usize, lines: Option<usize>) -> (String, String) {
-    let (mut stdout_file, mut stderr_file) =
-        match get_log_file_handles(id, &settings.shared.pueue_directory()) {
-            Ok((stdout, stderr)) => (stdout, stderr),
-            Err(err) => {
-                return (
-                    String::new(),
-                    format!("(Pueue error) Failed to get log file handles: {err}"),
-                );
-            }
-        };
+fn get_local_log(settings: &Settings, id: usize, lines: Option<usize>) -> String {
+    let mut file = match get_log_file_handle(id, &settings.shared.pueue_directory()) {
+        Ok(file) => file,
+        Err(err) => {
+            return format!("(Pueue error) Failed to get log file handle: {err}");
+        }
+    };
 
-    let stdout = if let Some(lines) = lines {
-        read_last_lines(&mut stdout_file, lines)
+    let output = if let Some(lines) = lines {
+        read_last_lines(&mut file, lines)
     } else {
-        let mut stdout = String::new();
-        if let Err(error) = stdout_file.read_to_string(&mut stdout) {
-            stdout.push_str(&format!(
+        let mut output = String::new();
+        if let Err(error) = file.read_to_string(&mut output) {
+            output.push_str(&format!(
                 "(Pueue error) Failed to read local log output file: {error:?}"
             ))
         };
 
-        stdout
+        output
     };
 
-    let stderr = if let Some(lines) = lines {
-        read_last_lines(&mut stderr_file, lines)
-    } else {
-        let mut stderr = String::new();
-        if let Err(error) = stderr_file.read_to_string(&mut stderr) {
-            stderr.push_str(&format!(
-                "(Pueue error) Failed to read local log output file: {error:?}"
-            ))
-        };
-
-        stderr
-    };
-
-    (stdout, stderr)
+    output
 }
 
 /// Read logs from from compressed remote logs.
 /// If logs don't exist, an empty string will be returned.
-fn get_remote_logs(
-    stdout_bytes: Option<Vec<u8>>,
-    stderr_bytes: Option<Vec<u8>>,
-) -> (String, String) {
-    let stdout = if let Some(bytes) = stdout_bytes {
+fn get_remote_log(output_bytes: Option<Vec<u8>>) -> String {
+    let output = if let Some(bytes) = output_bytes {
         let mut decoder = FrameDecoder::new(&bytes[..]);
-        let mut stdout = String::new();
-        if let Err(error) = decoder.read_to_string(&mut stdout) {
-            stdout.push_str(&format!(
+        let mut output = String::new();
+        if let Err(error) = decoder.read_to_string(&mut output) {
+            output.push_str(&format!(
                 "(Pueue error) Failed to decompress remote log output: {error:?}"
             ))
         }
-        stdout
+        output
     } else {
         String::new()
     };
 
-    let stderr = if let Some(bytes) = stderr_bytes {
-        let mut decoder = FrameDecoder::new(&bytes[..]);
-        let mut stderr = String::new();
-        if let Err(error) = decoder.read_to_string(&mut stderr) {
-            stderr.push_str(&format!(
-                "(Pueue error) Failed to decompress remote log output: {error:?}"
-            ))
-        }
-
-        stderr
-    } else {
-        String::new()
-    };
-
-    (stdout, stderr)
+    output
 }

--- a/client/display/log/local.rs
+++ b/client/display/log/local.rs
@@ -3,43 +3,34 @@ use std::io::{self, Stdout};
 
 use comfy_table::*;
 
-use pueue_lib::log::{get_log_file_handles, seek_to_last_lines};
+use pueue_lib::log::{get_log_file_handle, seek_to_last_lines};
 use pueue_lib::settings::Settings;
 
 use crate::display::{colors::Colors, helper::*};
 
 /// The daemon didn't send any log output, thereby we didn't request any.
-/// If that's the case, read the log files from the local pueue directory
+/// If that's the case, read the log file from the local pueue directory.
 pub fn print_local_log(task_id: usize, colors: &Colors, settings: &Settings, lines: Option<usize>) {
-    let (mut stdout_file, mut stderr_file) =
-        match get_log_file_handles(task_id, &settings.shared.pueue_directory()) {
-            Ok((stdout, stderr)) => (stdout, stderr),
-            Err(err) => {
-                println!("Failed to get log file handles: {err}");
-                return;
-            }
-        };
+    let mut file = match get_log_file_handle(task_id, &settings.shared.pueue_directory()) {
+        Ok(file) => file,
+        Err(err) => {
+            println!("Failed to get log file handle: {err}");
+            return;
+        }
+    };
     // Stdout handler to directly write log file output to io::stdout
     // without having to load anything into memory.
     let mut stdout = io::stdout();
 
     print_local_file(
         &mut stdout,
-        &mut stdout_file,
+        &mut file,
         &lines,
-        style_text("stdout:", Some(colors.green()), Some(Attribute::Bold)),
-    );
-
-    print_local_file(
-        &mut stdout,
-        &mut stderr_file,
-        &lines,
-        style_text("stderr:", Some(colors.red()), Some(Attribute::Bold)),
+        style_text("output:", Some(colors.green()), Some(Attribute::Bold)),
     );
 }
 
-/// Print a local log file.
-/// This is usually either the stdout or the stderr
+/// Print a local log file of a task.
 fn print_local_file(stdout: &mut Stdout, file: &mut File, lines: &Option<usize>, text: String) {
     if let Ok(metadata) = file.metadata() {
         if metadata.len() != 0 {

--- a/client/display/log/mod.rs
+++ b/client/display/log/mod.rs
@@ -17,7 +17,7 @@ use json::*;
 use local::*;
 use remote::*;
 
-/// Determine how many lines of stderr/out should be printed/returned.
+/// Determine how many lines of output should be printed/returned.
 /// `None` implicates that all lines are printed.
 ///
 /// By default, everything is returned for single tasks and only some lines for multiple.
@@ -120,7 +120,7 @@ fn print_log(
 
     if settings.client.read_local_logs {
         print_local_log(message.task.id, colors, settings, lines);
-    } else if message.stdout.is_some() && message.stderr.is_some() {
+    } else if message.output.is_some() {
         print_remote_log(message, colors);
     } else {
         println!("Logs requested from pueue daemon, but none received. Please report this bug.");

--- a/client/display/log/remote.rs
+++ b/client/display/log/remote.rs
@@ -9,35 +9,23 @@ use pueue_lib::network::message::TaskLogMessage;
 use crate::display::{colors::Colors, helper::*};
 
 /// Prints log output received from the daemon.
-/// We can safely call .unwrap() on stdout and stderr in here, since this
-/// branch is always called after ensuring that both are `Some`.
+/// We can safely call .unwrap() on output in here, since this
+/// branch is always called after ensuring that it is `Some`.
 pub fn print_remote_log(task_log: &TaskLogMessage, colors: &Colors) {
-    // Save whether stdout was printed, so we can add a newline between outputs.
-    if let Some(bytes) = task_log.stdout.as_ref() {
+    if let Some(bytes) = task_log.output.as_ref() {
         if !bytes.is_empty() {
-            let stdout_header = style_text("stdout: ", Some(colors.green()), Some(Attribute::Bold));
-            println!("\n{stdout_header}",);
+            let header = style_text("output: ", Some(colors.green()), Some(Attribute::Bold));
+            println!("\n{header}",);
 
             if let Err(err) = decompress_and_print_remote_log(bytes) {
                 println!("Error while parsing stdout: {err}");
             }
         }
     }
-
-    if let Some(bytes) = task_log.stderr.as_ref() {
-        if !bytes.is_empty() {
-            let stderr_header = style_text("stderr: ", Some(colors.red()), Some(Attribute::Bold));
-            println!("\n{stderr_header}");
-
-            if let Err(err) = decompress_and_print_remote_log(bytes) {
-                println!("Error while parsing stderr: {err}");
-            };
-        }
-    }
 }
 
 /// We cannot easily stream log output from the client to the daemon (yet).
-/// Right now, stdout and stderr are compressed in the daemon and sent as a single payload to the
+/// Right now, the output is compressed in the daemon and sent as a single payload to the
 /// client. In here, we take that payload, decompress it and stream it it directly to stdout.
 fn decompress_and_print_remote_log(bytes: &[u8]) -> Result<()> {
     let mut decompressor = FrameDecoder::new(bytes);

--- a/daemon/network/follow_log.rs
+++ b/daemon/network/follow_log.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
+use std::path::Path;
 use std::time::Duration;
-use std::{fs::File, path::Path};
 
 use anyhow::Result;
 
@@ -49,32 +49,23 @@ pub async fn handle_follow(
         }
     };
 
-    // The client requested streaming of stdout.
-    let mut handle: File;
-    match get_log_file_handles(task_id, pueue_directory) {
+    let mut handle = match get_log_file_handle(task_id, pueue_directory) {
         Err(_) => {
             return Ok(create_failure_message(
                 "Couldn't find output files for task. Maybe it finished? Try `log`",
             ))
         }
-        Ok((stdout_handle, stderr_handle)) => {
-            handle = if message.err {
-                stderr_handle
-            } else {
-                stdout_handle
-            };
-        }
-    }
+        Ok(handle) => handle,
+    };
 
-    // Get the stdout/stderr path.
+    // Get the output path.
     // We need to check continuously, whether the file still exists,
     // since the file can go away (e.g. due to finishing a task).
-    let (out_path, err_path) = get_log_paths(task_id, pueue_directory);
-    let handle_path = if message.err { err_path } else { out_path };
+    let path = get_log_path(task_id, pueue_directory);
 
     // If lines is passed as an option, seek the output file handle to the start of
     // the line corresponding to the `lines` number of lines from the end of the file.
-    // The loop following this section will copy those lines to stdout
+    // The loop following this section will copy those lines to stdout.
     if let Some(lines) = message.lines {
         if let Err(err) = seek_to_last_lines(&mut handle, lines) {
             println!("Error seeking to last lines from log: {err}");
@@ -82,7 +73,7 @@ pub async fn handle_follow(
     }
     loop {
         // Check whether the file still exists. Exit if it doesn't.
-        if !handle_path.exists() {
+        if !path.exists() {
             return Ok(create_success_message(
                 "File has gone away. Did somebody remove the task?",
             ));

--- a/daemon/network/message_handler/log.rs
+++ b/daemon/network/message_handler/log.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 
-use pueue_lib::log::read_and_compress_log_files;
+use pueue_lib::log::read_and_compress_log_file;
 use pueue_lib::network::message::*;
 use pueue_lib::state::SharedState;
 
 /// Invoked when calling `pueue log`.
-/// Return the current state and the stdou/stderr of all tasks to the client.
+/// Return tasks and their output to the client.
 pub fn get_log(message: LogRequestMessage, state: &SharedState) -> Message {
     let state = { state.lock().unwrap().clone() };
     // Return all logs, if no specific task id is specified.
@@ -21,13 +21,13 @@ pub fn get_log(message: LogRequestMessage, state: &SharedState) -> Message {
             // We send log output and the task at the same time.
             // This isn't as efficient as sending the raw compressed data directly,
             // but it's a lot more convenient for now.
-            let (stdout, stderr) = if message.send_logs {
-                match read_and_compress_log_files(
+            let output = if message.send_logs {
+                match read_and_compress_log_file(
                     *task_id,
                     &state.settings.shared.pueue_directory(),
                     message.lines,
                 ) {
-                    Ok((stdout, stderr)) => (Some(stdout), Some(stderr)),
+                    Ok(output) => (Some(output)),
                     Err(err) => {
                         // Fail early if there's some problem with getting the log output
                         return create_failure_message(format!(
@@ -36,13 +36,12 @@ pub fn get_log(message: LogRequestMessage, state: &SharedState) -> Message {
                     }
                 }
             } else {
-                (None, None)
+                None
             };
 
             let task_log = TaskLogMessage {
                 task: task.clone(),
-                stdout,
-                stderr,
+                output,
             };
             tasks.insert(*task_id, task_log);
         }

--- a/daemon/task_handler/callback.rs
+++ b/daemon/task_handler/callback.rs
@@ -72,21 +72,18 @@ impl TaskHandler {
         parameters.insert("end", print_time(task.end));
 
         // Read the last lines of the process' output and make it available.
-        if let Ok((stdout, stderr)) =
+        if let Ok(output) =
             read_last_log_file_lines(task.id, &self.pueue_directory, self.callback_log_lines)
         {
-            parameters.insert("stdout", stdout);
-            parameters.insert("stderr", stderr);
+            parameters.insert("output", output);
         } else {
-            parameters.insert("stdout", "".to_string());
-            parameters.insert("stderr", "".to_string());
+            parameters.insert("output", "".to_string());
         }
 
-        let (out_path, err_path) = get_log_paths(task.id, &self.pueue_directory);
+        let out_path = get_log_path(task.id, &self.pueue_directory);
         // Using Display impl of PathBuf which isn't necessarily a perfect
         // representation of the path but should work for most cases here
-        parameters.insert("stdout_path", out_path.display().to_string());
-        parameters.insert("stderr_path", err_path.display().to_string());
+        parameters.insert("output_path", out_path.display().to_string());
 
         // Get the exit code
         if let TaskStatus::Done(result) = &task.status {

--- a/daemon/task_handler/spawn_task.rs
+++ b/daemon/task_handler/spawn_task.rs
@@ -90,7 +90,7 @@ impl TaskHandler {
             }
         };
 
-        // Try to get the log files to which the output of the process will be written to.
+        // Try to get the log file to which the output of the process will be written to.
         // Panic if this doesn't work! This is unrecoverable.
         let (stdout_log, stderr_log) = match create_log_file_handles(task_id, &self.pueue_directory)
         {

--- a/lib/src/network/message.rs
+++ b/lib/src/network/message.rs
@@ -207,11 +207,9 @@ pub enum Shutdown {
     Graceful,
 }
 
-/// `err` decides, whether you should stream stderr or stdout.
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct StreamRequestMessage {
     pub task_id: Option<usize>,
-    pub err: bool,
     pub lines: Option<usize>,
 }
 
@@ -231,8 +229,7 @@ pub struct LogRequestMessage {
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct TaskLogMessage {
     pub task: Task,
-    pub stdout: Option<Vec<u8>>,
-    pub stderr: Option<Vec<u8>>,
+    pub output: Option<Vec<u8>>,
 }
 
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]

--- a/tests/fixtures/daemon.rs
+++ b/tests/fixtures/daemon.rs
@@ -78,6 +78,7 @@ pub async fn standalone_daemon(pueue_dir: &Path) -> Result<Child> {
         .arg(pueue_dir.join("pueue.yml").to_str().unwrap())
         .arg("-vvv")
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()?;
 
     let tries = 20;

--- a/tests/helper/env.rs
+++ b/tests/helper/env.rs
@@ -52,7 +52,7 @@ pub async fn assert_worker_envs(
         .get(&task_id)
         .expect("Log should contain requested task.");
 
-    let stdout = log.stdout.clone().unwrap();
+    let stdout = log.output.clone().unwrap();
     let output = String::from_utf8_lossy(&stdout);
     assert!(
         output.contains(&format!("WORKER_ID: {worker}")),


### PR DESCRIPTION
This PR is a prototype for a pretty large change of Pueue's internal working.

I've been thinking a lot about how Pueue's log handling should work in the first place.
Originally, I thought that it would be super handy to be able to filter log output by stdout/stderr.
However, by splitting stderr and stdout one loses all chronological context between those two.

This PR now merges both streams back together into a single file.
This makes using `log` and `follow` much easier to use and logs are now in correct chronological order, but one can no longer filter by `stdout` or `stderr`.

Since this project became quite big, I would like to get your opinion on this change.
What do you think about it? Just leave a thumbs-up if you're happy with this change and please leave a comment if you have any additions/doubts/thoughts about this.

Sorry for pinging all of you, but I would really like to get some feedback on this, since this is a huge breaking change.
@taylor1791 @KaindlJulian @Lej77 @sourcefrog @tinou98 @quebin31 @JP-Ellis @soruh @twillingham @Sh3Rm4n @dovahcrow @LovecraftianHorror @dadav @Mephistophiles @printfn @Cycatz 

I would love to get a single stream while still keeping the possibility to filter by stderr/stdout and maybe even time, but this turns out to be quite complicated and I won't be able to finish such a feature in the near future.
The tracking issue is #239.

As a result, I thought that it might be a good compromise to just merge the streams for now.
v2.0 has been in development since a few months now and a huge amount of changes has accrued.
The next implementation might then be added in a future v3.0 release.

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.