### PR TITLE
Use async sleep

### DIFF
--- a/client/commands/wait.rs
+++ b/client/commands/wait.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
-use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::Result;
 use chrono::Local;
 use crossterm::style::{Attribute, Color};
+use tokio::time::sleep;
 
 use pueue_lib::network::protocol::GenericStream;
 use pueue_lib::task::{Task, TaskResult, TaskStatus};
@@ -125,7 +125,7 @@ pub async fn wait(
         if std::env::var("PUEUED_TEST_ENV_VARIABLE").is_ok() {
             sleep_time = 250;
         }
-        sleep(Duration::from_millis(sleep_time));
+        sleep(Duration::from_millis(sleep_time)).await;
         first_run = false;
     }
 

--- a/client/display/follow.rs
+++ b/client/display/follow.rs
@@ -1,9 +1,9 @@
 use std::io;
 use std::path::Path;
-use std::thread::sleep;
 use std::time::Duration;
 
 use anyhow::Result;
+use tokio::time::sleep;
 
 use pueue_lib::{
     log::{get_log_file_handle, get_log_path, seek_to_last_lines},
@@ -89,6 +89,6 @@ pub async fn follow_local_task_logs(
 
         last_check += log_check_interval;
         let timeout = Duration::from_millis(log_check_interval);
-        sleep(timeout);
+        sleep(timeout).await;
     }
 }

--- a/daemon/network/socket.rs
+++ b/daemon/network/socket.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use clap::crate_version;
 use crossbeam_channel::Sender;
 use log::{debug, info, warn};
+use tokio::time::sleep;
 
 use pueue_lib::error::Error;
 use pueue_lib::network::message::*;
@@ -86,7 +87,7 @@ async fn handle_incoming(
             - SystemTime::now()
                 .duration_since(start)
                 .context("Couldn't calculate duration. Did the system time change?")?;
-        std::thread::sleep(remaining_sleep_time);
+        sleep(remaining_sleep_time).await;
         bail!("Received invalid secret");
     }
 

--- a/tests/client/wait.rs
+++ b/tests/client/wait.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::thread;
 
 use anyhow::Result;
+use tokio::time::sleep;
 
 use crate::fixtures::*;
 use crate::helper::*;
