### PR TITLE
Feature: add shell completions for `nushell`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Nushell autocompletion script [#527](https://github.com/Nukesor/pueue/pull/527)
+
 ## [3.4.0] - 2024-03-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0e48e026ce7df2040239117d25e4e79714907420c70294a5ce4b6bbe6a7b6"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1197,7 @@ dependencies = [
  "chrono-english",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "comfy-table",
  "command-group",
  "crossterm",

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -18,8 +18,9 @@ maintenance = { status = "actively-developed" }
 anyhow = "1.0"
 chrono = { workspace = true }
 chrono-english = "0.1"
-clap = { version = "4.3", features = ["derive", "cargo", "help"] }
-clap_complete = "4.3"
+clap = { version = "4.5.1", features = ["derive", "cargo", "help"] }
+clap_complete = "4.5.1"
+clap_complete_nushell = "4.5.1"
 comfy-table = "7"
 command-group = { workspace = true }
 ctrlc = { version = "3", features = ["termination"] }

--- a/pueue/src/bin/pueue.rs
+++ b/pueue/src/bin/pueue.rs
@@ -110,6 +110,12 @@ fn create_shell_completion_file(shell: &Shell, output_directory: &Option<PathBuf
                 generate_to(shells::PowerShell, &mut app, "pueue", output_directory)
             }
             Shell::Zsh => generate_to(shells::Zsh, &mut app, "pueue", output_directory),
+            Shell::Nushell => generate_to(
+                clap_complete_nushell::Nushell,
+                &mut app,
+                "pueue",
+                output_directory,
+            ),
         };
         completion_result.context(format!("Failed to generate completions for {shell:?}"))?;
 
@@ -125,6 +131,12 @@ fn create_shell_completion_file(shell: &Shell, output_directory: &Option<PathBuf
                 generate_to(shells::PowerShell, &mut app, "pueue", output_directory)
             }
             Shell::Zsh => generate_to(shells::Zsh, &mut app, "pueue", output_directory),
+            Shell::Nushell => generate_to(
+                clap_complete_nushell::Nushell,
+                &mut app,
+                "pueue",
+                output_directory,
+            ),
         };
         completion_result.context(format!("Failed to generate completions for {shell:?}"))?;
 
@@ -139,6 +151,12 @@ fn create_shell_completion_file(shell: &Shell, output_directory: &Option<PathBuf
         Shell::Fish => generate(shells::Fish, &mut app, "pueue", &mut stdout),
         Shell::PowerShell => generate(shells::PowerShell, &mut app, "pueue", &mut stdout),
         Shell::Zsh => generate(shells::Zsh, &mut app, "pueue", &mut stdout),
+        Shell::Nushell => generate(
+            clap_complete_nushell::Nushell,
+            &mut app,
+            "pueue",
+            &mut stdout,
+        ),
     };
 
     Ok(())

--- a/pueue/src/bin/pueue.rs
+++ b/pueue/src/bin/pueue.rs
@@ -122,27 +122,6 @@ fn create_shell_completion_file(shell: &Shell, output_directory: &Option<PathBuf
         return Ok(());
     }
 
-    if let Some(output_directory) = output_directory {
-        let completion_result = match shell {
-            Shell::Bash => generate_to(shells::Bash, &mut app, "pueue", output_directory),
-            Shell::Elvish => generate_to(shells::Elvish, &mut app, "pueue", output_directory),
-            Shell::Fish => generate_to(shells::Fish, &mut app, "pueue", output_directory),
-            Shell::PowerShell => {
-                generate_to(shells::PowerShell, &mut app, "pueue", output_directory)
-            }
-            Shell::Zsh => generate_to(shells::Zsh, &mut app, "pueue", output_directory),
-            Shell::Nushell => generate_to(
-                clap_complete_nushell::Nushell,
-                &mut app,
-                "pueue",
-                output_directory,
-            ),
-        };
-        completion_result.context(format!("Failed to generate completions for {shell:?}"))?;
-
-        return Ok(());
-    }
-
     // Print the completion file to stdout
     let mut stdout = std::io::stdout();
     match shell {

--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -528,6 +528,7 @@ pub enum Shell {
     Fish,
     PowerShell,
     Zsh,
+    Nushell,
 }
 
 #[derive(Parser, Debug)]

--- a/pueue/tests/client/integration/completions.rs
+++ b/pueue/tests/client/integration/completions.rs
@@ -16,7 +16,7 @@ use rstest::rstest;
 fn autocompletion_generation(#[case] shell: &'static str) -> Result<()> {
     let output = Command::cargo_bin("pueue")?
         .arg("completions")
-        .arg("zsh")
+        .arg(shell)
         .arg("./")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/pueue/tests/client/integration/completions.rs
+++ b/pueue/tests/client/integration/completions.rs
@@ -11,6 +11,7 @@ use rstest::rstest;
 #[case("bash")]
 #[case("fish")]
 #[case("power-shell")]
+#[case("nushell")]
 #[test]
 fn autocompletion_generation(#[case] shell: &'static str) -> Result<()> {
     let output = Command::cargo_bin("pueue")?


### PR DESCRIPTION
## Rationale
pueue recommended as a ~~temporary workaround~~ solution for background task spawning for nushell users.

It would be nice to have shell completions within nushell.

## Usage
Currently nushell has no preferred way to install completion files into system: https://github.com/nushell/nushell/issues/11337

One possible way of doing this could be:

1) generate completions

```nushell
mkdir /usr/share/nushell-completions/pueue/
pueue completions nushell /usr/share/nushell-completions/pueue/
mv /usr/share/nushell-completions/pueue/pueue.nu /usr/share/nushell-completions/pueue/mod.nu
```

2) open nushell config

```nushell
config nu
```

3) add reference to completion file into config (at the bottom)

```text
use ~/.config/nushell/completions/pueue/ *
```

4) save config and restart the shell