### PR TITLE
CI: make sure the target toolchain is available

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,6 +72,7 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+          target: ${{ matrix.target }}
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
           toolchain: stable
           override: true
           components: llvm-tools-preview
+          target: ${{ matrix.target }}
 
       - name: cargo build
         uses: actions-rs/cargo@v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,8 @@ ignore:
   - "CHANGELOG.md"
   - "LICENSE"
   - "README.md"
+  - ".github"
+  - ".gitignore"
 
 codecov:
   status:


### PR DESCRIPTION
For cross-compilation builds, the target toolchain needs to be installed (you
can't count on it being present in a GH build environment).

Making this change (adding the `target: ${{ matrix.target }}` line to the
`actions-rs/toolchain@v1` action), make my PR #320 [build properly for the iOS
cross-compilation target](https://github.com/Nukesor/pueue/actions/runs/2622867089) <sup>*)</sup>. Without it, you *may* get errors like:

```
error[E0463]: can't find crate for `core`
Error:   |
  = note: the `aarch64-apple-ios` target may not be installed
  = help: consider downloading the target with `rustup target add aarch64-apple-ios`
```

With the `target` line rustup makes sure to add any missing toolchains; e.g. the iOS *Setup Rust toolchain* step now includes:

```
/Users/runner/.cargo/bin/rustup target add --toolchain stable aarch64-apple-ios
info: downloading component 'rust-std' for 'aarch64-apple-ios'
info: installing component 'rust-std' for 'aarch64-apple-ios'
```

If you were lucky and got a build machine that already had the toolchain installed, the build would pass, I think.

Note: I omitted a changelog entry as this is purely a CI fix.

## Checklist

- [X] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.

----
<sup>*)</sup> The `aarch64-apple-ios` build was cancelled because of an unrelated issue with a pre-existing `clippy` warning, but the build got well past the point where otherwise it'd have failed.