### PR TITLE
Address flaky tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,7 @@
 # - Call out every test as it finishes, including slow, skipped and flaky tests
 # - List failures again at the end.
 # - Run all tests even if some failed.
+# - Output test results in JUnit format.
 [profile.ci]
 # "retries" defines the number of times a test should be retried. If set to a
 # non-zero value, tests that succeed on a subsequent attempt will be marked as
@@ -31,6 +32,12 @@ failure-output = "immediate-final"
 # Cancel the test run on the first failure. For CI runs, consider setting this
 # to false.
 fail-fast = false
+
+[profile.ci.junit]
+# Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
+# The default value for store.dir is 'target/nextest', so the following file
+# is written to the target/nextest/ci/ directory.
+path = "junit.xml"
 
 # profile used in GitHub coverage runs
 # - lower retry count as a compromise between speed and resilience

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,40 @@
+# See https://nexte.st/book/configuration.html for format and defaults
+# Profiles defined here inherit from profile.default
+
+# profile used in GitHub test runs
+# - Retry a few times to detect flaky tests
+# - Call out every test as it finishes, including slow, skipped and flaky tests
+# - List failures again at the end.
+# - Run all tests even if some failed.
+[profile.ci]
+# "retries" defines the number of times a test should be retried. If set to a
+# non-zero value, tests that succeed on a subsequent attempt will be marked as
+# non-flaky. Can be overridden through the `--retries` option.
+retries = 2
+
+# * none: no output
+# * fail: show failed (including exec-failed) tests
+# * retry: show flaky and retried tests
+# * slow: show slow tests
+# * pass: show passed tests
+# * skip: show skipped tests (most useful for CI)
+# * all: all of the above
+#
+# Each value includes all the values above it; for example, "slow" includes
+# failed and retried tests.
+status-level = "all"
+
+# * "immediate-final": output failures as soon as they happen and at the end of
+#   the test run; combination of "immediate" and "final"
+failure-output = "immediate-final"
+
+# Cancel the test run on the first failure. For CI runs, consider setting this
+# to false.
+fail-fast = false
+
+# profile used in GitHub coverage runs
+# - lower retry count as a compromise between speed and resilience
+# - no fail-fast to at least keep coverage percentages accurate.
+[profile.coverage]
+retries = 1
+fail-fast = false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,11 +48,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-
 
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-llvm-cov,nextest
 
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        env:
+          NEXTEST_PROFILE: coverage   # defined in .config/nextest.toml
+        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,4 +1,4 @@
-name: Test build
+name: 'Test Coverage'
 
 on:
   push:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,71 @@
+# This workflow makes it possible to publish test reports without running into
+# permission issues when the test workflow was run from a fork or by Dependabot.
+#
+# The test workflow uploads a junit file per matrix target as an artifact, plus
+# the worflow events file, both of which this worfklow buids upon. Note that
+# the events file artifact, specifically, is expected to be named 'Event File'.
+#
+# See the [Publish Test Results action documentation][ptr] for more information.
+#
+# [ptr]: https://github.com/marketplace/actions/publish-test-results#support-fork-repositories-and-dependabot-branches
+
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Test Build']
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # permission to comment on PRs
+      pull-requests: write
+
+      # permission to download artifacts
+      actions: read
+
+    steps:
+      - name: Download and extract artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+            # Unzip all artifacts created by the triggering workflow into
+            # directories under an `artifacts/` directory.
+            # 
+            # This uses `gh api` to output the name and URL for each artifact as
+            # tab-separated lines, then uses `read` to take each name and URL
+            # and download those to named zip files, and finally extracting those
+            # zip files into directories with matching names.
+
+            mkdir -p artifacts && cd artifacts
+
+            # The artifacts URL from the *triggering* test workflow, not *this*
+            # workflow.
+            artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+            gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+            do
+                IFS=$'\t' read name url <<< "$artifact"
+                gh api $url > "$name.zip"
+                unzip -d "$name" "$name.zip"
+            done
+
+      # Run the publisher. Note that it is given the 'Event File' artifact
+      # created by the test workflow so it has the *original* webhook payload
+      # to base its context on.
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          junit_files: "artifacts/**/*.xml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,9 @@ jobs:
           components: llvm-tools-preview
           target: ${{ matrix.target }}
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -97,7 +100,9 @@ jobs:
       - name: cargo test
         uses: actions-rs/cargo@v1
         if: ${{ !matrix.cross }}
