### PR TITLE
Don't inherit environment variables from daemon process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Commands no longer inherit environment variables from the daemon process
+
 ## [2.0.0] - 2022-02-18
 
 This release marks the second stable release of Pueue.

--- a/daemon/task_handler/spawn_task.rs
+++ b/daemon/task_handler/spawn_task.rs
@@ -124,6 +124,7 @@ impl TaskHandler {
         let spawned_command = command
             .current_dir(path)
             .stdin(Stdio::piped())
+            .env_clear()
             .envs(envs.clone())
             .stdout(Stdio::from(stdout_log))
             .stderr(Stdio::from(stderr_log))


### PR DESCRIPTION
Currently, the environment variables associated with a task are added to those of the daemon process on launch. Use `env_clear()` to start with a clean environment before adding the task environment variables

I wasn't sure if this should merge to `main` or `development`

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
