### PR TITLE
Use GetCurrentProcess instead of OpenProcess

### DIFF
--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -35,7 +35,7 @@ use std::{
     ffi::{c_void, OsString},
     iter,
     path::PathBuf,
-    process, ptr,
+    ptr,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc::{channel, Receiver, Sender},
@@ -61,10 +61,9 @@ use windows::{
             RemoteDesktop::{WTSGetActiveConsoleSessionId, WTSQueryUserToken},
             SystemServices::MAXIMUM_ALLOWED,
             Threading::{
-                CreateProcessAsUserW, GetExitCodeProcess, OpenProcess, OpenProcessToken,
+                CreateProcessAsUserW, GetCurrentProcess, GetExitCodeProcess, OpenProcessToken,
                 TerminateProcess, WaitForSingleObject, CREATE_NO_WINDOW,
-                CREATE_UNICODE_ENVIRONMENT, INFINITE, PROCESS_INFORMATION,
-                PROCESS_QUERY_INFORMATION, STARTUPINFOW,
+                CREATE_UNICODE_ENVIRONMENT, INFINITE, PROCESS_INFORMATION, STARTUPINFOW,
             },
         },
     },
@@ -373,12 +372,11 @@ fn event_loop() -> Result<()> {
 /// Set the specified process privilege to state.
 /// https://learn.microsoft.com/en-us/windows/win32/secauthz/privilege-constants
 fn set_privilege(name: PCWSTR, state: bool) -> Result<()> {
-    let handle: OwnedHandle =
-        unsafe { OpenProcess(PROCESS_QUERY_INFORMATION, false, process::id())?.into() };
+    let process: OwnedHandle = unsafe { GetCurrentProcess().into() };
 
     let mut token: OwnedHandle = OwnedHandle::default();
     unsafe {
-        OpenProcessToken(handle.0, TOKEN_ADJUST_PRIVILEGES, &mut token.0)?;
+        OpenProcessToken(process.0, TOKEN_ADJUST_PRIVILEGES, &mut token.0)?;
     }
 
     let mut luid = LUID::default();


### PR DESCRIPTION
Just a minor code change improvement to simplify one call.
Replaced `OpenProcess` with `GetCurrentProcess` since this is what we're doing anyways

## Checklist

Please make sure the PR adheres to this project's standards:

- [ ] I included a new entry to the `CHANGELOG.md`. (n/a change it too small anyways)
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
