### PR TITLE
Use new libproc functionality to list group pids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fix
 
-- Point to a new patched fork of `darwin-libproc`, as the original has been deleted.
-    This fixes the development builts for pueue on Apple platforms.
+- Switched the test suite on MacOS to use the new `libproc::processes::pids_by_type()` API to enumerate PIDs in a program group, removing the need to depend on the unmaintained darwing-librproc library. [#409](https://github.com/Nukesor/pueue/issues/409).
 
 ## [3.0.1] - 2022-12-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -126,6 +126,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -445,21 +446,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "darwin-libproc"
-version = "0.2.0"
-source = "git+https://github.com/Nukesor/darwin-libproc.git?branch=master#d783719c2f61a347a409ffe4ef1b2d893eec555a"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.2.0"
-source = "git+https://github.com/Nukesor/darwin-libproc.git?branch=master#d783719c2f61a347a409ffe4ef1b2d893eec555a"
 
 [[package]]
 name = "diff"
@@ -870,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "libproc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b799ad155d75ce914c467ee5627b62247c20d4aedbd446f821484cebf3cded7"
+checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
  "bindgen",
  "errno",
@@ -1280,7 +1266,6 @@ dependencies = [
  "byteorder",
  "chrono",
  "command-group",
- "darwin-libproc",
  "dirs",
  "libproc",
  "log",

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -62,17 +62,9 @@ winapi = { version = "0.3", features = [
 
 # Unix
 [target.'cfg(unix)'.dependencies]
+libproc = "0.13.0"
 whoami = "1"
 
 # Linux only
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.14.2", default-features = false }
-
-# Apple only
-[target.'cfg(target_vendor = "apple")'.dependencies]
-libproc = "0.12.0"
-
-[target.'cfg(target_vendor = "apple")'.dev-dependencies]
-# Fork that fixes a version conflict, see heim-rs/darwin-libproc#3
-# only used as a test dependency.
-darwin-libproc = { git = "https://github.com/Nukesor/darwin-libproc.git", branch = "master" }

--- a/pueue_lib/src/process_helper/apple.rs
+++ b/pueue_lib/src/process_helper/apple.rs
@@ -4,21 +4,3 @@ use libproc::libproc::{proc_pid, task_info};
 pub fn process_exists(pid: u32) -> bool {
     proc_pid::pidinfo::<task_info::TaskInfo>(pid.try_into().unwrap(), 0).is_ok()
 }
-
-#[cfg(test)]
-pub mod tests {
-    // TODO: swap darwin_libproc out for libproc when that project supports listing pids by
-    // group id.
-    use darwin_libproc;
-    use log::warn;
-
-    pub fn get_process_group_pids(pgrp: i32) -> Vec<i32> {
-        match darwin_libproc::pgrp_only_pids(pgrp) {
-            Err(error) => {
-                warn!("Failed to get list of processes in process group {pgrp}: {error}");
-                Vec::new()
-            }
-            Ok(processes) => processes,
-        }
-    }
-}

--- a/pueue_lib/src/process_helper/linux.rs
+++ b/pueue_lib/src/process_helper/linux.rs
@@ -10,32 +10,3 @@ pub fn process_exists(pid: u32) -> bool {
         },
     }
 }
-
-#[cfg(test)]
-pub mod tests {
-    use log::warn;
-
-    use super::process;
-
-    /// Get all processes in a process group
-    pub fn get_process_group_pids(pgrp: i32) -> Vec<i32> {
-        let all_processes = match process::all_processes() {
-            Err(error) => {
-                warn!("Failed to get full process list: {error}");
-                return Vec::new();
-            }
-            Ok(processes) => processes,
-        };
-
-        // Get all processes whose `stat` can be accessed without any errors.
-        // If the stat() result matches the process group, use the process PID.
-        all_processes
-            .into_iter()
-            .filter_map(|result| result.ok())
-            .filter_map(|process| match process.stat() {
-                Ok(stat) if stat.pgrp == pgrp => Some(process.pid),
-                _ => None,
-            })
-            .collect()
-    }
-}

--- a/pueue_lib/src/process_helper/mod.rs
+++ b/pueue_lib/src/process_helper/mod.rs
@@ -20,16 +20,12 @@ use command_group::Signal;
 mod linux;
 #[cfg(target_os = "linux")]
 pub use self::linux::process_exists;
-#[cfg(all(test, target_os = "linux"))]
-use self::linux::tests;
 
 // Apple specific process support
 #[cfg(target_vendor = "apple")]
 mod apple;
 #[cfg(target_vendor = "apple")]
 pub use self::apple::process_exists;
-#[cfg(all(test, target_vendor = "apple"))]
-use self::apple::tests;
 
 // Windows specific process handling
 #[cfg(any(target_os = "windows"))]


### PR DESCRIPTION
Replace darwin-libproc use with `libproc::processes::pids_by_type()`,
which is cross-platform. This returns pids _other than the group leader_,
so adjust the expected counts in tests down by one.

Fixes #409 

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
