### PR TITLE
CI: Lint on all platforms and targets

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,9 +19,10 @@ on:
 
 
 jobs:
-  publish:
+  linting:
     name: Lint on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,32 +37,25 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            cross: false
-            strip: true
+            experimental: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-musl
-            cross: true
-            strip: false
+            experimental: false
           - os: ubuntu-latest
             target: armv7-unknown-linux-musleabihf
-            cross: true
-            strip: false
+            experimental: false
           - os: ubuntu-latest
             target: arm-unknown-linux-musleabihf
-            cross: true
-            strip: false
+            experimental: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            cross: false
-            strip: true
+            experimental: true
           - os: macos-latest
             target: x86_64-apple-darwin
-            cross: false
-            strip: true
+            experimental: false
           - os: macos-latest
             target: aarch64-apple-ios
-            cross: true
-            strip: true
+            experimental: false
 
     steps:
       - name: Checkout code
@@ -99,3 +93,4 @@ jobs:
         with:
           command: clippy
           args: --tests --workspace -- -D warnings
+        continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   publish:
-    name: Test on ${{ matrix.os }} for ${{ matrix.target }}
+    name: Lint on ${{ matrix.os }} for ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,14 +77,12 @@ jobs:
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         with:
           command: fmt
           args: --all -- --check
 
       - name: cargo clippy
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu' }}
         with:
           command: clippy
           args: --tests --workspace -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,19 @@ jobs:
           components: rustfmt, clippy
           target: ${{ matrix.target }}
 
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: lint-${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            lint-${{ runner.os }}-cargo-${{ matrix.target }}-
+            ${{ runner.os }}-cargo-${{ matrix.target }}-
+
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:

--- a/lib/tests/helper.rs
+++ b/lib/tests/helper.rs
@@ -3,7 +3,9 @@ use tempdir::TempDir;
 use portpicker::pick_unused_port;
 use pueue_lib::settings::*;
 
-pub fn get_shared_settings() -> (Shared, TempDir) {
+pub fn get_shared_settings(
+    #[cfg_attr(target_os = "windows", allow(unused_variables))] use_unix_socket: bool,
+) -> (Shared, TempDir) {
     // Create a temporary directory used for testing.
     let tempdir = TempDir::new("pueue_lib").unwrap();
     let tempdir_path = tempdir.path();
@@ -14,7 +16,7 @@ pub fn get_shared_settings() -> (Shared, TempDir) {
         pueue_directory: Some(tempdir_path.to_path_buf()),
         runtime_directory: Some(tempdir_path.to_path_buf()),
         #[cfg(not(target_os = "windows"))]
-        use_unix_socket: true,
+        use_unix_socket,
         #[cfg(not(target_os = "windows"))]
         unix_socket_path: None,
         pid_path: None,

--- a/lib/tests/tls_socket.rs
+++ b/lib/tests/tls_socket.rs
@@ -14,11 +14,7 @@ mod helper;
 /// This tests whether we can create a listener and client, that communicate via TLS sockets.
 async fn test_tls_socket() -> Result<()> {
     better_panic::install();
-    let (mut shared_settings, _tempdir) = helper::get_shared_settings();
-    #[cfg(not(target_os = "windows"))]
-    {
-        shared_settings.use_unix_socket = false;
-    }
+    let (shared_settings, _tempdir) = helper::get_shared_settings(false);
 
     // Create new stub tls certificates/keys in our temp directory
     create_certificates(&shared_settings).unwrap();

--- a/lib/tests/unix_socket.rs
+++ b/lib/tests/unix_socket.rs
@@ -17,7 +17,7 @@ mod tests {
     /// This tests whether we can create a listener and client, that communicate via unix sockets.
     async fn test_unix_socket() -> Result<()> {
         better_panic::install();
-        let (shared_settings, _tempdir) = helper::get_shared_settings();
+        let (shared_settings, _tempdir) = helper::get_shared_settings(true);
 
         let listener = get_listener(&shared_settings).await?;
         let message = create_success_message("This is a test");


### PR DESCRIPTION
Running clippy and fmt on all targets and platforms is fine, bar one issue with
Windows that I fixed.

Since clippy needs to compile a bunch, I've added a linting-specific cache to
speed up this step.

(this PR was recreated from #323, now from an actual branch in my fork. Mea
Culpa).

## Checklist

- [X] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