+        env:
+          NEXTEST_PROFILE: ci   # defined in .config/nextest.toml
         with:
-          command: test
-          args:  --workspace --target=${{ matrix.target }}
+          command: nextest
+          args:  run --workspace --target=${{ matrix.target }}
           use-cross: ${{ matrix.cross }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test build
+name: 'Test Build'
 
 on:
   push:
@@ -106,3 +106,24 @@ jobs:
           command: nextest
           args:  run --workspace --target=${{ matrix.target }}
           use-cross: ${{ matrix.cross }}
+
+      # The test result artifacts are used by the test-report.yaml workflow.
+      - name: upload test results
+        uses: actions/upload-artifact@v3
+        if: ${{ !matrix.cross }}
+        with:
+          name: Test results (${{ matrix.target }})
+          path: target/nextest/ci/junit.xml
+
+  # the event file (containing the JSON payload for the webhook triggering this
+  # workflow) is needed to generate test result reports with the correct
+  # context. See the test-report.yaml workflow for details.
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Continuation of testing the `pueue` client, pushing the test coverage from ~70% to ~73%.
 - A codecov.yml syntax error was corrected, which prevented Codecov from applying the
   repository-specific configuration.
+- CI tests are now run using cargo nextest, for faster test execution, flaky test handling and better test output.
 
 ## [2.1.0] - 2022-07-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +429,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_logger"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +645,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -1054,6 +1082,7 @@ dependencies = [
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
+ "env_logger",
  "handlebars",
  "log",
  "nix 0.24.2",
@@ -1072,6 +1101,7 @@ dependencies = [
  "simplelog",
  "snap",
  "tempfile",
+ "test-log",
  "tokio",
  "whoami",
 ]
@@ -1222,10 +1252,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1633,6 +1680,17 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,13 @@ rstest = "0.15"
 serde_yaml = "0.9"
 similar-asserts = "1"
 
+# Make it easy to view log output for select tests.
+# Set log level for tests with RUST_LOG=<level>, use with failed tests or
+# disable test stdout/stderr capture (`cargo test -- --nocapture` / `cargo
+# nextest run --no-capture`)
+env_logger = "0.9.1"
+test-log = "0.2.11"
+
 # Test specific dev-dependencies
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 nix = "0.24"

--- a/tests/client/group.rs
+++ b/tests/client/group.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use pueue_lib::network::message::*;
+use pueue_lib::state::GroupStatus;
 
 use crate::fixtures::*;
 use crate::helper::*;
@@ -41,6 +42,8 @@ async fn colored() -> Result<()> {
     send_message(shared, message)
         .await
         .context("Failed to send message")?;
+
+    wait_for_group_status(shared, PUEUE_DEFAULT_GROUP, GroupStatus::Paused).await?;
 
     // Get the group status output
     let output = run_client_command(shared, &["--color", "always", "group"])?;

--- a/tests/client/group.rs
+++ b/tests/client/group.rs
@@ -15,6 +15,7 @@ async fn default() -> Result<()> {
 
     // Add a group via the cli interface.
     run_client_command(shared, &["group", "add", "testgroup", "--parallel=2"])?;
+    wait_for_group(shared, "testgroup").await?;
 
     // Get the group status output
     let output = run_client_command(shared, &["group"])?;

--- a/tests/daemon/edit.rs
+++ b/tests/daemon/edit.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};
+use test_log::test;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::Shared;
@@ -26,7 +27,7 @@ async fn create_edited_task(shared: &Shared) -> Result<EditResponseMessage> {
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 /// Test if adding a normal task works as intended.
 async fn test_edit_flow() -> Result<()> {
     let daemon = daemon().await?;

--- a/tests/helper/wait.rs
+++ b/tests/helper/wait.rs
@@ -161,23 +161,28 @@ pub async fn wait_for_group_status(
     group: &str,
     expected_status: GroupStatus,
 ) -> Result<()> {
-    let state = get_state(shared).await?;
-
-    // Give the daemon about 1 sec to shutdown.
+    // Give the daemon about 1 second to change group status.
     let tries = 20;
     let mut current_try = 0;
 
     while current_try < tries {
-        // Process is still alive, wait a little longer
-        if let Some(status) = state.groups.get(group) {
-            if matches!(status, _expected_status) {
-                return Ok(());
+        let state = get_state(shared).await?;
+        match state.groups.get(group) {
+            Some(group) => {
+                if group.status == expected_status {
+                    return Ok(());
+                }
+
+                // The status didn't change to the expected status. Try again.
+                current_try += 1;
+                sleep_ms(50).await;
+                continue;
+            }
+            None => {
+                bail!("Couldn't find group {group} while waiting for status change")
             }
         }
-
-        sleep_ms(50).await;
-        current_try += 1;
     }
 
-    bail!("Group {group} didn't change to state {expected_status:?} after about 1 sec.",);
+    bail!("Group {group} didn't change to state {expected_status:?} after about 1 second",);
 }


### PR DESCRIPTION
Handle flaking tests better at the CI level, make it easier to find flaking tests and address some of those issues.

This PR extracts work done to mitigate flaky tests from #376. I'll rebase that PR on top of this one (so include the commits here into that PR). If this PR is merged before the other, the other can be rebased again trivially.

Fixes #379.

## Background

Some tests in the test suite flake, fail based on exact timings or because of issues with test helpers. These failures are not signs that the project code is broken and so should not block accepting new work.

This PR aims to update how tests are run on GitHub Actions so flaky tests can be detected and be re-run to verify that the code-under-test is not the source of the test failure.

## Changes included in the PR

1. Switch to [cargo nextest](https://nexte.st/) to run the test suite. Not only does nextest run the test suite faster, it also can re-run tests that failed to verify that the failure wasn't a flake.

2. Adds a [test reporter action](https://github.com/marketplace/actions/publish-test-results), which surfaces test results in PRs and GitHub commit contexts. This makes it possible to see that a test flaked, as flaky tests, ideally, are fixed so they can't flake.

  **Note**: This part requires an additional GitHub workflow to actually publish the test report. This workflow will *not run* while still confined in this PR, because GitHub will not yet be able to find the workflow in the default
  (main) branch until it is merged into *that branch*. I've created a [demonstration PR](https://github.com/mjpieters/pueue/pull/2) in my own fork that shows what these reports look like.

3. Update dev-dependencies to make it easier to debug flaking tests, by making
   it trivially easy to enable logging for specific tests. I have found the
   existing logging already present in the pueue codebase to be _excellent_,
   and now only a `RUST_LOG=debug` environment variable away from becoming
   visible when a test fails.

4. And finally, individual commits to fix specific flaking tests I found I was
   able to fix.

## How to find and debug flaking tests

Run the test suite in a continuous loop; preferably with cargo nextest as that's faster; I've tuned the command-line switches to minimise output for runs without test failures:

```sh
while cargo nextest run --workspace --hide-progress-bar --status-level=fail
do :; done
```

You can do the same with the default `cargo test` command:

```sh
while cargo test --quiet
do :; done
```

Once a flaking test has been identified, add a test filter to focus on that specific test, add `RUST_LOG=debug` to the command-line to ensure you get plenty of log output when a failure happens, and if the test in question hasn't already been updated to [use the test-log macro](https://crates.io/crates/test-log), do so before trying to reproduce the issue:

```sh
while RUST_LOG=debug cargo nextest run --workspace --hide-progress-bar --status-level=fail \
    daemon::edit::test_edit_flow
do :; done
```

The cargo test equivalent is:

```sh
while RUST_LOG=debug cargo test --workspace --quiet \
    --test daemon_tests daemon::edit::test_edit_flow
do :; done
```

When you next hit a failure, you should have a plethora of information as to what pueue was doing up to that point.

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
