### PR TITLE
Include priority in `Task` debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Include priority in `Task`s' `Debug` output
+
 ## [3.3.3] - 2024-01-04
 
 ### Fixed

--- a/pueue_lib/src/task.rs
+++ b/pueue_lib/src/task.rs
@@ -191,6 +191,7 @@ impl std::fmt::Debug for Task {
             .field("prev_status", &self.prev_status)
             .field("start", &self.start)
             .field("end", &self.end)
+            .field("priority", &self.priority)
             .finish()
     }
 }


### PR DESCRIPTION
Working on #490, I noticed that the `Debug` impl of `Task` does not print the `priority` field. 

## Checklist

- [x] I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
