### PR TITLE
fix: handle settings with missing `shared` section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Include priority in `Task`s' `Debug` output
 
+- Fix reading of configuration files that lacks a `shared` section.
+
 ## [3.3.3] - 2024-01-04
 
 ### Fixed

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -194,6 +194,7 @@ pub struct Settings {
     pub client: Client,
     #[serde(default = "Default::default")]
     pub daemon: Daemon,
+    #[serde(default = "Default::default")]
     pub shared: Shared,
     #[serde(default = "HashMap::new")]
     pub profiles: HashMap<String, NestedSettings>,


### PR DESCRIPTION
## Description

This allows configuration files without a `shared` field, using the default value if missing.

Before:

    $ pueued -vv -c /dev/null
    Error: Error while reading configuration.

    Caused by:
        Error while reading configuration:
        missing field `shared`

After:

    $ pueued -vv -c /dev/null
    21:12:26 [INFO] Restoring state
    21:12:26 [INFO] Using unix socket at: "/run/user/1000/pueue_rycee.socket"

## Checklist

- [x] I _think_ I picked the correct source and target branch.
- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
