### PR TITLE
feat: add configurable socket permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The new state design fixes this issue, which allows Pueue to do subprocess state
 - Add `--all` and `--group` to `pueue log`. [#509](https://github.com/Nukesor/pueue/issues/509)
 - Add `pueue reset --groups [group_names]` to allow resetting individual groups. [#482](https://github.com/Nukesor/pueue/issues/482) \
   This also refactors the way resets are done internally, resulting in a cleaner code architecture.
+- Ability to set the Unix socket permissions through the new `unix_socket_permissions` configuration option. [#544](https://github.com/Nukesor/pueue/pull/544)
 
 ## \[3.4.1\] - 2024-06-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/pueue/tests/daemon/integration/mod.rs
+++ b/pueue/tests/daemon/integration/mod.rs
@@ -16,6 +16,7 @@ mod restart;
 mod restore;
 /// Tests for shutting down the daemon.
 mod shutdown;
+mod socket_permissions;
 mod spawn;
 mod start;
 mod stashed;

--- a/pueue/tests/daemon/integration/socket_permissions.rs
+++ b/pueue/tests/daemon/integration/socket_permissions.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use anyhow::Context;
+
+use crate::helper::*;
+
+/// Make sure that the socket permissions are appropriately set.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_socket_permissions_default() -> Result<()> {
+    let (settings, _tempdir) = daemon_base_setup()?;
+    let shared = &settings.shared;
+    let mut child = standalone_daemon(shared).await?;
+
+    assert_eq!(
+        fs::metadata(shared.unix_socket_path())?
+            .permissions()
+            .mode()
+            // The permissions are masked with 0o777 to only get the last 3
+            // digits.
+            & 0o777,
+        0o700
+    );
+
+    child.kill()?;
+    Ok(())
+}
+
+/// Make sure that the socket permissions can be changed
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "windows"))]
+async fn test_socket_permissions_modified() -> Result<()> {
+    let (mut settings, _tempdir) = daemon_base_setup()?;
+    settings.shared.unix_socket_permissions = Some(0o777);
+    let shared = &settings.shared;
+    settings
+        .save(&Some(settings.shared.runtime_directory().join("pueue.yml")))
+        .context("Couldn't write pueue config to temporary directory")?;
+
+    let mut child = standalone_daemon(shared).await?;
+
+    assert_eq!(
+        fs::metadata(shared.unix_socket_path())?
+            .permissions()
+            .mode()
+            // The permissions are masked with 0o777 to only get the last 3
+            // digits.
+            & 0o777,
+        0o777
+    );
+
+    child.kill()?;
+    Ok(())
+}

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -46,6 +46,12 @@ pub struct Shared {
     /// The path to the unix socket.
     #[cfg(not(target_os = "windows"))]
     pub unix_socket_path: Option<PathBuf>,
+    /// Unix socket permissions. Typically specified as an octal number and
+    /// defaults to `0o700` which grants only the current user access to the
+    /// socket. For a client to connect to the daemon, the client must have
+    /// read/write permissions.
+    #[cfg(not(target_os = "windows"))]
+    pub unix_socket_permissions: Option<u32>,
 
     /// The TCP hostname/ip address.
     #[serde(default = "default_host")]
@@ -147,6 +153,8 @@ impl Default for Shared {
             unix_socket_path: None,
             #[cfg(not(target_os = "windows"))]
             use_unix_socket: true,
+            #[cfg(not(target_os = "windows"))]
+            unix_socket_permissions: Some(0o700),
             host: default_host(),
             port: default_port(),
 

--- a/pueue_lib/tests/helper.rs
+++ b/pueue_lib/tests/helper.rs
@@ -20,6 +20,8 @@ pub fn get_shared_settings(
         use_unix_socket,
         #[cfg(not(target_os = "windows"))]
         unix_socket_path: None,
+        #[cfg(not(target_os = "windows"))]
+        unix_socket_permissions: Some(0o700),
         pid_path: None,
         host: "localhost".to_string(),
         port: pick_unused_port()


### PR DESCRIPTION
## Summary

Have `pueue` set the permissions of the socket created. Previously, the permissions where unspecified and (at least for me) defaulted to `755`. The permissions can be configured through the new `unix_socket_permissions` setting.

As part of this change, the default settings are moving to `700` which is more restricted than the (possibly system-dependent) previous default. The more restricted permissions should not have any practical impact as users without write permissions would not be able to use the socket, though removing read access to others may possibly improve security.

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
