### PR TITLE
Fix config dir and PID path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Return the correct path from `pueue_lib::settings::configuration_directories()`,
+  when we get a path from `dirs::config_dir()` (was `/home/<user>/.config/pueue.yaml/`, is now again `/home/<user>/.config/pueue/`).
+- Use the correct path to delete the PID file during shutdown.
+
 ## [2.0.3] - 2022-06-04
 
 ### Fixed

--- a/daemon/task_handler/mod.rs
+++ b/daemon/task_handler/mod.rs
@@ -175,7 +175,7 @@ impl TaskHandler {
         }
 
         // Cleanup the pid file
-        if let Err(error) = cleanup_pid_file(&self.pueue_directory) {
+        if let Err(error) = cleanup_pid_file(&state.settings.shared.pid_path()) {
             println!("Failed to cleanup pid during shutdown.");
             println!("{error}");
         }

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -171,7 +171,7 @@ pub struct NestedSettings {
 /// If no config can be found, fallback to the current directory.
 pub fn configuration_directories() -> Vec<PathBuf> {
     if let Some(config_dir) = dirs::config_dir() {
-        vec![config_dir.join("pueue.yml"), PathBuf::from(".")]
+        vec![config_dir.join("pueue"), PathBuf::from(".")]
     } else {
         vec![PathBuf::from(".")]
     }


### PR DESCRIPTION
This MR removes the `.yml` suffix from the default configuration directory, reverting it to the expected `~/.config/pueue/` and also uses the proper path for PID file removal during shutdown. 

## Checklist

- [X] I picked the correct source and target branch.
- [X] I included a new entry to the `CHANGELOG.md`.
- [X] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
