### PR TITLE
Super tiny little typo fix

### DIFF
--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -240,7 +240,7 @@ pub enum SubCommand {
         wait: bool,
     },
 
-    #[command(about = "Kill specific running tasks or whole task groups..\n\
+    #[command(about = "Kill specific running tasks or whole task groups.\n\
         Kills all tasks of the default group when no ids or a specific group are provided.")]
     Kill {
         /// Kill these specific tasks.


### PR DESCRIPTION
Hi thanks for the lib! When checking the `--help` (looking for pausing pending tasks), there seems to be a super tiny little typo, thus I create this PR

## Checklist

Please make sure the PR adheres to this project's standards:

- [ ] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
