### PR TITLE
CI: Add a cache for cargo to speed up actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
     name: Test on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         target:
             - x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
     name: Test on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         target:
             - x86_64-unknown-linux-gnu

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,18 @@ jobs:
           components: llvm-tools-preview
           target: ${{ matrix.target }}
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
The cache step here caches the cargo output as per the [recommended
settings](https://github.com/actions/cache/blob/main/examples.md#rust---cargo),
but with the cross-compilation target as part of the cache key, and a restore key
to take advantage of a partial cache should the cargo lock change only marginally.

## Checklist

- [X] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
