### PR TITLE
Address warnings issued by new rust release.

### DIFF
--- a/client/display/table_builder.rs
+++ b/client/display/table_builder.rs
@@ -189,7 +189,7 @@ impl<'a> TableBuilder<'a> {
             }
 
             if self.id {
-                row.add_cell(Cell::new(&task.id));
+                row.add_cell(Cell::new(task.id));
             }
 
             if self.status {
@@ -242,7 +242,7 @@ impl<'a> TableBuilder<'a> {
             }
 
             if self.label {
-                row.add_cell(Cell::new(&task.label.as_deref().unwrap_or_default()));
+                row.add_cell(Cell::new(task.label.as_deref().unwrap_or_default()));
             }
 
             // Add command and path.

--- a/daemon/lib.rs
+++ b/daemon/lib.rs
@@ -111,7 +111,7 @@ pub async fn run(config_path: Option<PathBuf>, profile: Option<String>, test: bo
 fn init_directories(pueue_dir: &Path) -> Result<()> {
     // Pueue base path
     if !pueue_dir.exists() {
-        create_dir_all(&pueue_dir).map_err(|err| {
+        create_dir_all(pueue_dir).map_err(|err| {
             Error::IoPathError(pueue_dir.to_path_buf(), "creating main directory", err)
         })?;
     }

--- a/daemon/pid.rs
+++ b/daemon/pid.rs
@@ -12,7 +12,7 @@ use pueue_lib::process_helper::process_exists;
 fn check_for_running_daemon(pid_path: &Path) -> Result<()> {
     info!("Placing pid file at {pid_path:?}");
     let mut file =
-        File::open(&pid_path).map_err(|err| Error::IoError("opening pid file".to_string(), err))?;
+        File::open(pid_path).map_err(|err| Error::IoError("opening pid file".to_string(), err))?;
     let mut pid = String::new();
     file.read_to_string(&mut pid)
         .map_err(|err| Error::IoError("reading pid file".to_string(), err))?;

--- a/lib/src/network/secret.rs
+++ b/lib/src/network/secret.rs
@@ -37,7 +37,7 @@ pub fn init_shared_secret(path: &Path) -> Result<(), Error> {
         .take(PASSWORD_LEN)
         .collect();
 
-    let mut file = File::create(&path)
+    let mut file = File::create(path)
         .map_err(|err| Error::IoPathError(path.to_path_buf(), "creating shared secret", err))?;
     file.write_all(&secret.into_bytes())
         .map_err(|err| Error::IoPathError(path.to_path_buf(), "writing shared secret", err))?;

--- a/lib/src/settings.rs
+++ b/lib/src/settings.rs
@@ -345,7 +345,7 @@ impl Settings {
 
         // Create the config dir, if it doesn't exist yet
         if !config_dir.exists() {
-            create_dir_all(&config_dir).map_err(|err| {
+            create_dir_all(config_dir).map_err(|err| {
                 Error::IoPathError(config_dir.to_path_buf(), "creating config dir", err)
             })?;
         }

--- a/tests/client/log.rs
+++ b/tests/client/log.rs
@@ -129,7 +129,7 @@ async fn json() -> Result<()> {
 
     // Deserialize the json back to the original task BTreeMap.
     let json = String::from_utf8_lossy(&output.stdout);
-    let mut task_logs: BTreeMap<usize, TaskLog> = serde_json::from_str(&*json)
+    let mut task_logs: BTreeMap<usize, TaskLog> = serde_json::from_str(&json)
         .context(format!("Failed to deserialize json tasks: \n{json}"))?;
 
     // Get the actual BTreeMap from the daemon

--- a/tests/client/status.rs
+++ b/tests/client/status.rs
@@ -142,7 +142,7 @@ async fn json() -> Result<()> {
 
     let json = String::from_utf8_lossy(&output.stdout);
     let deserialized_state: State =
-        serde_json::from_str(&*json).context("Failed to deserialize json state")?;
+        serde_json::from_str(&json).context("Failed to deserialize json state")?;
 
     let state = get_state(shared).await?;
     assert_eq!(

--- a/tests/client/status_query.rs
+++ b/tests/client/status_query.rs
@@ -287,7 +287,7 @@ async fn filter_label(
         if operator == "%=" {
             // Make sure the label contained our filter.
             assert!(
-                label.contains(&label_filter),
+                label.contains(label_filter),
                 "Label '{label}' didn't contain filter '{label_filter}'"
             );
         } else if operator == "=" {

--- a/tests/helper/client.rs
+++ b/tests/helper/client.rs
@@ -130,7 +130,7 @@ pub fn assert_stdout_matches(
         .join("tests")
         .join("client")
         .join("snapshots")
-        .join(&name);
+        .join(name);
 
     let actual = String::from_utf8(stdout).context("Got invalid utf8 as stdout!")?;
     // Trim all trailing whitespaces from the actual stdout output.

--- a/tests/helper/daemon.rs
+++ b/tests/helper/daemon.rs
@@ -34,7 +34,7 @@ pub async fn get_pid(pid_path: &Path) -> Result<i32> {
             continue;
         }
 
-        let mut file = File::open(&pid_path).context("Couldn't open pid file")?;
+        let mut file = File::open(pid_path).context("Couldn't open pid file")?;
         let mut content = String::new();
         file.read_to_string(&mut content)
             .context("Couldn't write to file")?;


### PR DESCRIPTION
Rust 1.65.0 was released this week and clippy now [flags up needless borrows in more situations][1]. This commit addresses the new warnings.

[1]: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#enhancements

## Checklist

- [x] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
