### PR TITLE
Use style_text to style group header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+ ## Unreleased
+
+ ### Fixed
+
+ - Only style the 'group' header in status output when on a TTY.
 
 ## [2.0.4] - 2022-06-05
 

--- a/client/display/helper.rs
+++ b/client/display/helper.rs
@@ -59,7 +59,7 @@ pub fn has_special_columns(tasks: &[Task]) -> (bool, bool, bool) {
 /// Return a nicely formatted headline that's displayed above group tables
 pub fn get_group_headline(name: &str, group: &Group, colors: &Colors) -> String {
     // Style group name
-    let name = style(format!("Group \"{}\"", name)).attribute(Attribute::Bold);
+    let name = style_text(format!("Group \"{}\"", name), None, Some(Attribute::Bold));
 
     // Print the current state of the group.
     let status = match group.status {


### PR DESCRIPTION
This ensures that the bold styling is only applied when on a TTY.

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
