### PR TITLE
feat: support command filter on `pueue status`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ TLDR: The new task state representation is more verbose but significantly cleane
 - Add `pueue reset --groups [group_names]` to allow resetting individual groups. [#482](https://github.com/Nukesor/pueue/issues/482) \
   This also refactors the way resets are done internally, resulting in a cleaner code architecture.
 - Ability to set the Unix socket permissions through the new `unix_socket_permissions` configuration option. [#544](https://github.com/Nukesor/pueue/pull/544)
+- Add `command` filter to `pueue status`. [#524](https://github.com/Nukesor/pueue/issues/524) [#560](https://github.com/Nukesor/pueue/pull/560)
 
 ## \[3.4.1\] - 2024-06-04
 

--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -315,7 +315,7 @@ where:
   - column := `id | status | command | label | path | enqueue_at | dependencies | start | end`
   - filter := `[filter_column] [filter_op] [filter_value]`
     (note: not all columns support all operators, see \"Filter columns\" below.)
-  - filter_column := `start | end | enqueue_at | status | label`
+  - filter_column := `status | command | label | start | end | enqueue_at`
   - filter_op := `= | != | < | > | %=`
     (`%=` means 'contains', as in the test value is a substring of the column value)
   - order_by := `order_by [column] [order_direction]`
@@ -325,6 +325,12 @@ where:
   - limit_count := a positive integer
 
 Filter columns:
+  - `status` supports the operators `=`, `!=`
+    against test values that are:
+      - strings like `queued`, `stashed`, `paused`, `running`, `success`, `failed`
+  - `command`, `label` support the operators `=`, `!=`, `%=`
+    against test values that are:
+      - strings like `some text`
   - `start`, `end`, `enqueue_at` contain a datetime
     which support the operators `=`, `!=`, `<`, `>`
     against test values that are:
@@ -335,6 +341,8 @@ Filter columns:
 
 Examples:
   - `status=running`
+  - `command%=echo`
+  - `label=mytask`
   - `columns=id,status,command status=running start > 2023-05-2112:03:17 order_by command first 5`
 
 The formal syntax is defined here:

--- a/pueue/src/client/query/filters.rs
+++ b/pueue/src/client/query/filters.rs
@@ -275,8 +275,8 @@ pub fn command(section: Pair<'_, Rule>, query_result: &mut QueryResult) -> Resul
     let filter_function = Box::new(move |task: &Task| -> bool {
         let command = task.command.as_str();
         match operator {
-            Rule::eq => command == &operand,
-            Rule::neq => command != &operand,
+            Rule::eq => command == operand,
+            Rule::neq => command != operand,
             Rule::contains => command.contains(&operand),
             _ => false,
         }

--- a/pueue/src/client/query/mod.rs
+++ b/pueue/src/client/query/mod.rs
@@ -170,6 +170,7 @@ pub fn apply_query(query: &str, group: &Option<String>) -> Result<QueryResult> {
             Rule::column_selection => column_selection::apply(section, &mut query_result)?,
             Rule::datetime_filter => filters::datetime(section, &mut query_result)?,
             Rule::label_filter => filters::label(section, &mut query_result)?,
+            Rule::command_filter => filters::command(section, &mut query_result)?,
             Rule::status_filter => filters::status(section, &mut query_result)?,
             Rule::order_by_condition => order_by::order_by(section, &mut query_result)?,
             Rule::limit_condition => limit::limit(section, &mut query_result)?,

--- a/pueue/src/client/query/syntax.pest
+++ b/pueue/src/client/query/syntax.pest
@@ -46,6 +46,10 @@ status_filter = { column_status ~ (eq | neq) ~ (status_queued | status_stashed |
 label = { ANY* }
 label_filter = { column_label ~ ( eq | neq | contains ) ~ label }
 
+// Command filter
+command = { ANY* }
+command_filter = { column_command ~ ( eq | neq | contains ) ~ command }
+
 // Time related filters
 datetime = { ASCII_DIGIT{4} ~ "-" ~ ASCII_DIGIT{2} ~ "-" ~ ASCII_DIGIT{2}  ~ ASCII_DIGIT{2} ~ ":" ~ ASCII_DIGIT{2} ~ (":" ~ ASCII_DIGIT{2})? }
 date = { ASCII_DIGIT{4} ~ "-" ~ ASCII_DIGIT{2} ~ "-" ~ ASCII_DIGIT{2} }
@@ -67,4 +71,4 @@ limit_count = { ASCII_DIGIT* }
 limit_condition = { (first | last) ~ limit_count }
 
 // ----- The final query syntax -----
-query = { SOI ~ column_selection? ~ ( datetime_filter | status_filter | label_filter )*?  ~ order_by_condition? ~ limit_condition? ~ EOI }
+query = { SOI ~ column_selection? ~ ( datetime_filter | status_filter | label_filter | command_filter )*?  ~ order_by_condition? ~ limit_condition? ~ EOI }


### PR DESCRIPTION
impl #524 

example:
```
pueue add -- ls /var

pueue status command%=ls
pueue status command=ls /var
pueue status command!=ls
```

I'm not sure if spaces require special handling. In the above example, the query statement seems works fine even without escaping.

Also, I would like to discuss that other than the existing OPs (eq:`=` neq:`!=` contains:`%=`), should we further implement the semantics of `not contain`?

Thanks!

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [x] (If applicable) I checked if anything in the wiki needs to be changed.
