### PR TITLE
add: make shell command configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - QoL improvement: Don't pause groups if there're no queued tasks. [#452](https://github.com/Nukesor/pueue/issues/452)
   Auto-pausing of groups was only done to prevent the unwanted execution of other tasks, but this isn't necessary, if there're no queued tasks.
 
+### Added
+
+- Allow configuration of the shell command that executes task commands. [#454](https://github.com/Nukesor/pueue/issues/454)
+
 ## [3.2.0] - 2023-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Allow configuration of the shell command that executes task commands. [#454](https://github.com/Nukesor/pueue/issues/454)
+- Allow injection of hard coded environment variables via config file. [#454](https://github.com/Nukesor/pueue/issues/454)
 
 ## [3.2.0] - 2023-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Allow configuration of the shell command that executes task commands. [#454](https://github.com/Nukesor/pueue/issues/454)
-- Allow injection of hard coded environment variables via config file. [#454](https://github.com/Nukesor/pueue/issues/454)
+The two following features are very new and marked as "experimental" for the time being.
+They might be reworked in a later release, since working with shells is always tricky and this definitely need more testing.
+
+- Experimental: Allow configuration of the shell command that executes task commands. [#454](https://github.com/Nukesor/pueue/issues/454)
+- Experimental: Allow injection of hard coded environment variables via config file. [#454](https://github.com/Nukesor/pueue/issues/454)
 
 ## [3.2.0] - 2023-06-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "chrono",
  "command-group",
  "dirs",
+ "handlebars",
  "libproc",
  "log",
  "portpicker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "pueue-lib"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ snap = "1.1"
 strum = "0.25"
 strum_macros = "0.25"
 tokio = { version = "1.32", features = ["rt-multi-thread", "time", "io-std"] }
+handlebars = "4.3"
 
 # Dev dependencies
 anyhow = "1"

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -24,7 +24,6 @@ clap_complete = "4.3"
 comfy-table = "7"
 crossterm = { version = "0.26", default-features = false }
 ctrlc = { version = "3", features = ["termination"] }
-handlebars = "4.3"
 pest = "2.7"
 pest_derive = "2.7"
 shell-escape = "0.1"
@@ -33,6 +32,7 @@ tempfile = "3"
 
 chrono = { workspace = true }
 command-group = { workspace = true }
+handlebars = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-pueue-lib = { version = "0.23.0", path = "../pueue_lib" }
+pueue-lib = { version = "0.24.0", path = "../pueue_lib" }
 
 anyhow = "1.0"
 chrono-english = "0.1"

--- a/pueue/src/bin/pueue.rs
+++ b/pueue/src/bin/pueue.rs
@@ -62,16 +62,6 @@ async fn main() -> Result<()> {
         settings.load_profile(profile)?;
     }
 
-    #[allow(deprecated)]
-    if settings.daemon.groups.is_some() {
-        println!(
-            "Please delete the 'daemon.groups' section from your config file.
-            Run `pueue -vv` to see where your config is located.\n\
-            It is no longer used and groups can now only be edited via the commandline interface.\n\n\
-            Attention: The first time the daemon is restarted this update, the amount of parallel tasks per group will be reset to 1!!"
-        )
-    }
-
     // Error if no configuration file can be found, as this is an indicator, that the daemon hasn't
     // been started yet.
     if !config_found {

--- a/pueue/src/client/client.rs
+++ b/pueue/src/client/client.rs
@@ -199,7 +199,15 @@ impl Client {
                 path,
                 label,
             } => {
-                let message = edit(&mut self.stream, *task_id, *command, *path, *label).await?;
+                let message = edit(
+                    &mut self.stream,
+                    &self.settings,
+                    *task_id,
+                    *command,
+                    *path,
+                    *label,
+                )
+                .await?;
                 self.handle_response(message)?;
                 Ok(true)
             }
@@ -231,6 +239,7 @@ impl Client {
                     (self.settings.client.restart_in_place || *in_place) && !*not_in_place;
                 restart(
                     &mut self.stream,
+                    &self.settings,
                     task_ids.clone(),
                     *all_failed,
                     failed_in_group.clone(),

--- a/pueue/src/client/commands/edit.rs
+++ b/pueue/src/client/commands/edit.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
+use pueue_lib::settings::Settings;
 use tempfile::NamedTempFile;
 
 use pueue_lib::network::message::*;
@@ -18,6 +19,7 @@ use pueue_lib::process_helper::compile_shell_command;
 /// Upon exiting the text editor, the line will then be read and sent to the server
 pub async fn edit(
     stream: &mut GenericStream,
+    settings: &Settings,
     task_id: usize,
     edit_command: bool,
     edit_path: bool,
@@ -41,6 +43,7 @@ pub async fn edit(
 
     // Edit all requested properties.
     let edit_result = edit_task_properties(
+        settings,
         &init_response.command,
         &init_response.path,
         &init_response.label,
@@ -100,6 +103,7 @@ pub struct EditedProperties {
 ///
 /// The returned values are: `(command, path, label)`
 pub fn edit_task_properties(
+    settings: &Settings,
     original_command: &str,
     original_path: &Path,
     original_label: &Option<String>,
@@ -111,7 +115,7 @@ pub fn edit_task_properties(
 
     // Update the command if requested.
     if edit_command {
-        props.command = Some(edit_line(original_command)?);
+        props.command = Some(edit_line(settings, original_command)?);
     };
 
     // Update the path if requested.
@@ -119,13 +123,13 @@ pub fn edit_task_properties(
         let str_path = original_path
             .to_str()
             .context("Failed to convert task path to string")?;
-        let changed_path = edit_line(str_path)?;
+        let changed_path = edit_line(settings, str_path)?;
         props.path = Some(PathBuf::from(changed_path));
     }
 
     // Update the label if requested.
     if edit_label {
-        let edited_label = edit_line(&original_label.clone().unwrap_or_default())?;
+        let edited_label = edit_line(settings, &original_label.clone().unwrap_or_default())?;
 
         // If the user deletes the label in their editor, an empty string will be returned.
         // This is an indicator that the task should no longer have a label, in which case we
@@ -143,7 +147,7 @@ pub fn edit_task_properties(
 /// This function enables the user to edit a task's details.
 /// Save any string to a temporary file, which is opened in the specified `$EDITOR`.
 /// As soon as the editor is closed, read the file content and return the line.
-fn edit_line(line: &str) -> Result<String> {
+fn edit_line(settings: &Settings, line: &str) -> Result<String> {
     // Create a temporary file with the command so we can edit it with the editor.
     let mut file = NamedTempFile::new().expect("Failed to create a temporary file");
     writeln!(file, "{line}").context("Failed to write to temporary file.")?;
@@ -158,7 +162,7 @@ fn edit_line(line: &str) -> Result<String> {
     // We escape the file path for good measure, but it shouldn't be necessary.
     let path = shell_escape::escape(file.path().to_string_lossy());
     let editor_command = format!("{editor} {path}");
-    let status = compile_shell_command(&editor_command)
+    let status = compile_shell_command(settings, &editor_command)
         .status()
         .context("Editor command did somehow fail. Aborting.")?;
 

--- a/pueue/src/client/commands/restart.rs
+++ b/pueue/src/client/commands/restart.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 
 use pueue_lib::network::message::*;
 use pueue_lib::network::protocol::*;
+use pueue_lib::settings::Settings;
 use pueue_lib::state::FilteredTasks;
 use pueue_lib::task::{Task, TaskResult, TaskStatus};
 
@@ -16,6 +17,7 @@ use crate::client::commands::get_state;
 #[allow(clippy::too_many_arguments)]
 pub async fn restart(
     stream: &mut GenericStream,
+    settings: &Settings,
     task_ids: Vec<usize>,
     all_failed: bool,
     failed_in_group: Option<String>,
@@ -85,6 +87,7 @@ pub async fn restart(
 
         // Edit any properties, if requested.
         let edited_props = edit_task_properties(
+            settings,
             &task.command,
             &task.path,
             &task.label,

--- a/pueue/src/daemon/mod.rs
+++ b/pueue/src/daemon/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use std::{fs::create_dir_all, path::PathBuf};
 
 use anyhow::{bail, Context, Result};
-use log::{error, warn};
+use log::warn;
 use std::sync::mpsc::channel;
 
 use pueue_lib::error::Error;
@@ -50,16 +50,6 @@ pub async fn run(config_path: Option<PathBuf>, profile: Option<String>, test: bo
     // Load any requested profile.
     if let Some(profile) = &profile {
         settings.load_profile(profile)?;
-    }
-
-    #[allow(deprecated)]
-    if settings.daemon.groups.is_some() {
-        error!(
-            "Please delete the 'daemon.groups' section from your config file.
-            Run `pueue -vv` to see where your config is located.\n\
-            It is no longer used and groups can now only be edited via the commandline interface. \n\n\
-            Attention: The first time the daemon is restarted this update, the amount of parallel tasks per group will be reset to 1!!"
-        )
     }
 
     init_directories(&settings.shared.pueue_directory())?;

--- a/pueue/src/daemon/task_handler/callback.rs
+++ b/pueue/src/daemon/task_handler/callback.rs
@@ -20,7 +20,7 @@ impl TaskHandler {
             }
         };
 
-        let mut command = compile_shell_command(&callback_command);
+        let mut command = compile_shell_command(&self.settings, &callback_command);
 
         // Spawn the callback subprocess and log if it fails.
         let spawn_result = command.spawn();

--- a/pueue/src/daemon/task_handler/spawn_task.rs
+++ b/pueue/src/daemon/task_handler/spawn_task.rs
@@ -135,7 +135,7 @@ impl TaskHandler {
         };
 
         // Build the shell command that should be executed.
-        let mut command = compile_shell_command(&command);
+        let mut command = compile_shell_command(&self.settings, &command);
 
         // Determine the worker's id depending on the current group.
         // Inject that info into the environment.

--- a/pueue/tests/helper/fixtures.rs
+++ b/pueue/tests/helper/fixtures.rs
@@ -139,36 +139,24 @@ pub fn daemon_base_setup() -> Result<(Settings, TempDir)> {
         pueue_directory: Some(tempdir_path.to_path_buf()),
         runtime_directory: Some(tempdir_path.to_path_buf()),
         alias_file: Some(tempdir_path.join("pueue_aliases.yml")),
-        #[cfg(not(target_os = "windows"))]
-        use_unix_socket: true,
-        #[cfg(not(target_os = "windows"))]
-        unix_socket_path: None,
-        pid_path: None,
         host: "localhost".to_string(),
         port: "51230".to_string(),
         daemon_cert: Some(tempdir_path.join("certs").join("daemon.cert")),
         daemon_key: Some(tempdir_path.join("certs").join("daemon.key")),
         shared_secret_path: Some(tempdir_path.join("secret")),
+        ..Default::default()
     };
 
     let client = Client {
-        restart_in_place: false,
-        read_local_logs: true,
-        show_confirmation_questions: false,
-        show_expanded_aliases: false,
-        dark_mode: false,
         max_status_lines: Some(15),
-        status_time_format: "%H:%M:%S".into(),
         status_datetime_format: "%Y-%m-%d %H:%M:%S".into(),
+        ..Default::default()
     };
 
     #[allow(deprecated)]
     let daemon = Daemon {
-        pause_group_on_failure: false,
-        pause_all_on_failure: false,
-        callback: None,
         callback_log_lines: 15,
-        groups: None,
+        ..Default::default()
     };
 
     let settings = Settings {

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -6,18 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres **somewhat** to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The concept of SemVer is applied to the daemon/client API, but not the library API itself.
 
-## [0.23.0] - unreleased
+## [0.24.0] - 2023-06-13
+
+### Added
+
+- New setting `daemon.shell_command` to configure how the command shall be executed.
+- New setting `daemon.env_vars` to inject hard coded environment variables into the process.
 
 ### Changed
 
 - Refactor `State::filter_*` functions to return proper type.
 
-## [0.22.0] - 2023-06-13
+## [0.23.0] - 2023-06-13
 
-## Added
+### Added
 
 - Add `priority` field to `Task`
 - Remove `tempdir` dependency
+
+## [0.22.0]
+
+This version was skipped due to a error during release :).
+
 
 ## [0.21.3] - 2023-02-12
 

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pueue-lib"
-version = "0.23.0"
+version = "0.24.0"
 description = "The shared library to work with the Pueue client and daemon."
 keywords = ["pueue"]
 readme = "README.md"

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "1.0"
 tokio-rustls = { version = "0.24", default-features = false }
 
 command-group = { workspace = true }
+handlebars = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/pueue_lib/src/process_helper/mod.rs
+++ b/pueue_lib/src/process_helper/mod.rs
@@ -99,5 +99,14 @@ pub fn compile_shell_command(settings: &Settings, command: &str) -> Command {
         command.arg(&arg);
     }
 
+    // Inject custom environment variables.
+    if !settings.daemon.env_vars.is_empty() {
+        log::info!(
+            "Inject environment variables: {:?}",
+            &settings.daemon.env_vars
+        );
+        command.envs(&settings.daemon.env_vars);
+    }
+
     command
 }

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -11,7 +11,7 @@ use crate::error::Error;
 use crate::setting_defaults::*;
 
 /// All settings which are used by both, the client and the daemon
-#[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub struct Shared {
     /// Don't access this property directly, but rather use the getter with the same name.
     /// It's only public to allow proper integration testing.
@@ -74,7 +74,7 @@ pub struct Shared {
 }
 
 /// All settings which are used by the client
-#[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub struct Client {
     /// If set to true, all tasks will be restart in place, instead of creating a new task.
     /// False is the default, as you'll lose the logs of the previously failed tasks when
@@ -106,7 +106,7 @@ pub struct Client {
 }
 
 /// All settings which are used by the daemon
-#[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub struct Daemon {
     /// Whether a group should be paused as soon as a single task fails
     #[serde(default = "Default::default")]
@@ -128,34 +128,58 @@ pub struct Daemon {
     pub groups: Option<HashMap<String, i64>>,
 }
 
-impl Default for Settings {
+impl Default for Shared {
     fn default() -> Self {
-        Settings {
-            client: Client {
-                read_local_logs: true,
-                status_time_format: default_status_time_format(),
-                status_datetime_format: default_status_datetime_format(),
-                ..Default::default()
-            },
-            daemon: Daemon {
-                callback_log_lines: default_callback_log_lines(),
-                ..Default::default()
-            },
-            shared: Shared {
-                #[cfg(not(target_os = "windows"))]
-                use_unix_socket: true,
-                host: default_host(),
-                port: default_port(),
-                ..Default::default()
-            },
-            profiles: HashMap::new(),
+        Shared {
+            pueue_directory: None,
+            runtime_directory: None,
+            alias_file: None,
+
+            #[cfg(not(target_os = "windows"))]
+            unix_socket_path: None,
+            #[cfg(not(target_os = "windows"))]
+            use_unix_socket: true,
+            host: default_host(),
+            port: default_port(),
+
+            pid_path: None,
+            daemon_cert: None,
+            daemon_key: None,
+            shared_secret_path: None,
+        }
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Client {
+            restart_in_place: false,
+            read_local_logs: true,
+            show_confirmation_questions: false,
+            show_expanded_aliases: false,
+            dark_mode: false,
+            max_status_lines: None,
+            status_time_format: default_status_time_format(),
+            status_datetime_format: default_status_datetime_format(),
+        }
+    }
+}
+
+impl Default for Daemon {
+    fn default() -> Self {
+        Daemon {
+            pause_group_on_failure: false,
+            pause_all_on_failure: false,
+            callback: None,
+            callback_log_lines: default_callback_log_lines(),
+            groups: None,
         }
     }
 }
 
 /// The parent settings struct. \
 /// This contains all other setting structs.
-#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Default, Debug, Deserialize, Serialize)]
 pub struct Settings {
     #[serde(default = "Default::default")]
     pub client: Client,

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -119,6 +119,15 @@ pub struct Daemon {
     /// The amount of log lines from stdout/stderr that are passed to the callback command.
     #[serde(default = "default_callback_log_lines")]
     pub callback_log_lines: usize,
+    /// The command that should be used for task and callback execution.
+    /// The following are the only officially supported modi for Pueue.
+    ///
+    /// Unix default:
+    /// `vec!["sh", "-c", "{{ pueue_command_string }}"]`.
+    ///
+    /// Windows default:
+    /// `vec!["powershell", "-c", "[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8; {{ pueue_command_string }}"]`
+    pub shell_command: Option<Vec<String>>,
 }
 
 impl Default for Shared {
@@ -165,6 +174,7 @@ impl Default for Daemon {
             pause_all_on_failure: false,
             callback: None,
             callback_log_lines: default_callback_log_lines(),
+            shell_command: None,
         }
     }
 }

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -116,6 +116,9 @@ pub struct Daemon {
     pub pause_all_on_failure: bool,
     /// The callback that's called whenever a task finishes.
     pub callback: Option<String>,
+    /// Enironment variables that can be will be injected into all executed processes.
+    #[serde(default = "Default::default")]
+    pub env_vars: HashMap<String, String>,
     /// The amount of log lines from stdout/stderr that are passed to the callback command.
     #[serde(default = "default_callback_log_lines")]
     pub callback_log_lines: usize,
@@ -175,6 +178,7 @@ impl Default for Daemon {
             callback: None,
             callback_log_lines: default_callback_log_lines(),
             shell_command: None,
+            env_vars: HashMap::new(),
         }
     }
 }

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -119,13 +119,6 @@ pub struct Daemon {
     /// The amount of log lines from stdout/stderr that are passed to the callback command.
     #[serde(default = "default_callback_log_lines")]
     pub callback_log_lines: usize,
-    /// The legacy configuration for groups
-    #[serde(skip_serializing)]
-    #[deprecated(
-        since = "1.1.0",
-        note = "The configuration for groups is now stored in the state."
-    )]
-    pub groups: Option<HashMap<String, i64>>,
 }
 
 impl Default for Shared {
@@ -172,7 +165,6 @@ impl Default for Daemon {
             pause_all_on_failure: false,
             callback: None,
             callback_log_lines: default_callback_log_lines(),
-            groups: None,
         }
     }
 }

--- a/pueue_lib/tests/settings_backward_compatibility.rs
+++ b/pueue_lib/tests/settings_backward_compatibility.rs
@@ -23,14 +23,10 @@ fn test_restore_from_old_state() -> Result<()> {
         .join("v0.15.0_settings.yml");
 
     // Open v0.15.0 file and ensure the settings file can be read.
-    let (settings, config_found) = Settings::read(&Some(old_settings_path))
+    let (_settings, config_found) = Settings::read(&Some(old_settings_path))
         .context("Failed to read old config with defaults:")?;
 
     assert!(config_found);
-    // Legacy group setting exists
-    #[allow(deprecated)]
-    let groups = settings.daemon.groups.unwrap();
-    assert_eq!(*groups.get("webhook").unwrap(), 1);
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #454
Fixes #363 

This is waiting for some people to actually test this.

I would like to see some tests for:

- [x] Bash
- [x] Zsh ( if it's possible)
- [ ] Oilshell
- [ ] Fish
- [x] Nushell 
- [x] Powershell

However, the more the merrier.

How to test:

```sh
cd /tmp
git clone git@github.com:nukesor/pueue
cd pueue
git switch configurable-shell
cargo install --path pueue
```

For bash, add this to your daemon settings section:
```yml
  shell_command: [
    "bash",
    "-c",
    "shopt -s expand_aliases && {{ pueue_command_string }}",
  ]
  env_vars:
    BASH_ENV: "/path/to/aliases_file"
```

For zsh, add this:
```yml
  shell_command: [
    "zsh",
    "-c",
    ". /path/to/aliases_file; setopt aliases; eval {{ pueue_command_string }}",
  ]
```


Make sure to restart your daemon!