### PR TITLE
fix: flush stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Fixed
+
+- Fixed changes to stdout not being printed after each I/O copy when using `pueue follow`.
+
 ## [3.1.2] - unreleased
 
 ## Fixed

--- a/pueue/src/client/display/follow.rs
+++ b/pueue/src/client/display/follow.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 use std::path::Path;
 use std::time::Duration;
 
@@ -64,6 +64,11 @@ pub async fn follow_local_task_logs(
         // Read the next chunk of text from the last position.
         if let Err(err) = io::copy(&mut handle, &mut stdout) {
             println!("Error while reading file: {err}");
+            return Ok(());
+        };
+        // Flush the stdout buffer to actually print the output.
+        if let Err(err) = stdout.flush() {
+            println!("Error while flushing stdout: {err}");
             return Ok(());
         };
 


### PR DESCRIPTION
Thanks for sending a pull request!
Here's some info on how development works in this project:

The `main` branch is the version of the last release. \
`patch` level PRs, for example bugs or critical library updates, should be merged into `main` directly. \
A new `patch` release is usually published shortly after the PR is accepted.

New features should branch of the `development` branch. \

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.

## Experiment

Previously, `stdout`s from between `pueue follow` and `pueue log` are different. `pueue log` prints a line more than `pueue follow` when the last line is still being produced.

I have made an experiment to proof the idea that it is `io::Stdout` not flushing the inner buffer:

```rust
#[cfg(test)]
mod tests {
    use std::{
        io::{self, Write},
        thread,
    };

    #[test]
    fn wo_flush() {
        let mut stdout = io::stdout();

        loop {
            stdout.write(b".").unwrap();

            thread::sleep(std::time::Duration::from_secs(1));
        }
    }

    #[test]
    fn with_flush() {
        let mut stdout = io::stdout();

        loop {
            stdout.write(b".").unwrap();
            stdout.flush().unwrap();

            thread::sleep(std::time::Duration::from_secs(1));
        }
    }
}
```

The `with_flush` test case prints `.` once every second but `wo_flush` does not.
