### PR TITLE
Add FreeBSD process helper to facilitate FreeBSD builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - Nushell autocompletion script [#527](https://github.com/Nukesor/pueue/pull/527)
+- Add FreeBSD process helper to facilitate FreeBSD builds
 
 ## \[3.4.0\] - 2024-03-22
 

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -65,5 +65,7 @@ crossterm = { version = "0.27", default-features = false, features = ["windows"]
 # Test specific dev-dependencies
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 whoami = "1"
-procfs = { version = "0.16", default-features = false }
 
+# Test specific Linux dev-dependencies
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { version = "0.16", default-features = false }

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -67,8 +67,10 @@ winapi = { version = "0.3", features = [
 
 # Unix
 [target.'cfg(unix)'.dependencies]
-libproc = "0.14.6"
 whoami = "1"
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+libproc = "0.14.6"
 
 # Linux only
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/pueue_lib/src/process_helper/freebsd.rs
+++ b/pueue_lib/src/process_helper/freebsd.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+/// Check, whether a specific process is exists or not
+pub fn process_exists(pid: u32) -> bool {
+    return Path::new(&format!("/proc/{}", pid)).is_dir();
+}
+
+#[cfg(test)]
+pub mod tests {
+    /// Get all processes in a process group
+    pub fn get_process_group_pids(pgrp: i32) -> Vec<i32> {
+        /// TODO
+	return { };
+    }
+}

--- a/pueue_lib/src/process_helper/mod.rs
+++ b/pueue_lib/src/process_helper/mod.rs
@@ -21,6 +21,7 @@ use command_group::Signal;
 #[cfg_attr(target_os = "linux", path = "linux.rs")]
 #[cfg_attr(target_vendor = "apple", path = "apple.rs")]
 #[cfg_attr(target_os = "windows", path = "windows.rs")]
+#[cfg_attr(target_os = "freebsd", path = "freebsd.rs")]
 mod platform;
 pub use self::platform::*;
 


### PR DESCRIPTION
These patches are already part of the FreeBSD port for pueue.  Including them here will make port updates a little easier.

You can view existing applied patches [here](https://cgit.freebsd.org/ports/tree/deskutils/pueue/files).

To completely fix the build, we also need to remove procfs/libproc from the Cargo files [while building under Freebsd].  I wasn't sure on the best way to achieve this, so I am simply noting it here.

## Checklist

Please make sure the PR adheres to this project's standards:

- [X] I included a new entry to the `CHANGELOG.md`.
- [X] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.