### PR TITLE
Add windows service functionality #344

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ TLDR: The new task state representation is more verbose but significantly cleane
 - Fixed delay after sending process related commands from client. [#548](https://github.com/Nukesor/pueue/pull/548)
 - Callback templating arguments were html escaped by accident. [#564](https://github.com/Nukesor/pueue/pull/564)
 - Print incompatible version warning info as a log message instead of plain stdout input, which broke json outputs [#562](https://github.com/Nukesor/pueue/issues/562).
+- Fixed `-d` daemon mode on Windows. [#344](https://github.com/Nukesor/pueue/issues/344)
 
 ## \[3.4.1\] - 2024-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ TLDR: The new task state representation is more verbose but significantly cleane
 - Ability to set the Unix socket permissions through the new `unix_socket_permissions` configuration option. [#544](https://github.com/Nukesor/pueue/pull/544)
 - Add `command` filter to `pueue status`. [#524](https://github.com/Nukesor/pueue/issues/524) [#560](https://github.com/Nukesor/pueue/pull/560)
 - Allow `pueue status` to order tasks by `enqueue_at`. [#554](https://github.com/Nukesor/pueue/issues/554)
+- Added Windows service on Windows to allow a true daemon experience. [#344](https://github.com/Nukesor/pueue/issues/344) [#567](https://github.com/Nukesor/pueue/pull/567)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ TLDR: The new task state representation is more verbose but significantly cleane
 - **Breaking**: Remove the `--children` commandline flags, that have been deprecated and no longer serve any function since `v3.0.0`.
 - Send log output to `stderr` instead of `stdout` [#562](https://github.com/Nukesor/pueue/issues/562).
 - Change default log level from error to warning [#562](https://github.com/Nukesor/pueue/issues/562).
+- Bumped MSRV to 1.70.
 
 ### Add
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -864,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1108,7 +1108,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.1",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1288,6 +1288,7 @@ dependencies = [
  "handlebars",
  "interim",
  "log",
+ "once_cell",
  "pest",
  "pest_derive",
  "pretty_assertions",
@@ -1308,6 +1309,8 @@ dependencies = [
  "test-log",
  "tokio",
  "whoami",
+ "windows",
+ "windows-service",
 ]
 
 [[package]]
@@ -2194,6 +2197,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,12 +2234,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags 2.5.0",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2248,7 +2332,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2268,18 +2352,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -2290,9 +2374,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2302,9 +2386,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2314,15 +2398,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2332,9 +2416,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2344,9 +2428,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2356,9 +2440,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2368,9 +2452,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,15 +232,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.20"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.28"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b378c786d3bde9442d2c6dd7e6080b2a818db2b96e30d6e7f1b6d224eb617d3"
+checksum = "8937760c3f4c60871870b8c3ee5f9b30771f792a7045c48bcbba999d7d6b3b8e"
 dependencies = [
  "clap",
 ]
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -758,7 +758,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -893,18 +893,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ceb190eb9bdeecdd8f1ad6a71d6d632a50905948771718741b5461fb01e13"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90be66cb7bd40cb5cc2e9cfaf2d1133b04a3d93b72344267715010a466e0915a"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
 dependencies = [
  "beef",
  "fnv",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45154231e8e96586b39494029e58f12f8ffcb5ecf80333a603a13aa205ea8cbd"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
 dependencies = [
  "logos-codegen",
 ]
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1106,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1129,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -1283,6 +1283,8 @@ dependencies = [
  "test-log",
  "tokio",
  "whoami",
+ "windows",
+ "windows-service",
 ]
 
 [[package]]
@@ -2030,9 +2032,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -2162,6 +2164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,11 +2201,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-service"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24d6bcc7f734a4091ecf8d7a64c5f7d7066f45585c1861eba06449909609c8a"
+dependencies = [
+ "bitflags",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,6 @@ dependencies = [
  "handlebars",
  "interim",
  "log",
- "once_cell",
  "pest",
  "pest_derive",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/nukesor/pueue"
 repository = "https://github.com/nukesor/pueue"
 license = "MIT"
 edition = "2021"
-rust-version = "1.67"
+rust-version = "1.70"
 
 [workspace.dependencies]
 # Chrono version is hard pinned to a specific version.

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -39,6 +39,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true }
+once_cell = "1.19.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -62,6 +63,8 @@ test-log = "0.2"
 crossterm = { version = "0.27", default-features = false }
 [target.'cfg(windows)'.dependencies]
 crossterm = { version = "0.27", default-features = false, features = ["windows"] }
+windows-service = "0.7.0"
+windows = { version = "0.58.0", features = ["Win32_System_RemoteDesktop", "Win32_Security", "Win32_System_Threading", "Win32_System_SystemServices", "Win32_System_Environment"] }
 
 # Test specific dev-dependencies
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -26,7 +26,6 @@ ctrlc = { version = "3", features = ["termination"] }
 handlebars = { workspace = true }
 interim = { version = "0.1.2", features = ["chrono"] }
 log = { workspace = true }
-once_cell = "1.19.0"
 pest = "2.7"
 pest_derive = "2.7"
 pueue-lib = { version = "0.26.1", path = "../pueue_lib" }

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -26,6 +26,7 @@ ctrlc = { version = "3", features = ["termination"] }
 handlebars = { workspace = true }
 interim = { version = "0.1.2", features = ["chrono"] }
 log = { workspace = true }
+once_cell = "1.19.0"
 pest = "2.7"
 pest_derive = "2.7"
 pueue-lib = { version = "0.26.1", path = "../pueue_lib" }
@@ -39,7 +40,6 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true }
-once_cell = "1.19.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/pueue/src/bin/pueued.rs
+++ b/pueue/src/bin/pueued.rs
@@ -125,7 +125,17 @@ fn fork_daemon(opt: &CliArguments) -> Result<()> {
         "pueued".to_string()
     };
 
-    Command::new(current_exe)
+    let mut command = Command::new(current_exe);
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    command
         .args(&arguments)
         .spawn()
         .expect("Failed to fork new process.");

--- a/pueue/src/bin/pueued.rs
+++ b/pueue/src/bin/pueued.rs
@@ -131,7 +131,10 @@ fn fork_daemon(opt: &CliArguments) -> Result<()> {
     {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
-
+        // create_no_window causes all children to not show a visible console window
+        // but it also apparently has the effect of DETACH_PROCESS in that it's no longer tied to
+        // the parent process
+        // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags
         command.creation_flags(CREATE_NO_WINDOW);
     }
 

--- a/pueue/src/bin/pueued.rs
+++ b/pueue/src/bin/pueued.rs
@@ -130,9 +130,9 @@ fn fork_daemon(opt: &CliArguments) -> Result<()> {
     {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
-        // create_no_window causes all children to not show a visible console window
+        // CREATE_NO_WINDOW causes all children to not show a visible console window,
         // but it also apparently has the effect of DETACH_PROCESS in that it's no longer tied to
-        // the parent process
+        // the parent processs.
         // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags
         command.creation_flags(CREATE_NO_WINDOW);
     }

--- a/pueue/src/bin/pueued.rs
+++ b/pueue/src/bin/pueued.rs
@@ -13,13 +13,12 @@ async fn main() -> Result<()> {
     let opt = CliArguments::parse();
 
     if opt.daemonize {
-        // Ordinarily this would be handled in clap, but they don't support conflicting args
-        // with subcommands
+        // Ordinarily this would be handled in clap, but they don't support conflicting specific args
+        // with subcommands. We can't turn this off globally because -c and -p are valid args when using
+        // subcommand to install the service
         #[cfg(target_os = "windows")]
         if opt.service.is_some() {
-            use clap::CommandFactory;
-            let mut cmd = CliArguments::command();
-            cmd.print_help()?;
+            println!("daemonize flag cannot be used with service subcommand");
             return Ok(());
         }
 

--- a/pueue/src/bin/pueued.rs
+++ b/pueue/src/bin/pueued.rs
@@ -131,9 +131,10 @@ fn fork_daemon(opt: &CliArguments) -> Result<()> {
         use std::os::windows::process::CommandExt;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         // CREATE_NO_WINDOW causes all children to not show a visible console window,
-        // but it also apparently has the effect of DETACH_PROCESS in that it's no longer tied to
-        // the parent processs.
+        // but it also apparently has the effect of starting a new process group.
+        //
         // https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags#flags
+        // https://stackoverflow.com/a/71364777/9423933
         command.creation_flags(CREATE_NO_WINDOW);
     }
 

--- a/pueue/src/daemon/cli.rs
+++ b/pueue/src/daemon/cli.rs
@@ -24,4 +24,23 @@ pub struct CliArguments {
     /// The name of the profile that should be loaded from your config file.
     #[arg(short, long)]
     pub profile: Option<String>,
+
+    /// Install as a Windows service.
+    /// Once installed, you must not move the binary, otherwise the Windows
+    /// service will not be able to find it. If you wish to move the binary,
+    /// first uninstall the service, then install the service again.
+    #[cfg(target_os = "windows")]
+    #[arg(long, conflicts_with_all = ["daemonize", "uninstall"])]
+    pub install: bool,
+
+    /// Uninstall the Windows service.
+    #[cfg(target_os = "windows")]
+    #[arg(long, conflicts_with_all = ["daemonize", "install"])]
+    pub uninstall: bool,
+
+    /// Start the Windows service. This command is internal and should never
+    /// be used. As a user, to manage the service, use the Windows Service Manager.
+    #[cfg(target_os = "windows")]
+    #[arg(long, conflicts_with_all = ["daemonize", "install", "uninstall"])]
+    pub service: bool,
 }

--- a/pueue/src/daemon/cli.rs
+++ b/pueue/src/daemon/cli.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+#[cfg(target_os = "windows")]
+use clap::Subcommand;
 use clap::{ArgAction, Parser, ValueHint};
 
 #[derive(Parser, Debug)]
@@ -25,22 +27,34 @@ pub struct CliArguments {
     #[arg(short, long)]
     pub profile: Option<String>,
 
+    #[cfg(target_os = "windows")]
+    #[command(subcommand)]
+    pub service: Option<ServiceSubcommandEntry>,
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Copy, Clone, Debug, Subcommand)]
+pub enum ServiceSubcommandEntry {
+    /// Manage the Windows Service.
+    #[command(subcommand)]
+    Service(ServiceSubcommand),
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Copy, Clone, Debug, Subcommand)]
+pub enum ServiceSubcommand {
+    /// Run the Windows service. This command is internal and should never
+    /// be used.
+    Run,
     /// Install as a Windows service.
     /// Once installed, you must not move the binary, otherwise the Windows
     /// service will not be able to find it. If you wish to move the binary,
     /// first uninstall the service, then install the service again.
-    #[cfg(target_os = "windows")]
-    #[arg(long, conflicts_with_all = ["daemonize", "uninstall"])]
-    pub install: bool,
-
-    /// Uninstall the Windows service.
-    #[cfg(target_os = "windows")]
-    #[arg(long, conflicts_with_all = ["daemonize", "install"])]
-    pub uninstall: bool,
-
-    /// Start the Windows service. This command is internal and should never
-    /// be used. As a user, to manage the service, use the Windows Service Manager.
-    #[cfg(target_os = "windows")]
-    #[arg(long, conflicts_with_all = ["daemonize", "install", "uninstall"])]
-    pub service: bool,
+    Install,
+    /// Uninstall the service.
+    Uninstall,
+    /// Start the service.
+    Start,
+    /// Stop the service.
+    Stop,
 }

--- a/pueue/src/daemon/cli.rs
+++ b/pueue/src/daemon/cli.rs
@@ -49,7 +49,8 @@ pub enum ServiceSubcommand {
     /// Install as a Windows service.
     /// Once installed, you must not move the binary, otherwise the Windows
     /// service will not be able to find it. If you wish to move the binary,
-    /// first uninstall the service, then install the service again.
+    /// first uninstall the service, move the binary, then install the service
+    /// again.
     Install,
     /// Uninstall the service.
     Uninstall,

--- a/pueue/src/daemon/mod.rs
+++ b/pueue/src/daemon/mod.rs
@@ -23,6 +23,8 @@ pub mod cli;
 mod network;
 mod pid;
 mod process_handler;
+#[cfg(target_os = "windows")]
+pub mod service;
 /// Contains re-usable helper functions, that operate on the pueue-lib state.
 pub mod state_helper;
 pub mod task_handler;

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -152,9 +152,7 @@ fn run_service() -> Result<()> {
 
                 ServiceControl::SessionChange(param) => {
                     match param.reason {
-                        SessionChangeReason::SessionLogon
-                        | SessionChangeReason::RemoteConnect
-                        | SessionChangeReason::SessionUnlock => {
+                        SessionChangeReason::SessionLogon => {
                             if !spawner.running() {
                                 if let Err(e) = spawner.start(Some(param.notification.session_id)) {
                                     error!("failed to spawn: {e}");

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -81,11 +81,11 @@ pub fn install_service(config_path: Option<PathBuf>, profile: Option<String>) ->
     let mut args = vec!["--service".into()];
     if let Some(config_path) = config_path {
         args.push("--config".into());
-        args.push(config_path.into_os_string());
+        args.push(format!(r#""{}""#, config_path.to_string_lossy()).into());
     }
     if let Some(profile) = profile {
         args.push("--profile".into());
-        args.push(profile.into());
+        args.push(format!(r#""{profile}""#).into());
     }
 
     let service_info = ServiceInfo {
@@ -414,7 +414,6 @@ impl Spawner {
             }
 
             Err(e) => {
-                self.request_stop.store(false, Ordering::Relaxed);
                 error!("failed to stop(): {e}");
             }
         }

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -480,7 +480,7 @@ impl Spawner {
                     .chain(iter::once(0))
                     .collect::<Vec<_>>();
 
-                command.reserve(1024 - command.len());
+                command.reserve(1024 - (command.len() / 2));
 
                 let env_block = EnvBlock::new(token.0)?;
 

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::{channel, Receiver, Sender},
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
     },
     thread,
     time::Duration,
@@ -15,7 +15,6 @@ use std::{
 
 use anyhow::{anyhow, bail, Result};
 use log::{debug, error};
-use once_cell::sync::OnceCell;
 use windows::{
     core::{PCWSTR, PWSTR},
     Win32::{
@@ -58,7 +57,7 @@ struct Config {
 
 const SERVICE_NAME: &str = "pueued";
 const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
-static CONFIG: OnceCell<Config> = OnceCell::new();
+static CONFIG: OnceLock<Config> = OnceLock::new();
 
 define_windows_service!(ffi_service_main, service_main);
 

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -297,6 +297,7 @@ fn run_as<T>(session_id: u32, cb: impl FnOnce(OwnedHandle) -> Result<T>) -> Resu
     Ok(t)
 }
 
+#[derive(Default)]
 struct OwnedHandle(HANDLE);
 
 unsafe impl Send for OwnedHandle {}
@@ -305,12 +306,6 @@ unsafe impl Sync for OwnedHandle {}
 impl OwnedHandle {
     fn is_valid(&self) -> bool {
         !self.0.is_invalid()
-    }
-}
-
-impl Default for OwnedHandle {
-    fn default() -> Self {
-        Self(HANDLE::default())
     }
 }
 
@@ -447,7 +442,7 @@ impl Spawner {
     }
 
     fn start(&self, session: Option<u32>) -> Result<()> {
-        let Some(session) = session.or_else(|| get_current_session()) else {
+        let Some(session) = session.or_else(get_current_session) else {
             bail!("get_current_session failed");
         };
 

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -211,6 +211,7 @@ fn service_event_loop() -> Result<()> {
                         debug!("event login: spawning");
                         if let Err(e) = spawner.start(Some(session)) {
                             error!("failed to spawn: {e}");
+                            return ServiceControlHandlerResult::Other(1);
                         }
                     }
 

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -1,34 +1,34 @@
 //! How Windows services (and this service) work
 //!
-//! - This service runs as SYSTEM, and survives logoff and logon.
-//! - This service launches the daemon as current user on login, and kills it on logoff
-//!   (actually it's a noop; Windows itself kills it - see below).
-//! - All user processes are auto killed by Windows on user logoff. This is not a feature
-//!   of this service, it's just how Windows does things.
+//! This service runs as SYSTEM, and survives logoff and logon. On startup/login, it launches
+//! pueued as the current user. On logoff Windows kills all user processes (including the daemon).
+//!
+//! - All install/uninstallations of the service requires you are running as admin.
 //! - You must install the service. After installed, the service entry maintains a cmdline
 //!   string with args to the pueued binary. Therefore, the binary must _not_ move while the
 //!   service is installed, otherwise it will not be able to function properly. It is best
 //!   not to rely on PATH for this, as it is finicky and a hassle for user setup. Absolute paths
 //!   are the way to go, and it is standard practice.
 //! - To move the pueued binary: Uninstall the service, move the binary, and reinstall the service.
-//! - When the service is installed, you can use pueued to start, stop, or uninstall the service.
+//! - When the service is installed, you can use pueued cli to start, stop, or uninstall the service.
 //!   You can also use the official service manager to start, stop, and restart the service.
 //! - Services are automatically started/stopped by the system according to the setting the user
 //!   sets in the windows service manager. By default we install it as autostart, but the user
 //!   can set this to manual or even disabled.
 //! - If you have the official service manager window open and you tell pueued to uninstall the
 //!   service, it will not disappear from the list until you close all service manager windows.
-//!   This is Windows specific behavior, and not a bug. (In Windows parlance, the service is pending
+//!   This is not a bug. It's Windows specific behavior. (In Windows parlance, the service is pending
 //!   deletion, and all HANDLES to the service need to be closed).
-//! - We do not support long running processes past when a user logs off; this would be
-//!   a massive security risk to allow anyone to run processes as SYSTEM. This account bypasses
-//!   even administrator in power! It is not something small to give permission to.
+//! - We do not support long running daemon past when a user logs off; this would be
+//!   a massive security risk to allow anyone to launch tasks as SYSTEM. This account bypasses
+//!   even administrator in power!
 //! - Additionally, taking the above into account, as SYSTEM is its own account, the user config
-//!   would not apply to this account. You'd have to set up special configs for the SYSTEM account,
-//!   and I'm not even sure where the SYSTEM account's appdata is stored to begin with.
-//!   (not to mention, it would be a pain for the user to setup anyways)
-//! - Is the service failing to start up? It's probably a problem with the daemon. Run `pueued`
-//!   to see the actual error.
+//!   does not apply to this account. Unless there's an exception for config locations with this case,
+//!   you'd have to set up separate configs for the SYSTEM account in
+//!   `C:\Windows\system32\config\systemprofile\AppData`. (And even if there's an exception, what if
+//!   there's multiple users? Which user's config would be used?) This is very unintuitive.
+//! - Is the service failing to start up? It's probably a problem with the daemon itself. Re-run `pueued`
+//!   by itself to see the actual startup error.
 
 use std::{
     env,

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -400,9 +400,7 @@ fn run_as<T>(session_id: u32, cb: impl FnOnce(OwnedHandle) -> Result<T>) -> Resu
         )?;
     }
 
-    let t = cb(token)?;
-
-    Ok(t)
+    cb(token)
 }
 
 /// Newtype over handle which closes the HANDLE on drop.

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -1,4 +1,4 @@
-//! How Windows services (and this file) work
+//! How Windows services (and this service) work
 //!
 //! - This service runs as SYSTEM, and survives logoff and logon.
 //! - This service launches the daemon as current user on login, and kills it on logoff
@@ -27,6 +27,8 @@
 //!   would not apply to this account. You'd have to set up special configs for the SYSTEM account,
 //!   and I'm not even sure where the SYSTEM account's appdata is stored to begin with.
 //!   (not to mention, it would be a pain for the user to setup anyways)
+//! - Is the service failing to start up? It's probably a problem with the daemon. Run `pueued`
+//!   to see the actual error.
 
 use std::{
     env,

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -1,0 +1,515 @@
+use std::{
+    env,
+    ffi::{c_void, OsString},
+    iter,
+    path::PathBuf,
+    process, ptr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    time::Duration,
+};
+
+use anyhow::{anyhow, bail, Result};
+use log::error;
+use once_cell::sync::OnceCell;
+use windows::{
+    core::{PCWSTR, PWSTR},
+    Win32::{
+        Foundation::{CloseHandle, HANDLE, LUID},
+        Security::{
+            AdjustTokenPrivileges, DuplicateTokenEx, LookupPrivilegeValueW, SecurityIdentification,
+            TokenPrimary, SECURITY_ATTRIBUTES, SE_PRIVILEGE_ENABLED, SE_PRIVILEGE_REMOVED,
+            SE_TCB_NAME, TOKEN_ACCESS_MASK, TOKEN_ADJUST_PRIVILEGES, TOKEN_PRIVILEGES,
+        },
+        System::{
+            Environment::{CreateEnvironmentBlock, DestroyEnvironmentBlock},
+            RemoteDesktop::{WTSGetActiveConsoleSessionId, WTSQueryUserToken},
+            SystemServices::MAXIMUM_ALLOWED,
+            Threading::{
+                CreateProcessAsUserW, OpenProcess, OpenProcessToken, TerminateProcess,
+                WaitForSingleObject, CREATE_NO_WINDOW, CREATE_UNICODE_ENVIRONMENT, INFINITE,
+                PROCESS_INFORMATION, PROCESS_QUERY_INFORMATION, STARTUPINFOW,
+            },
+        },
+    },
+};
+use windows_service::{
+    define_windows_service,
+    service::{
+        ServiceAccess, ServiceControl, ServiceControlAccept, ServiceErrorControl, ServiceExitCode,
+        ServiceInfo, ServiceStartType, ServiceState, ServiceStatus, ServiceType,
+        SessionChangeReason,
+    },
+    service_control_handler::{self, ServiceControlHandlerResult},
+    service_dispatcher,
+    service_manager::{ServiceManager, ServiceManagerAccess},
+};
+
+#[derive(Clone)]
+struct Config {
+    config_path: Option<PathBuf>,
+    profile: Option<String>,
+}
+
+const SERVICE_NAME: &str = "pueued";
+const SERVICE_TYPE: ServiceType = ServiceType::OWN_PROCESS;
+static CONFIG: OnceCell<Config> = OnceCell::new();
+
+define_windows_service!(ffi_service_main, service_main);
+
+pub fn start_service(config_path: Option<PathBuf>, profile: Option<String>) -> Result<()> {
+    CONFIG
+        .set(Config {
+            config_path,
+            profile,
+        })
+        .map_err(|_| anyhow!("static CONFIG set failed"))?;
+
+    service_dispatcher::start(SERVICE_NAME, ffi_service_main)?;
+    Ok(())
+}
+
+pub fn install_service(config_path: Option<PathBuf>, profile: Option<String>) -> Result<()> {
+    let manager_access = ServiceManagerAccess::CONNECT | ServiceManagerAccess::CREATE_SERVICE;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service_binary_path = std::env::current_exe()?;
+
+    let mut args = vec!["--service".into()];
+    if let Some(config_path) = config_path {
+        args.push("--config".into());
+        args.push(config_path.into_os_string());
+    }
+    if let Some(profile) = profile {
+        args.push("--profile".into());
+        args.push(profile.into());
+    }
+
+    let service_info = ServiceInfo {
+        name: SERVICE_NAME.into(),
+        display_name: SERVICE_NAME.into(),
+        service_type: SERVICE_TYPE,
+        start_type: ServiceStartType::AutoStart,
+        error_control: ServiceErrorControl::Normal,
+        executable_path: service_binary_path,
+        launch_arguments: args,
+        dependencies: vec![],
+        account_name: None, // run as System
+        account_password: None,
+    };
+
+    let service = service_manager.create_service(&service_info, ServiceAccess::CHANGE_CONFIG)?;
+    service.set_description("pueued daemon is a task management tool for sequential and parallel execution of long-running tasks.")?;
+
+    Ok(())
+}
+
+pub fn uninstall_service() -> Result<()> {
+    let manager_access = ServiceManagerAccess::CONNECT;
+    let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
+
+    let service_access = ServiceAccess::QUERY_STATUS | ServiceAccess::STOP | ServiceAccess::DELETE;
+    let service = service_manager.open_service(SERVICE_NAME, service_access)?;
+
+    // The service will be marked for deletion as long as this function call succeeds.
+    // However, it will not be deleted from the database until it is stopped and all open handles to it are closed.
+    service.delete()?;
+
+    // Our handle to it is not closed yet. So we can still query it.
+    if service.query_status()?.current_state != ServiceState::Stopped {
+        // If the service cannot be stopped, it will be deleted when the system restarts.
+        service.stop()?;
+    }
+
+    Ok(())
+}
+
+fn service_main(_: Vec<OsString>) {
+    if let Err(e) = run_service() {
+        error!("Failed to start service: {e}");
+    }
+}
+
+fn run_service() -> Result<()> {
+    let spawner = Arc::new(Spawner::new());
+
+    let shutdown = Arc::new(AtomicBool::default());
+
+    let event_handler = {
+        let spawner = spawner.clone();
+        let shutdown = shutdown.clone();
+
+        move |control_event| -> ServiceControlHandlerResult {
+            match control_event {
+                ServiceControl::Stop => {
+                    spawner.stop();
+                    shutdown.store(true, Ordering::Relaxed);
+
+                    ServiceControlHandlerResult::NoError
+                }
+
+                ServiceControl::SessionChange(param) => {
+                    match param.reason {
+                        SessionChangeReason::SessionLogon
+                        | SessionChangeReason::RemoteConnect
+                        | SessionChangeReason::SessionUnlock => {
+                            if !spawner.running() {
+                                if let Err(e) = spawner.start(Some(param.notification.session_id)) {
+                                    error!("failed to spawn: {e}");
+                                }
+                            }
+                        }
+
+                        SessionChangeReason::SessionLogoff => {
+                            spawner.stop();
+                        }
+
+                        _ => (),
+                    }
+
+                    ServiceControlHandlerResult::NoError
+                }
+
+                // All services must accept Interrogate even if it's a no-op.
+                ServiceControl::Interrogate => ServiceControlHandlerResult::NoError,
+
+                _ => ServiceControlHandlerResult::NotImplemented,
+            }
+        }
+    };
+
+    // Register system service event handler
+    let status_handle = service_control_handler::register(SERVICE_NAME, event_handler)?;
+
+    let set_status = move |state: ServiceState, controls: ServiceControlAccept| -> Result<()> {
+        status_handle.set_service_status(ServiceStatus {
+            service_type: SERVICE_TYPE,
+            current_state: state,
+            controls_accepted: controls,
+            exit_code: ServiceExitCode::Win32(0),
+            checkpoint: 0,
+            wait_hint: Duration::default(),
+            process_id: None,
+        })?;
+
+        Ok(())
+    };
+
+    set_status(ServiceState::StartPending, ServiceControlAccept::STOP)?;
+
+    // make sure we have privileges
+    if let Err(e) = set_privilege(SE_TCB_NAME, true) {
+        set_status(ServiceState::Stopped, ServiceControlAccept::empty())?;
+        bail!("failed to set privileges: {e}");
+    }
+
+    if let Err(e) = spawner.start(None) {
+        //set_status(ServiceState::Stopped, ServiceControlAccept::empty())?;
+        bail!("failed to spawn: {e}");
+    }
+
+    set_status(
+        ServiceState::Running,
+        ServiceControlAccept::STOP | ServiceControlAccept::SESSION_CHANGE,
+    )?;
+
+    while !shutdown.load(Ordering::Relaxed) {
+        spawner.wait();
+    }
+
+    // ensure we kill the daemon after
+    spawner.stop();
+
+    set_status(ServiceState::Stopped, ServiceControlAccept::empty())?;
+
+    Ok(())
+}
+
+fn set_privilege(name: PCWSTR, state: bool) -> Result<()> {
+    let handle: OwnedHandle =
+        unsafe { OpenProcess(PROCESS_QUERY_INFORMATION, false, process::id())?.into() };
+
+    let mut token: OwnedHandle = OwnedHandle::default();
+    unsafe {
+        OpenProcessToken(handle.0, TOKEN_ADJUST_PRIVILEGES, &mut token.0)?;
+    }
+
+    let mut luid = LUID::default();
+
+    unsafe {
+        LookupPrivilegeValueW(PCWSTR::null(), name, &mut luid)?;
+    }
+
+    let mut tp = TOKEN_PRIVILEGES {
+        PrivilegeCount: 1,
+        ..Default::default()
+    };
+
+    tp.Privileges[0].Luid = luid;
+
+    let attributes = if state {
+        SE_PRIVILEGE_ENABLED
+    } else {
+        SE_PRIVILEGE_REMOVED
+    };
+
+    if state {
+        tp.Privileges[0].Attributes = attributes;
+    } else {
+        tp.Privileges[0].Attributes = attributes;
+    }
+
+    unsafe {
+        AdjustTokenPrivileges(token.0, false, Some(&tp), 0, None, None)?;
+    }
+
+    Ok(())
+}
+
+fn get_current_session() -> Option<u32> {
+    let session = unsafe { WTSGetActiveConsoleSessionId() };
+
+    match session {
+        0xFFFFFFFF => None,
+        session => Some(session),
+    }
+}
+
+fn run_as<T>(session_id: u32, cb: impl FnOnce(OwnedHandle) -> Result<T>) -> Result<T> {
+    let mut query_token: OwnedHandle = OwnedHandle::default();
+    unsafe {
+        WTSQueryUserToken(session_id, &mut query_token.0)?;
+    }
+
+    let sa = SECURITY_ATTRIBUTES {
+        bInheritHandle: true.into(),
+        ..Default::default()
+    };
+
+    let mut token = OwnedHandle::default();
+
+    unsafe {
+        DuplicateTokenEx(
+            query_token.0,
+            TOKEN_ACCESS_MASK(MAXIMUM_ALLOWED),
+            Some(&sa),
+            SecurityIdentification,
+            TokenPrimary,
+            &mut token.0,
+        )?;
+    };
+
+    let t = cb(token)?;
+
+    Ok(t)
+}
+
+struct OwnedHandle(HANDLE);
+
+unsafe impl Send for OwnedHandle {}
+unsafe impl Sync for OwnedHandle {}
+
+impl OwnedHandle {
+    fn is_valid(&self) -> bool {
+        !self.0.is_invalid()
+    }
+}
+
+impl Default for OwnedHandle {
+    fn default() -> Self {
+        Self(HANDLE::default())
+    }
+}
+
+impl From<HANDLE> for OwnedHandle {
+    fn from(value: HANDLE) -> Self {
+        Self(value)
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if !self.0.is_invalid() {
+            _ = unsafe { CloseHandle(self.0) };
+        }
+    }
+}
+
+struct Child(OwnedHandle);
+
+impl Child {
+    fn new() -> Self {
+        Self(OwnedHandle::default())
+    }
+
+    fn kill(&mut self) -> Result<()> {
+        if self.0.is_valid() {
+            unsafe { TerminateProcess(self.0 .0, 0)? };
+            self.0 = OwnedHandle::default();
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for Child {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Child {
+    fn drop(&mut self) {
+        _ = self.kill();
+    }
+}
+
+struct EnvBlock(*mut c_void);
+
+impl EnvBlock {
+    fn new(token: HANDLE) -> Result<Self> {
+        let mut env = ptr::null_mut();
+        unsafe {
+            CreateEnvironmentBlock(&mut env, token, false)?;
+        }
+
+        Ok(Self(env))
+    }
+}
+
+impl Drop for EnvBlock {
+    fn drop(&mut self) {
+        _ = unsafe { DestroyEnvironmentBlock(self.0) };
+    }
+}
+
+struct Spawner {
+    running: Arc<AtomicBool>,
+    child: Arc<Mutex<Child>>,
+}
+
+impl Spawner {
+    fn new() -> Self {
+        Self {
+            running: Arc::default(),
+            child: Arc::default(),
+        }
+    }
+
+    fn running(&self) -> bool {
+        self.running.load(Ordering::Relaxed)
+    }
+
+    fn stop(&self) {
+        let mut child = self.child.lock().unwrap();
+        if child.kill().is_ok() {
+            self.running.store(false, Ordering::Relaxed);
+        }
+    }
+
+    fn wait(&self) {
+        let mut handle = { self.child.lock().unwrap().0 .0 };
+
+        if handle.is_invalid() {
+            while !self.running.load(Ordering::Relaxed) {
+                thread::park();
+            }
+
+            handle = self.child.lock().unwrap().0 .0;
+        }
+
+        unsafe {
+            WaitForSingleObject(handle, INFINITE);
+        }
+    }
+
+    fn start(&self, session: Option<u32>) -> Result<()> {
+        let Some(session) = session.or_else(|| get_current_session()) else {
+            bail!("get_current_session failed");
+        };
+
+        let running = self.running.clone();
+        let child = self.child.clone();
+        let curr_thread = thread::current();
+        _ = thread::spawn(move || {
+            let res = run_as(session, move |token| {
+                let mut arguments = Vec::new();
+
+                let config = CONFIG
+                    .get()
+                    .ok_or_else(|| anyhow!("failed to get CONFIG"))?
+                    .clone();
+
+                if let Some(config) = &config.config_path {
+                    arguments.push("--config".to_string());
+                    arguments.push(format!(r#""{}""#, config.to_string_lossy().into_owned()));
+                }
+
+                if let Some(profile) = &config.profile {
+                    arguments.push("--profile".to_string());
+                    arguments.push(format!(r#""{profile}""#));
+                }
+
+                let arguments = arguments.join(" ");
+
+                // Try to get the path to the current binary, since it may not be in the $PATH.
+                // If we cannot detect it (for some unknown reason), fallback to the raw `pueued` binary name.
+                let current_exe = env::current_exe()?.to_string_lossy().to_string();
+
+                let mut command = format!(r#""{current_exe}" {arguments}"#)
+                    .encode_utf16()
+                    .chain(iter::once(0))
+                    .collect::<Vec<_>>();
+
+                command.reserve(1024 - command.len());
+
+                let env_block = EnvBlock::new(token.0)?;
+
+                let mut process_info = PROCESS_INFORMATION::default();
+                unsafe {
+                    CreateProcessAsUserW(
+                        token.0,
+                        None,
+                        PWSTR(command.as_mut_ptr()),
+                        None,
+                        None,
+                        false,
+                        CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
+                        Some(env_block.0),
+                        None,
+                        &STARTUPINFOW::default(),
+                        &mut process_info,
+                    )?;
+                }
+
+                {
+                    let mut lock = child.lock().unwrap();
+                    *lock = Child(process_info.hProcess.into());
+                    running.store(true, Ordering::Relaxed);
+                    curr_thread.unpark();
+                }
+
+                unsafe {
+                    WaitForSingleObject(process_info.hProcess, INFINITE);
+                }
+
+                {
+                    let mut lock = child.lock().unwrap();
+                    _ = lock.kill();
+                    running.store(false, Ordering::Relaxed);
+                }
+
+                Ok(())
+            });
+
+            if let Err(e) = res {
+                error!("spawner failed: {e}");
+            }
+        });
+
+        Ok(())
+    }
+}

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -445,7 +445,7 @@ struct Spawner {
     // whether the process has exited without our request
     dirty: Arc<AtomicBool>,
     request_stop: Arc<AtomicBool>,
-    park_tx: Arc<Sender<()>>,
+    park_tx: Sender<()>,
     // we don't need mutation, but we do need Sync
     park_rx: Mutex<Receiver<()>>,
 }
@@ -459,7 +459,7 @@ impl Spawner {
             child: Arc::default(),
             dirty: Arc::default(),
             request_stop: Arc::default(),
-            park_tx: Arc::new(park_tx),
+            park_tx,
             park_rx: Mutex::new(park_rx),
         }
     }

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -446,6 +446,8 @@ fn run_as<T>(session_id: u32, cb: impl FnOnce(HANDLE) -> Result<T>) -> Result<T>
         )?;
     }
 
+    drop(query_token);
+
     cb(token.0)
 }
 
@@ -670,6 +672,10 @@ impl Spawner {
                         &mut process_info,
                     )?;
                 }
+
+                // It is safe to drop this after calling CreateProcessAsUser.
+                // https://learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-createenvironmentblock#remarks
+                drop(env_block);
 
                 // Store the child process.
                 {

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -664,7 +664,10 @@ impl Spawner {
                         None,
                         false,
                         // CREATE_UNICODE_ENVIRONMENT is required if we pass env block.
+                        // https://learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-createenvironmentblock#remarks
+                        //
                         // CREATE_NO_WINDOW causes all child processes to not show a visible console window.
+                        // https://stackoverflow.com/a/71364777/9423933
                         CREATE_UNICODE_ENVIRONMENT | CREATE_NO_WINDOW,
                         Some(env_block.0),
                         None,

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -568,7 +568,6 @@ impl Spawner {
                     let mut lock = child.lock().unwrap();
                     *lock = Child(process_info.hProcess.into());
                     running.store(true, Ordering::Relaxed);
-                    _ = parker.send(());
                 }
 
                 unsafe {


### PR DESCRIPTION
This is an initial implementation of a Windows service for pueued. #344 

~~This is a draft and I would like to have some testing/feedback on it before it gets merged.~~

How to use:
The following subcommands now exist:
* `pueued service install`
* `pueued service uninstall`
* `pueued service start`
* `pueued service stop`
* `pueued service run` (internal only)

In an admin terminal:
* `pueued service install`
* Go to your services manager and start the service, or run `pueued service start`. It's set to autostart, so it will start up with the system, though that can obviously be adjusted to manual if the user wants. After the initial install, _the service is not started automatically_, so you must start it yourself the first time.
* To uninstall `pueued service uninstall`

![image](https://github.com/user-attachments/assets/4f414b45-4fa7-4c47-94f9-6703c4bca4cd)

This should also respect it when users log out and other users log in.

The service process itself runs as SYSTEM. It spawns a new `pueued` daemon process as the currently logged in user.

What I want tested:
- Just the general functionality, but specifically I want to know how it works when:
- [x] - user logs out
- [x] - another user logs in
- [x] - on bootup/restart

Todo / possible bug:
- [x] What happens if the daemon process fails on its own?
- [x] Adding tasks then trying to follow / log them / status, gives these weird "cannot deserialize" errors. Possibly caused by not enough perms? Should they be inherited then? - Edit: not my service's fault.
- [x] unpark inside stop after process killed so it doesn't get stuck on parked without ever being able to stop service
- [x] logoff/logon stops service
- [x] Fix daemon `-d` to actually detach in windows using process creation flags
- [x] Fix daemon in `-d` launching visible shell windows

Possible additional features:
- [ ] Make `-d` mode check if windows service exists, if so, start and run the service instead of the daemon, otherwise, fallback to forking daemon mode.

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [x] (If applicable) I checked if anything in the wiki needs to be changed.*
* Following pages need to be changed:
  * https://github.com/Nukesor/pueue/wiki/Common-Pitfalls-and-Debugging#windows-quirks (this service fixes the quirk, though it should be noted the quirk is still there in `-d` mode, but using the service will properly fix it)
  * https://github.com/Nukesor/pueue/wiki/Get-started#start-the-daemon (add a section for windows and the service)
