### PR TITLE
Add encoding detection and conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,6 +517,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -1223,6 +1243,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "better-panic",
+ "chardetng",
  "chrono",
  "chrono-english",
  "clap",
@@ -1231,6 +1252,7 @@ dependencies = [
  "command-group",
  "crossterm",
  "ctrlc",
+ "encoding_rs",
  "env_logger",
  "handlebars",
  "log",
@@ -1264,9 +1286,11 @@ dependencies = [
  "async-trait",
  "better-panic",
  "byteorder",
+ "chardetng",
  "chrono",
  "command-group",
  "dirs",
+ "encoding_rs",
  "libproc",
  "log",
  "portpicker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ edition = "2021"
 rust-version = "1.67"
 
 [workspace.dependencies]
+chardetng = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 command-group = "2"
+encoding_rs = "0.8"
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -31,8 +31,10 @@ shell-escape = "0.1"
 simplelog = "0.12"
 tempfile = "3.3"
 
+chardetng = { workspace = true }
 chrono = { workspace = true }
 command-group = { workspace = true }
+encoding_rs = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/pueue/src/client/display/log/remote.rs
+++ b/pueue/src/client/display/log/remote.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use comfy_table::*;
 use snap::read::FrameDecoder;
 
-use pueue_lib::network::message::TaskLogMessage;
+use pueue_lib::{
+    log::{copy_with_conversion_to_utf8, detect_encoding},
+    network::message::TaskLogMessage,
+};
 
 use super::OutputStyle;
 
@@ -36,11 +39,16 @@ pub fn print_remote_log(task_log: &TaskLogMessage, style: &OutputStyle, lines: O
 /// Right now, the output is compressed in the daemon and sent as a single payload to the
 /// client. In here, we take that payload, decompress it and stream it it directly to stdout.
 fn decompress_and_print_remote_log(bytes: &[u8]) -> Result<()> {
-    let mut decompressor = FrameDecoder::new(bytes);
-
     let stdout = io::stdout();
     let mut write = stdout.lock();
-    io::copy(&mut decompressor, &mut write)?;
+    let encoding = detect_encoding(&mut FrameDecoder::new(bytes))?;
+    copy_with_conversion_to_utf8(
+        // We need another FrameDecoder because `detect_encoding`
+        // advances the reader
+        &mut FrameDecoder::new(bytes),
+        &mut write,
+        encoding.new_decoder(),
+    )?;
 
     Ok(())
 }

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -31,7 +31,9 @@ shellexpand = "3.0"
 thiserror = "1.0"
 tokio-rustls = { version = "0.23", default-features = false }
 
+chardetng = { workspace = true }
 command-group = { workspace = true }
+encoding_rs = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
This PR adds the ability to detect character encoding of task logs and convert them to UTF-8.

It would fix #417 

## Checklist

- [x] I picked the correct source and target branch.
- [ ] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
