### PR TITLE
fix: make graceful daemon shutdown exit with code 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix reading of configuration files that lacks a `shared` section.
 
+- Made the daemon exit gracefully (exit code 0) on SIGINT and SIGTEM.
+
 ## [3.3.3] - 2024-01-04
 
 ### Fixed

--- a/pueue/src/daemon/mod.rs
+++ b/pueue/src/daemon/mod.rs
@@ -145,7 +145,7 @@ fn setup_signal_panic_handling(settings: &Settings, sender: &TaskSender) -> Resu
     ctrlc::set_handler(move || {
         // Notify the task handler
         sender_clone
-            .send(Shutdown::Emergency)
+            .send(Shutdown::Graceful)
             .expect("Failed to send Message to TaskHandler on Shutdown");
     })?;
 

--- a/pueue/tests/daemon/integration/shutdown.rs
+++ b/pueue/tests/daemon/integration/shutdown.rs
@@ -21,7 +21,7 @@ async fn test_ctrlc() -> Result<()> {
     let result = child.try_wait();
     assert!(matches!(result, Ok(Some(_))));
     let code = result.unwrap().unwrap();
-    assert!(matches!(code.code(), Some(1)));
+    assert!(matches!(code.code(), Some(0)));
 
     Ok(())
 }


### PR DESCRIPTION
## Description

When shutting down pueued using SIGINT or SIGTERM then the exit code should be zero. This is necessary, for example, when running as a systemd service since systemd will otherwise put the service in a failed state whenever it shuts down.

I'm not sure why it is currently exiting with an error-code. Maybe it is for some good reason? But looking at the code comments it definitely mentions exiting _gracefully_, which I would interpret as exit code 0.

## Checklist

- [X] I _think_ I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [x] (If applicable) I checked if anything in the wiki needs to be changed.
