### PR TITLE
fix: Flaky tests with parallel tasks

### DIFF
--- a/daemon/task_handler/mod.rs
+++ b/daemon/task_handler/mod.rs
@@ -114,6 +114,10 @@ impl TaskHandler {
     /// - Whether whe should perform a shutdown.
     /// - If the client requested a reset: reset the state if all children have been killed and handled.
     /// - Check whether we can spawn new tasks.
+    ///
+    /// This first step waits for 200ms while receiving new messages.
+    /// This prevents this loop from running hot, but also means that we only check if a new task
+    /// can be scheduled or if tasks are finished, every 200ms.
     pub fn run(&mut self) {
         loop {
             self.receive_messages();

--- a/tests/helper/env.rs
+++ b/tests/helper/env.rs
@@ -26,7 +26,7 @@ pub async fn assert_worker_envs(
     assert_eq!(
         task.envs.get("PUEUE_WORKER_ID"),
         Some(&worker.to_string()),
-        "Worker id hasn't been correctly for task {task_id}",
+        "Worker id hasn't been correctly set for task {task_id}",
     );
 
     // Get the log output for the task.


### PR DESCRIPTION
The duration of the tasks in the worker_environment_variables test suite was too low, resulting in occasional flakes.

This should now be fixed, by making the tasks live longer.

This MR is mainly here to run this on the CI environment, as this only happens on potato machines.
