### PR TITLE
CI: correct codecov configuration syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Misc
 
 - Continuation of testing the `pueue` client, pushing the test coverage from ~70% to ~73%.
+- A codecov.yml syntax error was corrected, which prevented Codecov from applying the
+  repository-specific configuration.
 
 ## [2.1.0] - 2022-07-21
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ ignore:
   - ".github"
   - ".gitignore"
 
-codecov:
+coverage:
   status:
     project:
       default:


### PR DESCRIPTION
Following the [documentation][1], this is clearly intended to be the
[`coverage` section][2]. The file is now valid [as per the codecov
API][3].

[1]: https://docs.codecov.com/docs/codecovyml-reference
[2]: https://docs.codecov.com/docs/codecovyml-reference#coverage
[3]: https://docs.codecov.com/docs/codecov-yaml#validate-your-repository-yaml

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
