### PR TITLE
Refactor: Use From / Into to abstract message sending

### DIFF
--- a/client/client.rs
+++ b/client/client.rs
@@ -374,7 +374,7 @@ impl Client {
     /// This function is pretty large, but it consists mostly of simple conversions
     /// of [SubCommand] variant to a [Message] variant.
     fn get_message_from_opt(&self) -> Result<Message> {
-        match &self.subcommand {
+        Ok(match &self.subcommand {
             SubCommand::Add {
                 command,
                 working_directory,
@@ -403,7 +403,7 @@ impl Client {
                         .collect();
                 }
 
-                Ok(Message::Add(AddMessage {
+                AddMessage {
                     command: command.join(" "),
                     path,
                     // Catch the current environment for later injection into the task's process.
@@ -415,63 +415,54 @@ impl Client {
                     dependencies: dependencies.to_vec(),
                     label: label.clone(),
                     print_task_id: *print_task_id,
-                }))
+                }
+                .into()
             }
             SubCommand::Remove { task_ids } => {
                 if self.settings.client.show_confirmation_questions {
                     self.handle_user_confirmation("remove", task_ids)?;
                 }
-                Ok(Message::Remove(task_ids.clone()))
+                Message::Remove(task_ids.clone())
             }
-            SubCommand::Stash { task_ids } => Ok(Message::Stash(task_ids.clone())),
+            SubCommand::Stash { task_ids } => Message::Stash(task_ids.clone()),
             SubCommand::Switch {
                 task_id_1,
                 task_id_2,
-            } => {
-                let message = SwitchMessage {
-                    task_id_1: *task_id_1,
-                    task_id_2: *task_id_2,
-                };
-                Ok(Message::Switch(message))
+            } => SwitchMessage {
+                task_id_1: *task_id_1,
+                task_id_2: *task_id_2,
             }
+            .into(),
             SubCommand::Enqueue {
                 task_ids,
                 delay_until,
-            } => {
-                let message = EnqueueMessage {
-                    task_ids: task_ids.clone(),
-                    enqueue_at: *delay_until,
-                };
-                Ok(Message::Enqueue(message))
+            } => EnqueueMessage {
+                task_ids: task_ids.clone(),
+                enqueue_at: *delay_until,
             }
+            .into(),
             SubCommand::Start {
                 task_ids,
                 group,
                 all,
                 children,
-            } => {
-                let selection = selection_from_params(*all, group, task_ids);
-                let message = StartMessage {
-                    tasks: selection,
-                    children: *children,
-                };
-                Ok(Message::Start(message))
+            } => StartMessage {
+                tasks: selection_from_params(*all, group, task_ids),
+                children: *children,
             }
+            .into(),
             SubCommand::Pause {
                 task_ids,
                 group,
                 wait,
                 all,
                 children,
-            } => {
-                let selection = selection_from_params(*all, group, task_ids);
-                let message = PauseMessage {
-                    tasks: selection,
-                    wait: *wait,
-                    children: *children,
-                };
-                Ok(Message::Pause(message))
+            } => PauseMessage {
+                tasks: selection_from_params(*all, group, task_ids),
+                wait: *wait,
+                children: *children,
             }
+            .into(),
             SubCommand::Kill {
                 task_ids,
                 group,
@@ -482,34 +473,28 @@ impl Client {
                 if self.settings.client.show_confirmation_questions {
                     self.handle_user_confirmation("kill", task_ids)?;
                 }
-                let selection = selection_from_params(*all, group, task_ids);
-                let message = KillMessage {
-                    tasks: selection,
+                KillMessage {
+                    tasks: selection_from_params(*all, group, task_ids),
                     children: *children,
                     signal: signal.clone(),
-                };
-                Ok(Message::Kill(message))
+                }
+                .into()
             }
-            SubCommand::Send { task_id, input } => {
-                let message = SendMessage {
-                    task_id: *task_id,
-                    input: input.clone(),
-                };
-                Ok(Message::Send(message))
+            SubCommand::Send { task_id, input } => SendMessage {
+                task_id: *task_id,
+                input: input.clone(),
             }
+            .into(),
             SubCommand::Group { cmd } => match cmd {
-                Some(GroupCommand::Add { name, parallel }) => {
-                    Ok(Message::Group(GroupMessage::Add {
-                        name: name.to_owned(),
-                        parallel_tasks: parallel.to_owned(),
-                    }))
-                }
-                Some(GroupCommand::Remove { name }) => {
-                    Ok(Message::Group(GroupMessage::Remove(name.to_owned())))
-                }
-                None => Ok(Message::Group(GroupMessage::List)),
-            },
-            SubCommand::Status { .. } => Ok(Message::Status),
+                Some(GroupCommand::Add { name, parallel }) => GroupMessage::Add {
+                    name: name.to_owned(),
+                    parallel_tasks: parallel.to_owned(),
+                },
+                Some(GroupCommand::Remove { name }) => GroupMessage::Remove(name.to_owned()),
+                None => GroupMessage::List,
+            }
+            .into(),
+            SubCommand::Status { .. } => Message::Status,
             SubCommand::Log {
                 task_ids,
                 lines,
@@ -523,56 +508,51 @@ impl Client {
                     send_logs: !self.settings.client.read_local_logs,
                     lines,
                 };
-                Ok(Message::Log(message))
+                Message::Log(message)
             }
-            SubCommand::Follow { task_id, lines } => {
-                let message = StreamRequestMessage {
-                    task_id: *task_id,
-                    lines: *lines,
-                };
-                Ok(Message::StreamRequest(message))
+            SubCommand::Follow { task_id, lines } => StreamRequestMessage {
+                task_id: *task_id,
+                lines: *lines,
             }
+            .into(),
             SubCommand::Clean {
                 successful_only,
                 group,
-            } => {
-                let message = CleanMessage {
-                    successful_only: *successful_only,
-                    group: group.clone(),
-                };
-
-                Ok(Message::Clean(message))
+            } => CleanMessage {
+                successful_only: *successful_only,
+                group: group.clone(),
             }
+            .into(),
             SubCommand::Reset { children, force } => {
                 if self.settings.client.show_confirmation_questions && !force {
                     self.handle_user_confirmation("reset", &Vec::new())?;
                 }
 
-                let message = ResetMessage {
+                ResetMessage {
                     children: *children,
-                };
-                Ok(Message::Reset(message))
+                }
+                .into()
             }
-            SubCommand::Shutdown => Ok(Message::DaemonShutdown(Shutdown::Graceful)),
+            SubCommand::Shutdown => Shutdown::Graceful.into(),
             SubCommand::Parallel {
                 parallel_tasks,
                 group,
             } => match parallel_tasks {
                 Some(parallel_tasks) => {
                     let group = group_or_default(group);
-                    let message = ParallelMessage {
+                    ParallelMessage {
                         parallel_tasks: *parallel_tasks,
                         group,
-                    };
-                    Ok(Message::Parallel(message))
+                    }
+                    .into()
                 }
-                None => Ok(Message::Group(GroupMessage::List)),
+                None => GroupMessage::List.into(),
             },
             SubCommand::FormatStatus { .. } => bail!("FormatStatus has to be handled earlier"),
             SubCommand::Completions { .. } => bail!("Completions have to be handled earlier"),
             SubCommand::Restart { .. } => bail!("Restarts have to be handled earlier"),
             SubCommand::Edit { .. } => bail!("Edits have to be handled earlier"),
             SubCommand::Wait { .. } => bail!("Wait has to be handled earlier"),
-        }
+        })
     }
 }

--- a/client/commands/edit.rs
+++ b/client/commands/edit.rs
@@ -75,13 +75,13 @@ pub async fn edit(
     };
 
     // Create a new message with the edited properties.
-    let edit_message = Message::Edit(EditMessage {
+    let edit_message = EditMessage {
         task_id,
         command: edited_props.command,
         path: edited_props.path,
         label: edited_props.label,
         delete_label: edited_props.delete_label,
-    });
+    };
     send_message(edit_message, stream).await?;
 
     Ok(receive_message(stream).await?)

--- a/client/commands/restart.rs
+++ b/client/commands/restart.rs
@@ -104,7 +104,7 @@ pub async fn restart(
 
         // In case we don't do in-place restarts, we have to add a new task.
         // Create a AddMessage to send the task to the daemon from the updated info and the old task.
-        let add_task_message = Message::Add(AddMessage {
+        let add_task_message = AddMessage {
             command: edited_props.command.unwrap_or_else(|| task.command.clone()),
             path: edited_props.path.unwrap_or_else(|| task.path.clone()),
             envs: task.envs.clone(),
@@ -115,7 +115,7 @@ pub async fn restart(
             dependencies: Vec::new(),
             label: edited_props.label.or_else(|| task.label.clone()),
             print_task_id: false,
-        });
+        };
 
         // Send the cloned task to the daemon and abort on any failure messages.
         send_message(add_task_message, stream).await?;
@@ -126,7 +126,7 @@ pub async fn restart(
 
     // Send the singular in-place restart message to the daemon.
     if in_place {
-        send_message(Message::Restart(restart_message), stream).await?;
+        send_message(restart_message, stream).await?;
         if let Message::Failure(message) = receive_message(stream).await? {
             bail!(message);
         };

--- a/daemon/lib.rs
+++ b/daemon/lib.rs
@@ -3,12 +3,12 @@ use std::sync::{Arc, Mutex};
 use std::{fs::create_dir_all, path::PathBuf};
 
 use anyhow::{bail, Context, Result};
-use crossbeam_channel::{unbounded, Sender};
+use crossbeam_channel::unbounded;
 use log::{error, warn};
 
 use pueue_lib::error::Error;
 use pueue_lib::network::certificate::create_certificates;
-use pueue_lib::network::message::{Message, Shutdown};
+use pueue_lib::network::message::Shutdown;
 use pueue_lib::network::protocol::socket_cleanup;
 use pueue_lib::network::secret::init_shared_secret;
 use pueue_lib::settings::Settings;
@@ -16,7 +16,7 @@ use pueue_lib::state::State;
 
 use self::state_helper::{restore_state, save_state};
 use crate::network::socket::accept_incoming;
-use crate::task_handler::TaskHandler;
+use crate::task_handler::{TaskHandler, TaskSender};
 
 pub mod cli;
 mod network;
@@ -88,6 +88,7 @@ pub async fn run(config_path: Option<PathBuf>, profile: Option<String>, test: bo
     let state = Arc::new(Mutex::new(state));
 
     let (sender, receiver) = unbounded();
+    let sender = TaskSender::new(sender);
     let mut task_handler = TaskHandler::new(state.clone(), settings.clone(), receiver);
 
     // Don't set ctrlc and panic handlers during testing.
@@ -145,7 +146,7 @@ fn init_directories(pueue_dir: &Path) -> Result<()> {
 /// TaskHandler. This is to prevent dangling processes and other weird edge-cases.
 ///
 /// On panic, we want to cleanup existing unix sockets and the PID file.
-fn setup_signal_panic_handling(settings: &Settings, sender: &Sender<Message>) -> Result<()> {
+fn setup_signal_panic_handling(settings: &Settings, sender: &TaskSender) -> Result<()> {
     let sender_clone = sender.clone();
 
     // This section handles Shutdown via SigTerm/SigInt process signals
@@ -154,7 +155,7 @@ fn setup_signal_panic_handling(settings: &Settings, sender: &Sender<Message>) ->
     ctrlc::set_handler(move || {
         // Notify the task handler
         sender_clone
-            .send(Message::DaemonShutdown(Shutdown::Emergency))
+            .send(Shutdown::Emergency)
             .expect("Failed to send Message to TaskHandler on Shutdown");
     })?;
 

--- a/daemon/network/message_handler/add.rs
+++ b/daemon/network/message_handler/add.rs
@@ -1,5 +1,3 @@
-use crossbeam_channel::Sender;
-
 use pueue_lib::aliasing::insert_alias;
 use pueue_lib::network::message::*;
 use pueue_lib::state::{GroupStatus, SharedState};
@@ -14,7 +12,7 @@ use crate::state_helper::save_state;
 /// If the start_immediately flag is set, send a StartMessage to the task handler.
 pub fn add_task(
     message: AddMessage,
-    sender: &Sender<Message>,
+    sender: &TaskSender,
     state: &SharedState,
     settings: &Settings,
 ) -> Message {
@@ -75,10 +73,10 @@ pub fn add_task(
     // Notify the task handler, in case the client wants to start the task immediately.
     if message.start_immediately {
         sender
-            .send(Message::Start(StartMessage {
+            .send(StartMessage {
                 tasks: TaskSelection::TaskIds(vec![task_id]),
                 children: false,
-            }))
+            })
             .expect(SENDER_ERR);
     }
 

--- a/daemon/network/message_handler/edit.rs
+++ b/daemon/network/message_handler/edit.rs
@@ -21,13 +21,13 @@ pub fn edit_request(task_id: usize, state: &SharedState) -> Message {
             task.prev_status = task.status.clone();
             task.status = TaskStatus::Locked;
 
-            let message = EditResponseMessage {
+            EditResponseMessage {
                 task_id: task.id,
                 command: task.original_command.clone(),
                 path: task.path.clone(),
                 label: task.label.clone(),
-            };
-            Message::EditResponse(message)
+            }
+            .into()
         }
         None => create_failure_message("No task with this id."),
     }

--- a/daemon/network/message_handler/kill.rs
+++ b/daemon/network/message_handler/kill.rs
@@ -1,14 +1,12 @@
-use crossbeam_channel::Sender;
-
 use pueue_lib::network::message::*;
 use pueue_lib::state::SharedState;
 
-use super::SENDER_ERR;
+use super::{TaskSender, SENDER_ERR};
 use crate::network::response_helper::{ensure_group_exists, task_action_response_helper};
 
 /// Invoked when calling `pueue kill`.
 /// Forward the kill message to the task handler, which then kills the process.
-pub fn kill(message: KillMessage, sender: &Sender<Message>, state: &SharedState) -> Message {
+pub fn kill(message: KillMessage, sender: &TaskSender, state: &SharedState) -> Message {
     let mut state = state.lock().unwrap();
 
     // If a group is selected, make sure it exists.
@@ -18,9 +16,7 @@ pub fn kill(message: KillMessage, sender: &Sender<Message>, state: &SharedState)
         }
     }
 
-    sender
-        .send(Message::Kill(message.clone()))
-        .expect(SENDER_ERR);
+    sender.send(message.clone()).expect(SENDER_ERR);
 
     if let Some(signal) = message.signal {
         match message.tasks {

--- a/daemon/network/message_handler/mod.rs
+++ b/daemon/network/message_handler/mod.rs
@@ -1,11 +1,10 @@
 use std::fmt::Display;
 
-use crossbeam_channel::Sender;
-
 use pueue_lib::network::message::*;
 use pueue_lib::settings::Settings;
 use pueue_lib::state::SharedState;
 
+use super::TaskSender;
 use crate::network::response_helper::*;
 
 mod add;
@@ -28,7 +27,7 @@ pub static SENDER_ERR: &str = "Failed to send message to task handler thread";
 
 pub fn handle_message(
     message: Message,
-    sender: &Sender<Message>,
+    sender: &TaskSender,
     state: &SharedState,
     settings: &Settings,
 ) -> Message {
@@ -59,8 +58,8 @@ pub fn handle_message(
 /// Invoked when calling `pueue reset`.
 /// Forward the reset request to the task handler.
 /// The handler then kills all children and clears the task queue.
-fn reset(message: ResetMessage, sender: &Sender<Message>) -> Message {
-    sender.send(Message::Reset(message)).expect(SENDER_ERR);
+fn reset(message: ResetMessage, sender: &TaskSender) -> Message {
+    sender.send(message).expect(SENDER_ERR);
     create_success_message("Everything is being reset right now.")
 }
 

--- a/daemon/network/message_handler/pause.rs
+++ b/daemon/network/message_handler/pause.rs
@@ -1,15 +1,13 @@
-use crossbeam_channel::Sender;
-
 use pueue_lib::network::message::*;
 use pueue_lib::state::SharedState;
 use pueue_lib::task::TaskStatus;
 
-use super::SENDER_ERR;
+use super::{TaskSender, SENDER_ERR};
 use crate::network::response_helper::*;
 
 /// Invoked when calling `pueue pause`.
 /// Forward the pause message to the task handler, which then pauses groups/tasks/everything.
-pub fn pause(message: PauseMessage, sender: &Sender<Message>, state: &SharedState) -> Message {
+pub fn pause(message: PauseMessage, sender: &TaskSender, state: &SharedState) -> Message {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {
@@ -19,9 +17,7 @@ pub fn pause(message: PauseMessage, sender: &Sender<Message>, state: &SharedStat
     }
 
     // Forward the message to the task handler.
-    sender
-        .send(Message::Pause(message.clone()))
-        .expect(SENDER_ERR);
+    sender.send(message.clone()).expect(SENDER_ERR);
 
     // Return a response depending on the selected tasks.
     match message.tasks {

--- a/daemon/network/message_handler/restart.rs
+++ b/daemon/network/message_handler/restart.rs
@@ -1,4 +1,3 @@
-use crossbeam_channel::Sender;
 use pueue_lib::settings::Settings;
 use std::sync::MutexGuard;
 
@@ -7,7 +6,7 @@ use pueue_lib::network::message::*;
 use pueue_lib::state::{SharedState, State};
 use pueue_lib::task::TaskStatus;
 
-use super::{task_action_response_helper, SENDER_ERR};
+use super::{task_action_response_helper, TaskSender, SENDER_ERR};
 
 /// This is a small wrapper around the actual in-place task `restart` functionality.
 ///
@@ -15,7 +14,7 @@ use super::{task_action_response_helper, SENDER_ERR};
 /// new task, which is completely handled on the client-side.
 pub fn restart_multiple(
     message: RestartMessage,
-    sender: &Sender<Message>,
+    sender: &TaskSender,
     state: &SharedState,
     settings: &Settings,
 ) -> Message {
@@ -39,10 +38,10 @@ pub fn restart_multiple(
     // Tell the task manager to start the task immediately if requested.
     if message.start_immediately {
         sender
-            .send(Message::Start(StartMessage {
+            .send(StartMessage {
                 tasks: TaskSelection::TaskIds(task_ids),
                 children: false,
-            }))
+            })
             .expect(SENDER_ERR);
     }
 

--- a/daemon/network/message_handler/send.rs
+++ b/daemon/network/message_handler/send.rs
@@ -1,15 +1,13 @@
-use crossbeam_channel::Sender;
-
 use pueue_lib::network::message::*;
 use pueue_lib::state::SharedState;
 use pueue_lib::task::TaskStatus;
 
-use super::SENDER_ERR;
+use super::{TaskSender, SENDER_ERR};
 
 /// Invoked when calling `pueue send`.
 /// The message will be forwarded to the task handler, which then sends the user input to the process.
 /// In here we only do some error handling.
-pub fn send(message: SendMessage, sender: &Sender<Message>, state: &SharedState) -> Message {
+pub fn send(message: SendMessage, sender: &TaskSender, state: &SharedState) -> Message {
     // Check whether the task exists and is running. Abort if that's not the case.
     {
         let state = state.lock().unwrap();
@@ -24,7 +22,7 @@ pub fn send(message: SendMessage, sender: &Sender<Message>, state: &SharedState)
     }
 
     // Check whether the task exists and is running, abort if that's not the case.
-    sender.send(Message::Send(message)).expect(SENDER_ERR);
+    sender.send(message).expect(SENDER_ERR);
 
     create_success_message("Message is being send to the process.")
 }

--- a/daemon/network/message_handler/start.rs
+++ b/daemon/network/message_handler/start.rs
@@ -1,15 +1,13 @@
-use crossbeam_channel::Sender;
-
 use pueue_lib::network::message::*;
 use pueue_lib::state::SharedState;
 use pueue_lib::task::TaskStatus;
 
-use super::SENDER_ERR;
+use super::{TaskSender, SENDER_ERR};
 use crate::network::response_helper::*;
 
 /// Invoked when calling `pueue start`.
 /// Forward the start message to the task handler, which then starts the process(es).
-pub fn start(message: StartMessage, sender: &Sender<Message>, state: &SharedState) -> Message {
+pub fn start(message: StartMessage, sender: &TaskSender, state: &SharedState) -> Message {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {
@@ -19,9 +17,7 @@ pub fn start(message: StartMessage, sender: &Sender<Message>, state: &SharedStat
     }
 
     // Forward the message to the task handler.
-    sender
-        .send(Message::Start(message.clone()))
-        .expect(SENDER_ERR);
+    sender.send(message.clone()).expect(SENDER_ERR);
 
     // Return a response depending on the selected tasks.
     match message.tasks {

--- a/daemon/network/mod.rs
+++ b/daemon/network/mod.rs
@@ -2,3 +2,5 @@ pub mod follow_log;
 pub mod message_handler;
 pub mod response_helper;
 pub mod socket;
+
+use super::TaskSender;

--- a/lib/src/network/protocol.rs
+++ b/lib/src/network/protocol.rs
@@ -17,7 +17,11 @@ pub const PACKET_SIZE: usize = 1280;
 
 /// Convenience wrapper around send_bytes.
 /// Deserialize a message and feed the bytes into send_bytes.
-pub async fn send_message(message: Message, stream: &mut GenericStream) -> Result<(), Error> {
+pub async fn send_message<T>(message: T, stream: &mut GenericStream) -> Result<(), Error>
+where
+    T: Into<Message>,
+{
+    let message: Message = message.into();
     debug!("Sending message: {message:#?}",);
     // Prepare command for transfer and determine message byte size
     let payload = to_vec(&message).map_err(|err| Error::MessageDeserialization(err.to_string()))?;

--- a/tests/client/edit.rs
+++ b/tests/client/edit.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use anyhow::{Context, Result};
-use pueue_lib::network::message::Message;
 use pueue_lib::task::TaskStatus;
 
 use crate::fixtures::*;
@@ -16,7 +15,7 @@ async fn edit_task_default() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, Message::Add(message))
+    send_message(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -46,7 +45,7 @@ async fn edit_all_task_properties() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, Message::Add(message))
+    send_message(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -79,7 +78,7 @@ async fn edit_delete_label() -> Result<()> {
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
     message.label = Some("Testlabel".to_owned());
-    send_message(shared, Message::Add(message))
+    send_message(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -106,7 +105,7 @@ async fn fail_to_edit_task() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, Message::Add(message))
+    send_message(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 

--- a/tests/client/group.rs
+++ b/tests/client/group.rs
@@ -33,11 +33,11 @@ async fn colored() -> Result<()> {
 
     // Pauses the default queue while waiting for tasks
     // We do this to ensure that paused groups are properly colored.
-    let message = Message::Pause(PauseMessage {
+    let message = PauseMessage {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
         children: false,
-    });
+    };
     send_message(shared, message)
         .await
         .context("Failed to send message")?;

--- a/tests/daemon/add.rs
+++ b/tests/daemon/add.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use pueue_lib::network::message::{Message, TaskSelection};
+use pueue_lib::network::message::TaskSelection;
 use pueue_lib::task::*;
 
 use crate::fixtures::*;
@@ -34,9 +34,8 @@ async fn test_stashed_add() -> Result<()> {
     let shared = &daemon.settings.shared;
 
     // Tell the daemon to add a task in stashed state.
-    let mut inner_message = create_add_message(shared, "sleep 60");
-    inner_message.stashed = true;
-    let message = Message::Add(inner_message);
+    let mut message = create_add_message(shared, "sleep 60");
+    message.stashed = true;
     assert_success(send_message(shared, message).await?);
 
     // Make sure the task is actually stashed.

--- a/tests/daemon/aliases.rs
+++ b/tests/daemon/aliases.rs
@@ -59,7 +59,7 @@ async fn test_restart_with_alias() -> Result<()> {
     create_test_alias_file(daemon.tempdir.path(), aliases)?;
 
     // Restart the task while editing its command.
-    let message = Message::Restart(RestartMessage {
+    let message = RestartMessage {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: Some("replaced_cmd test".to_string()),
@@ -69,7 +69,7 @@ async fn test_restart_with_alias() -> Result<()> {
         }],
         start_immediately: true,
         stashed: false,
-    });
+    };
     send_message(shared, message).await?;
     let task = wait_for_task_condition(shared, 0, |task| task.is_done()).await?;
 

--- a/tests/daemon/clean.rs
+++ b/tests/daemon/clean.rs
@@ -22,7 +22,7 @@ async fn test_normal_clean() -> Result<()> {
         successful_only: false,
         group: None,
     };
-    send_message(shared, Message::Clean(clean_message)).await?;
+    send_message(shared, clean_message).await?;
 
     // Assert that task 0 and 1 have both been removed
     let state = get_state(shared).await?;
@@ -50,7 +50,7 @@ async fn test_successful_only_clean() -> Result<()> {
         successful_only: true,
         group: None,
     };
-    send_message(shared, Message::Clean(clean_message)).await?;
+    send_message(shared, clean_message).await?;
 
     // Assert that task 0 is still there, as it failed.
     let state = get_state(shared).await?;
@@ -83,7 +83,7 @@ async fn test_clean_in_selected_group() -> Result<()> {
         successful_only: false,
         group: Some("other".to_string()),
     };
-    send_message(shared, Message::Clean(clean_message)).await?;
+    send_message(shared, clean_message).await?;
 
     // Assert that task 0 and 1 are still there
     let state = get_state(shared).await?;
@@ -121,7 +121,7 @@ async fn test_clean_successful_only_in_selected_group() -> Result<()> {
         successful_only: true,
         group: Some("other".to_string()),
     };
-    send_message(shared, Message::Clean(clean_message)).await?;
+    send_message(shared, clean_message).await?;
 
     let state = get_state(shared).await?;
     // group default

--- a/tests/daemon/edit.rs
+++ b/tests/daemon/edit.rs
@@ -51,13 +51,13 @@ async fn test_edit_flow() -> Result<()> {
     // Send the final message of the protocol and actually change the task.
     let response = send_message(
         shared,
-        Message::Edit(EditMessage {
+        EditMessage {
             task_id: 0,
             command: Some("ls -ahl".into()),
             path: Some("/tmp".into()),
             label: Some("test".to_string()),
             delete_label: false,
-        }),
+        },
     )
     .await?;
     assert_success(response);

--- a/tests/daemon/group.rs
+++ b/tests/daemon/group.rs
@@ -15,14 +15,14 @@ async fn test_add_and_remove() -> Result<()> {
     add_group_with_slots(shared, "testgroup", 1).await?;
 
     // Try to add the same group again. This should fail
-    let add_message = Message::Group(GroupMessage::Add {
+    let add_message = GroupMessage::Add {
         name: "testgroup".to_string(),
         parallel_tasks: None,
-    });
+    };
     assert_failure(send_message(shared, add_message).await?);
 
     // Remove the newly added group and wait for the deletion to be processed.
-    let remove_message = Message::Group(GroupMessage::Remove("testgroup".to_string()));
+    let remove_message = GroupMessage::Remove("testgroup".to_string());
     assert_success(send_message(shared, remove_message.clone()).await?);
     wait_for_group_absence(shared, "testgroup").await?;
 
@@ -38,7 +38,7 @@ async fn test_add_and_remove() -> Result<()> {
 async fn test_cannot_delete_default() -> Result<()> {
     let daemon = daemon().await?;
 
-    let message = Message::Group(GroupMessage::Remove(PUEUE_DEFAULT_GROUP.to_string()));
+    let message = GroupMessage::Remove(PUEUE_DEFAULT_GROUP.to_string());
     assert_failure(send_message(&daemon.settings.shared, message).await?);
 
     Ok(())
@@ -49,7 +49,7 @@ async fn test_cannot_delete_default() -> Result<()> {
 async fn test_cannot_delete_non_existing() -> Result<()> {
     let daemon = daemon().await?;
 
-    let message = Message::Group(GroupMessage::Remove("doesnt_exist".to_string()));
+    let message = GroupMessage::Remove("doesnt_exist".to_string());
     assert_failure(send_message(&daemon.settings.shared, message).await?);
 
     Ok(())
@@ -69,7 +69,7 @@ async fn test_cannot_delete_group_with_tasks() -> Result<()> {
     wait_for_task_condition(&daemon.settings.shared, 0, |task| task.is_done()).await?;
 
     // We shouldn't be capable of removing that group
-    let message = Message::Group(GroupMessage::Remove("testgroup".to_string()));
+    let message = GroupMessage::Remove("testgroup".to_string());
     assert_failure(send_message(shared, message).await?);
 
     // Remove the task from the group
@@ -77,7 +77,7 @@ async fn test_cannot_delete_group_with_tasks() -> Result<()> {
     send_message(shared, remove_message).await?;
 
     // Removal should now work.
-    let message = Message::Group(GroupMessage::Remove("testgroup".to_string()));
+    let message = GroupMessage::Remove("testgroup".to_string());
     assert_success(send_message(shared, message).await?);
 
     Ok(())

--- a/tests/daemon/kill.rs
+++ b/tests/daemon/kill.rs
@@ -11,25 +11,25 @@ use crate::helper::*;
 
 #[rstest]
 #[case(
-    Message::Kill(KillMessage {
+    KillMessage {
         tasks: TaskSelection::All,
         children: false,
         signal: None,
-    }), true
+    }, true
 )]
 #[case(
-    Message::Kill(KillMessage {
+    KillMessage {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         children: false,
         signal: None,
-    }), true
+    }, true
 )]
 #[case(
-    Message::Kill(KillMessage {
+    KillMessage {
         tasks: TaskSelection::TaskIds(vec![0, 1, 2]),
         children: false,
         signal: None,
-    }), false
+    }, false
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// Test if killing running tasks works as intended.
@@ -42,7 +42,7 @@ use crate::helper::*;
 /// If a whole group or everything is killed, the respective groups should also be paused!
 /// This is security measure to prevent unwanted task execution in an emergency.
 async fn test_kill_tasks(
-    #[case] kill_message: Message,
+    #[case] kill_message: KillMessage,
     #[case] group_should_pause: bool,
 ) -> Result<()> {
     let daemon = daemon().await?;

--- a/tests/daemon/pause.rs
+++ b/tests/daemon/pause.rs
@@ -62,11 +62,11 @@ async fn test_pause_with_wait() -> Result<()> {
     wait_for_task_condition(shared, 0, |task| task.is_running()).await?;
 
     // Pauses the default queue while waiting for tasks
-    let message = Message::Pause(PauseMessage {
+    let message = PauseMessage {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
         children: false,
-    });
+    };
     send_message(shared, message)
         .await
         .context("Failed to send message")?;

--- a/tests/daemon/reset.rs
+++ b/tests/daemon/reset.rs
@@ -18,7 +18,7 @@ async fn test_reset() -> Result<()> {
     wait_for_task_condition(shared, 1, |task| task.is_running()).await?;
 
     // Reset the daemon
-    send_message(shared, Message::Reset(ResetMessage { children: true }))
+    send_message(shared, ResetMessage { children: true })
         .await
         .context("Failed to send Start tasks message")?;
 

--- a/tests/daemon/restart.rs
+++ b/tests/daemon/restart.rs
@@ -20,7 +20,7 @@ async fn test_restart_in_place() -> Result<()> {
     wait_for_task_condition(shared, 0, |task| task.is_done()).await?;
 
     // Restart task 0 with an extended sleep command with a different path.
-    let restart_message = Message::Restart(RestartMessage {
+    let restart_message = RestartMessage {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: Some("sleep 60".to_string()),
@@ -30,7 +30,7 @@ async fn test_restart_in_place() -> Result<()> {
         }],
         start_immediately: false,
         stashed: false,
-    });
+    };
     assert_success(send_message(shared, restart_message).await?);
 
     let state = get_state(shared).await?;
@@ -62,7 +62,7 @@ async fn test_cannot_restart_running() -> Result<()> {
     wait_for_task_condition(shared, 0, |task| task.is_running()).await?;
 
     // Restart task 0 with an extended sleep command.
-    let restart_message = Message::Restart(RestartMessage {
+    let restart_message = RestartMessage {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: None,
@@ -72,7 +72,7 @@ async fn test_cannot_restart_running() -> Result<()> {
         }],
         start_immediately: false,
         stashed: false,
-    });
+    };
     assert_failure(send_message(shared, restart_message).await?);
 
     Ok(())

--- a/tests/daemon/start.rs
+++ b/tests/daemon/start.rs
@@ -8,22 +8,22 @@ use crate::helper::*;
 
 #[rstest]
 #[case(
-    Message::Start(StartMessage {
+    StartMessage {
         tasks: TaskSelection::All,
         children: false,
-    })
+    }
 )]
 #[case(
-    Message::Start(StartMessage {
+    StartMessage {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         children: false,
-    })
+    }
 )]
 #[case(
-    Message::Start(StartMessage {
+    StartMessage {
         tasks: TaskSelection::TaskIds(vec![0, 1, 2]),
         children: false,
-    })
+    }
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// Test if explicitely starting tasks and resuming tasks works as intended.
@@ -32,7 +32,7 @@ use crate::helper::*;
 /// - Via the --all flag, which resumes everything.
 /// - Via the --group flag, which resumes everything in a specific group (in our case 'default').
 /// - Via specific ids.
-async fn test_start_tasks(#[case] start_message: Message) -> Result<()> {
+async fn test_start_tasks(#[case] start_message: StartMessage) -> Result<()> {
     let daemon = daemon().await?;
     let shared = &daemon.settings.shared;
 

--- a/tests/daemon/stashed.rs
+++ b/tests/daemon/stashed.rs
@@ -16,10 +16,9 @@ pub async fn add_stashed_task(
     stashed: bool,
     enqueue_at: Option<DateTime<Local>>,
 ) -> Result<Message> {
-    let mut inner_message = create_add_message(shared, command);
-    inner_message.stashed = stashed;
-    inner_message.enqueue_at = enqueue_at;
-    let message = Message::Add(inner_message);
+    let mut message = create_add_message(shared, command);
+    message.stashed = stashed;
+    message.enqueue_at = enqueue_at;
 
     send_message(shared, message)
         .await
@@ -60,10 +59,10 @@ async fn test_enqueued_tasks(
     }
 
     // Manually enqueue the task
-    let enqueue_message = Message::Enqueue(EnqueueMessage {
+    let enqueue_message = EnqueueMessage {
         task_ids: vec![0],
         enqueue_at: None,
-    });
+    };
     send_message(shared, enqueue_message)
         .await
         .context("Failed to to add task message")?;

--- a/tests/helper/daemon.rs
+++ b/tests/helper/daemon.rs
@@ -11,7 +11,7 @@ use super::*;
 
 /// Send the Shutdown message to the test daemon.
 pub async fn shutdown_daemon(shared: &Shared) -> Result<Message> {
-    let message = Message::DaemonShutdown(Shutdown::Graceful);
+    let message = Shutdown::Graceful;
 
     send_message(shared, message)
         .await

--- a/tests/helper/env.rs
+++ b/tests/helper/env.rs
@@ -32,11 +32,11 @@ pub async fn assert_worker_envs(
     // Get the log output for the task.
     let response = send_message(
         shared,
-        Message::Log(LogRequestMessage {
+        LogRequestMessage {
             task_ids: vec![task_id],
             send_logs: true,
             lines: None,
-        }),
+        },
     )
     .await?;
 

--- a/tests/helper/group.rs
+++ b/tests/helper/group.rs
@@ -7,10 +7,10 @@ use super::*;
 
 /// Create a new group with a specific amount of slots.
 pub async fn add_group_with_slots(shared: &Shared, group_name: &str, slots: usize) -> Result<()> {
-    let add_message = Message::Group(GroupMessage::Add {
+    let add_message = GroupMessage::Add {
         name: group_name.to_string(),
         parallel_tasks: Some(slots),
-    });
+    };
     assert_success(send_message(shared, add_message.clone()).await?);
     wait_for_group(shared, group_name).await?;
 

--- a/tests/helper/log.rs
+++ b/tests/helper/log.rs
@@ -22,11 +22,11 @@ pub fn decompress_log(bytes: Vec<u8>) -> Result<String> {
 /// Convenience function to get the log of a specific task.
 /// `lines: None` requests all log lines.
 pub async fn get_task_log(shared: &Shared, task_id: usize, lines: Option<usize>) -> Result<String> {
-    let message = Message::Log(LogRequestMessage {
+    let message = LogRequestMessage {
         task_ids: vec![task_id],
         send_logs: true,
         lines,
-    });
+    };
     let response = send_message(shared, message).await?;
 
     let mut logs = match response {

--- a/tests/helper/network.rs
+++ b/tests/helper/network.rs
@@ -9,7 +9,10 @@ use pueue_lib::network::secret::read_shared_secret;
 use pueue_lib::settings::Shared;
 
 /// This is a small convenience wrapper that sends a message and immediately returns the response.
-pub async fn send_message(shared: &Shared, message: Message) -> Result<Message> {
+pub async fn send_message<T>(shared: &Shared, message: T) -> Result<Message>
+where
+    T: Into<Message>,
+{
     let mut stream = get_authenticated_stream(shared).await?;
 
     // Check if we can receive the response from the daemon

--- a/tests/helper/task.rs
+++ b/tests/helper/task.rs
@@ -11,9 +11,8 @@ use crate::helper::*;
 
 /// Adds a task to the test daemon.
 pub async fn add_task(shared: &Shared, command: &str, start_immediately: bool) -> Result<Message> {
-    let mut inner_message = create_add_message(shared, command);
-    inner_message.start_immediately = start_immediately;
-    let message = Message::Add(inner_message);
+    let mut message = create_add_message(shared, command);
+    message.start_immediately = start_immediately;
 
     send_message(shared, message)
         .await
@@ -42,7 +41,7 @@ pub async fn add_task_to_group(shared: &Shared, command: &str, group: &str) -> R
     let mut message = create_add_message(shared, command);
     message.group = group.to_string();
 
-    send_message(shared, Message::Add(message))
+    send_message(shared, message)
         .await
         .context("Failed to to add task to group.")
 }
@@ -65,10 +64,10 @@ pub async fn add_env_task_to_group(shared: &Shared, command: &str, group: &str) 
 
 /// Helper to either continue the daemon or start specific tasks
 pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Message> {
-    let message = Message::Start(StartMessage {
+    let message = StartMessage {
         tasks,
         children: false,
-    });
+    };
 
     send_message(shared, message)
         .await
@@ -77,11 +76,11 @@ pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Messag
 
 /// Helper to pause the default group of the daemon
 pub async fn pause_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Message> {
-    let message = Message::Pause(PauseMessage {
+    let message = PauseMessage {
         tasks,
         wait: false,
         children: false,
-    });
+    };
 
     send_message(shared, message)
         .await


### PR DESCRIPTION
This makes Message use simpler, getting rid of a lot of boilerplate. The task manager channel is now a wrapper type accepting Into<Message>, keeping implementation details closer to the rest of the task manager code base.

## Checklist

- [x] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.

No changelog entry as this is a code refactor with no functionality difference.