@@ -22,7 +23,7 @@ async fn multiple_tasks() -> Result<()> {
     let shared_clone = shared.clone();
     let wait_handle = thread::spawn(move || run_client_command(&shared_clone, &["wait"]));
     // Sleep for half a second to give `pueue wait` time to properly start.
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    sleep(std::time::Duration::from_millis(500)).await;
 
     // We now spawn another task that should be picked up by and waited upon completion
     // by the `wait` process.

--- a/tests/daemon/pause.rs
+++ b/tests/daemon/pause.rs
@@ -19,7 +19,7 @@ async fn test_pause_daemon() -> Result<()> {
 
     // Add a task and give the taskmanager time to theoretically start the process
     add_task(shared, "ls", false).await?;
-    sleep_ms(500);
+    sleep_ms(500).await;
 
     // Make sure it's not started
     assert_eq!(get_task_status(shared, 0).await?, TaskStatus::Queued);

--- a/tests/daemon/restore.rs
+++ b/tests/daemon/restore.rs
@@ -19,7 +19,7 @@ async fn test_start_running() -> Result<()> {
 
     // Kill the daemon and wait for it to shut down.
     assert_success(shutdown_daemon(shared).await?);
-    wait_for_shutdown(child.id().try_into()?)?;
+    wait_for_shutdown(child.id().try_into()?).await?;
 
     // Boot it up again
     let mut child = standalone_daemon(&settings.shared).await?;
@@ -48,7 +48,7 @@ async fn test_start_paused() -> Result<()> {
 
     // Kill the daemon and wait for it to shut down.
     assert_success(shutdown_daemon(shared).await?);
-    wait_for_shutdown(child.id().try_into()?)?;
+    wait_for_shutdown(child.id().try_into()?).await?;
 
     // Boot it up again
     let mut child = standalone_daemon(&settings.shared).await?;

--- a/tests/daemon/shutdown.rs
+++ b/tests/daemon/shutdown.rs
@@ -18,7 +18,7 @@ async fn test_ctrlc() -> Result<()> {
     kill(nix_pid, Signal::SIGTERM).context("Failed to send SIGTERM to pid")?;
 
     // Sleep for 500ms and give the daemon time to shut down
-    sleep_ms(500);
+    sleep_ms(500).await;
 
     let result = child.try_wait();
     assert!(matches!(result, Ok(Some(_))));
@@ -37,10 +37,10 @@ async fn test_graceful_shutdown() -> Result<()> {
 
     // Kill the daemon gracefully and wait for it to shut down.
     assert_success(shutdown_daemon(&settings.shared).await?);
-    wait_for_shutdown(child.id().try_into()?)?;
+    wait_for_shutdown(child.id().try_into()?).await?;
 
     // Sleep for 500ms and give the daemon time to shut down
-    sleep_ms(500);
+    sleep_ms(500).await;
 
     let result = child.try_wait();
     assert!(matches!(result, Ok(Some(_))));

--- a/tests/daemon/stashed.rs
+++ b/tests/daemon/stashed.rs
@@ -97,7 +97,7 @@ async fn test_delayed_tasks() -> Result<()> {
     .await?;
 
     // Make sure the task is started after being automatically enqueued.
-    sleep_ms(800);
+    sleep_ms(800).await;
     wait_for_task_condition(shared, 0, |task| task.is_running()).await?;
 
     Ok(())

--- a/tests/fixtures/daemon.rs
+++ b/tests/fixtures/daemon.rs
@@ -42,7 +42,7 @@ pub async fn daemon_with_settings(settings: Settings, tempdir: TempDir) -> Resul
     let path = pueue_dir.to_path_buf();
     // Start/spin off the daemon and get its PID
     tokio::spawn(run_and_handle_error(path, true));
-    let pid = get_pid(&settings.shared.pid_path())?;
+    let pid = get_pid(&settings.shared.pid_path()).await?;
 
     let tries = 20;
     let mut current_try = 0;
@@ -50,7 +50,7 @@ pub async fn daemon_with_settings(settings: Settings, tempdir: TempDir) -> Resul
     // Wait up to 1s for the unix socket to pop up.
     let socket_path = settings.shared.unix_socket_path();
     while current_try < tries {
-        sleep_ms(50);
+        sleep_ms(50).await;
         if socket_path.exists() {
             create_test_groups(&settings.shared).await?;
             return Ok(PueueDaemon {
@@ -105,7 +105,7 @@ pub async fn standalone_daemon(shared: &Shared) -> Result<Child> {
     // Wait up to 1s for the unix socket to pop up.
     let socket_path = shared.unix_socket_path();
     while current_try < tries {
-        sleep_ms(50);
+        sleep_ms(50).await;
         if socket_path.exists() {
             return Ok(child);
         }

--- a/tests/helper/daemon.rs
+++ b/tests/helper/daemon.rs
@@ -21,7 +21,7 @@ pub async fn shutdown_daemon(shared: &Shared) -> Result<Message> {
 /// Get a daemon pid from a specific pueue directory.
 /// This function gives the daemon a little time to boot up, but ultimately crashes if it takes too
 /// long.
-pub fn get_pid(pid_path: &Path) -> Result<i32> {
+pub async fn get_pid(pid_path: &Path) -> Result<i32> {
     // Give the daemon about 1 sec to boot and create the pid file.
     let tries = 20;
     let mut current_try = 0;
@@ -29,7 +29,7 @@ pub fn get_pid(pid_path: &Path) -> Result<i32> {
     while current_try < tries {
         // The daemon didn't create the pid file yet. Wait for 100ms and try again.
         if !pid_path.exists() {
-            sleep_ms(50);
+            sleep_ms(50).await;
             current_try += 1;
             continue;
         }
@@ -41,7 +41,7 @@ pub fn get_pid(pid_path: &Path) -> Result<i32> {
 
         // The file has been created but not yet been written to.
         if content.is_empty() {
-            sleep_ms(50);
+            sleep_ms(50).await;
             current_try += 1;
             continue;
         }
@@ -57,7 +57,7 @@ pub fn get_pid(pid_path: &Path) -> Result<i32> {
 
 /// Waits for a daemon to shut down.
 /// This is done by waiting for the pid to disappear.
-pub fn wait_for_shutdown(pid: i32) -> Result<()> {
+pub async fn wait_for_shutdown(pid: i32) -> Result<()> {
     // Try to read the process. If this fails, the daemon already exited.
     let process = match Process::new(pid) {
         Ok(process) => process,
@@ -71,7 +71,7 @@ pub fn wait_for_shutdown(pid: i32) -> Result<()> {
     while current_try < tries {
         // Process is still alive, wait a little longer
         if process.is_alive() {
-            sleep_ms(50);
+            sleep_ms(50).await;
             current_try += 1;
             continue;
         }

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -28,8 +28,8 @@ pub use wait::*;
 
 /// A helper function to sleep for ms time.
 /// Only used to avoid the biolerplate of importing the same stuff all over the place.
-pub fn sleep_ms(ms: u64) {
-    std::thread::sleep(std::time::Duration::from_millis(ms));
+pub async fn sleep_ms(ms: u64) {
+    tokio::time::sleep(std::time::Duration::from_millis(ms)).await;
 }
 
 /// A small helper function, which instantly writes the given string to stdout with a newline.

--- a/tests/helper/wait.rs
+++ b/tests/helper/wait.rs
@@ -21,7 +21,7 @@ pub async fn wait_for_task(shared: &Shared, task_id: usize) -> Result<Task> {
         let state = get_state(shared).await?;
         if !state.tasks.contains_key(&task_id) {
             current_try += 1;
-            sleep_ms(50);
+            sleep_ms(50).await;
             continue;
         }
 
@@ -51,7 +51,7 @@ pub async fn wait_for_status_change(
 
                 // The status didn't change. Try again.
                 current_try += 1;
-                sleep_ms(50);
+                sleep_ms(50).await;
                 continue;
             }
             None => {
@@ -87,7 +87,7 @@ where
 
                 // The status didn't change to target. Try again.
                 current_try += 1;
-                sleep_ms(50);
+                sleep_ms(50).await;
                 continue;
             }
             None => {
@@ -107,7 +107,7 @@ pub async fn wait_for_task_absence(shared: &Shared, task_id: usize) -> Result<()
         let state = get_state(shared).await?;
         if state.tasks.contains_key(&task_id) {
             current_try += 1;
-            sleep_ms(50);
+            sleep_ms(50).await;
             continue;
         }
 
@@ -126,7 +126,7 @@ pub async fn wait_for_group(shared: &Shared, group: &str) -> Result<()> {
         let state = get_state(shared).await?;
         if !state.groups.contains_key(group) {
             current_try += 1;
-            sleep_ms(50);
+            sleep_ms(50).await;
             continue;
         }
 
@@ -145,7 +145,7 @@ pub async fn wait_for_group_absence(shared: &Shared, group: &str) -> Result<()> 
         let state = get_state(shared).await?;
         if state.groups.contains_key(group) {
             current_try += 1;
-            sleep_ms(50);
+            sleep_ms(50).await;
             continue;
         }
 
@@ -175,7 +175,7 @@ pub async fn wait_for_group_status(
             }
         }
 
-        sleep_ms(50);
+        sleep_ms(50).await;
         current_try += 1;
     }
 


### PR DESCRIPTION
Use tokio::time::sleep rather than std::thread::sleep; the async version cooperates (yields to other tasks), so _just the task_ is blocked, not all tasks being run in the same thread.

It's a minor efficiency improvement, so I didn't include a changelog entry. LMK if this warrants one anyway.

## Checklist

- [x] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
