### PR TITLE
Upgrade to `tracing` and `color_eyre` (2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Upon updating Pueue and restarting the daemon, the previous state will be wiped,
   Pueue now allows editing all properties a task in one editor session. There're two modes to do so: `toml` and `files`.
 - Revisited, fixed and cleaned up CLI help texts.
 - Print most of Pueue's info/log messages to `stderr`. Only keep useful stuff like json and task log output on `stdout`.
+- **Breaking**: Ported from `anyhow::Error` to `color_eyre::Report`, which shouldn't break non-lib compatability
 
 ### Add
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler2"
-version = "2.0.0"
+name = "adler"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -92,12 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,17 +132,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -352,6 +346,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,40 +561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +574,16 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -667,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -710,22 +707,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
@@ -751,6 +736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,17 +759,6 @@ checksum = "9afd0f0bff60c0e845844b6ee665e07990541ef3b70d8cd21861cf85b69fbef4"
 dependencies = [
  "chrono",
  "logos",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -933,11 +913,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
- "adler2",
+ "adler",
 ]
 
 [[package]]
@@ -1020,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1044,6 +1024,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -1240,7 +1226,6 @@ dependencies = [
 name = "pueue"
 version = "4.0.0-rc.1"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "assert_matches",
  "better-panic",
@@ -1248,14 +1233,13 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_complete_nushell",
+ "color-eyre",
  "comfy-table",
  "command-group",
  "crossterm",
  "ctrlc",
- "env_logger 0.10.2",
  "handlebars",
  "interim",
- "log",
  "pest",
  "pest_derive",
  "pretty_assertions",
@@ -1267,13 +1251,15 @@ dependencies = [
  "serde_yaml",
  "shell-escape",
  "similar-asserts",
- "simplelog",
  "snap",
  "strum",
  "tempfile",
- "test-log",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-error",
+ "tracing-subscriber",
+ "tracing-test",
  "whoami",
  "windows",
  "windows-service",
@@ -1283,16 +1269,15 @@ dependencies = [
 name = "pueue-lib"
 version = "0.27.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "better-panic",
  "byteorder",
  "chrono",
+ "color-eyre",
  "command-group",
  "dirs 6.0.0",
  "handlebars",
  "libproc",
- "log",
  "portpicker",
  "pretty_assertions",
  "procfs",
@@ -1312,6 +1297,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tokio-rustls",
+ "tracing",
  "whoami",
  "winapi",
 ]
@@ -1728,17 +1714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
-dependencies = [
- "log",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,15 +1810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,28 +1824,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "test-log"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
-dependencies = [
- "env_logger 0.11.6",
- "test-log-macros",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "test-log-macros"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thiserror"
@@ -2042,7 +1986,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2053,6 +2009,16 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2072,15 +2038,39 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2264,15 +2254,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,6 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
- "tracing-test",
  "whoami",
  "windows",
  "windows-service",
@@ -2050,27 +2049,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ repository = "https://github.com/nukesor/pueue"
 rust-version = "1.70"
 
 [workspace.dependencies]
-anyhow = "1"
 better-panic = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
+color-eyre = "0.6.3"
 command-group = "5"
 handlebars = "5.1"
-log = "0.4"
 pretty_assertions = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -25,6 +24,7 @@ serde_yaml = "0.9"
 snap = "1.1"
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.43", features = ["io-std", "rt-multi-thread", "time"] }
+tracing = "0.1.41"
 
 [profile.release]
 codegen-units = 1

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -58,11 +58,6 @@ pretty_assertions.workspace = true
 rstest = "0.24"
 serde_yaml.workspace = true
 similar-asserts = "1"
-# Make it easy to view log output for select tests.
-# Set log level for tests with RUST_LOG=<level>, use with failed tests or
-# disable test stdout/stderr capture (`cargo test -- --nocapture` / `cargo
-# nextest run --no-capture`)
-tracing-test = "0.2.5"
 
 # We don't need any of the default features for crossterm.
 # However, the windows build needs the windows feature enabled.

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-anyhow = "1.0"
 chrono.workspace = true
 clap = { version = "4.4.18", features = [
     "cargo",
@@ -25,40 +24,52 @@ clap = { version = "4.4.18", features = [
 ] }
 clap_complete = "4.4.10"
 clap_complete_nushell = "4.4.2"
+color-eyre.workspace = true
 comfy-table = "7"
 command-group.workspace = true
 ctrlc = { version = "3", features = ["termination"] }
 handlebars.workspace = true
 interim = { version = "0.1.2", features = ["chrono"] }
-log.workspace = true
 pest = "2.7"
 pest_derive = "2.7"
 pueue-lib = { version = "0.27.0", path = "../pueue_lib" }
 serde.workspace = true
 serde_json.workspace = true
 shell-escape = "0.1"
-simplelog = "0.12"
 snap.workspace = true
 strum.workspace = true
 tempfile = "3"
 tokio.workspace = true
 toml = "0.8"
+tracing.workspace = true
+tracing-error = "0.2.1"
+tracing-subscriber = { version = "0.3.19", features = [
+    "chrono",
+    "env-filter",
+    "fmt",
+    "local-time",
+] }
 
 [dev-dependencies]
-anyhow.workspace = true
 assert_cmd = "2"
 assert_matches = "1"
 better-panic.workspace = true
-# Make it easy to view log output for select tests.
-# Set log level for tests with RUST_LOG=<level>, use with failed tests or
-# disable test stdout/stderr capture (`cargo test -- --nocapture` / `cargo
-# nextest run --no-capture`)
-env_logger = "0.10"
 pretty_assertions.workspace = true
 rstest = "0.24"
 serde_yaml.workspace = true
 similar-asserts = "1"
-test-log = "0.2"
+tracing-test = "0.2.5"
+
+# Make it easy to view log output for select tests.
+# Set log level for tests with RUST_LOG=<level>, use with failed tests or
+# disable test stdout/stderr capture (`cargo test -- --nocapture` / `cargo
+# nextest run --no-capture`)
+tracing-subscriber = { version = "*", features = [
+    "chrono",
+    "env-filter",
+    "fmt",
+    "local-time",
+] }
 
 # We don't need any of the default features for crossterm.
 # However, the windows build needs the windows feature enabled.

--- a/pueue/Cargo.toml
+++ b/pueue/Cargo.toml
@@ -58,18 +58,11 @@ pretty_assertions.workspace = true
 rstest = "0.24"
 serde_yaml.workspace = true
 similar-asserts = "1"
-tracing-test = "0.2.5"
-
 # Make it easy to view log output for select tests.
 # Set log level for tests with RUST_LOG=<level>, use with failed tests or
 # disable test stdout/stderr capture (`cargo test -- --nocapture` / `cargo
 # nextest run --no-capture`)
-tracing-subscriber = { version = "*", features = [
-    "chrono",
-    "env-filter",
-    "fmt",
-    "local-time",
-] }
+tracing-test = "0.2.5"
 
 # We don't need any of the default features for crossterm.
 # However, the windows build needs the windows feature enabled.

--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -632,7 +632,7 @@ fn parse_delay_until(src: &str) -> Result<DateTime<Local>, String> {
     if let Ok(seconds) = src.parse::<i64>() {
         let delay_until = Local::now()
             + TimeDelta::try_seconds(seconds)
-                .ok_or("Failed to get timedelta from {seconds} seconds")?;
+                .ok_or(format!("Failed to get timedelta from {seconds} seconds"))?;
         return Ok(delay_until);
     }
 

--- a/pueue/src/client/commands/edit.rs
+++ b/pueue/src/client/commands/edit.rs
@@ -1,10 +1,11 @@
+use crate::internal_prelude::*;
+
 use std::collections::BTreeMap;
 use std::env;
 use std::fs::{create_dir, read_to_string, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
 use pueue_lib::error::Error;
 use pueue_lib::settings::Settings;
 use tempfile::tempdir;

--- a/pueue/src/client/commands/format_state.rs
+++ b/pueue/src/client/commands/format_state.rs
@@ -1,9 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::{
     collections::BTreeMap,
     io::{self, prelude::*},
 };
-
-use anyhow::{Context, Result};
 
 use pueue_lib::{network::protocol::GenericStream, settings::Settings, task::Task};
 

--- a/pueue/src/client/commands/local_follow.rs
+++ b/pueue/src/client/commands/local_follow.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use crate::internal_prelude::*;
 
-use anyhow::{bail, Result};
+use std::path::Path;
 
 use pueue_lib::network::protocol::GenericStream;
 

--- a/pueue/src/client/commands/mod.rs
+++ b/pueue/src/client/commands/mod.rs
@@ -4,7 +4,8 @@
 //! "non-trivial" vaguely means that we, for instance, have to do additional requests to the
 //! daemon, open some files on the filesystem, edit files and so on.
 //! All commands that cannot be simply handled by handling requests or using `pueue_lib`.
-use anyhow::Result;
+
+use crate::internal_prelude::*;
 
 use pueue_lib::network::protocol::*;
 use pueue_lib::state::State;

--- a/pueue/src/client/commands/restart.rs
+++ b/pueue/src/client/commands/restart.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use crate::internal_prelude::*;
 
 use chrono::Local;
 use pueue_lib::network::message::*;

--- a/pueue/src/client/commands/wait.rs
+++ b/pueue/src/client/commands/wait.rs
@@ -1,7 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use anyhow::Result;
 use chrono::Local;
 use crossterm::style::{Attribute, Color};
 use pueue_lib::network::message::TaskSelection;

--- a/pueue/src/client/display/follow.rs
+++ b/pueue/src/client/display/follow.rs
@@ -1,8 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::io::{self, Write};
 use std::path::Path;
 use std::time::Duration;
 
-use anyhow::Result;
 use tokio::time::sleep;
 
 use pueue_lib::{

--- a/pueue/src/client/display/log/remote.rs
+++ b/pueue/src/client/display/log/remote.rs
@@ -1,6 +1,7 @@
+use crate::internal_prelude::*;
+
 use std::io;
 
-use anyhow::Result;
 use crossterm::style::{Attribute, Color};
 use snap::read::FrameDecoder;
 

--- a/pueue/src/client/display/state.rs
+++ b/pueue/src/client/display/state.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::internal_prelude::*;
 
 use pueue_lib::settings::Settings;
 use pueue_lib::state::{State, PUEUE_DEFAULT_GROUP};

--- a/pueue/src/client/query/column_selection.rs
+++ b/pueue/src/client/query/column_selection.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::internal_prelude::*;
+
 use pest::iterators::Pair;
 
 use super::{QueryResult, Rule};

--- a/pueue/src/client/query/filters.rs
+++ b/pueue/src/client/query/filters.rs
@@ -1,5 +1,6 @@
 #![allow(bindings_with_variant_name)]
-use anyhow::{bail, Context, Result};
+use crate::internal_prelude::*;
+
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta};
 use pest::iterators::Pair;
 use pueue_lib::task::{Task, TaskResult, TaskStatus};

--- a/pueue/src/client/query/limit.rs
+++ b/pueue/src/client/query/limit.rs
@@ -1,4 +1,5 @@
-use anyhow::{bail, Context, Result};
+use crate::internal_prelude::*;
+
 use pest::iterators::Pair;
 
 use super::{QueryResult, Rule};

--- a/pueue/src/client/query/mod.rs
+++ b/pueue/src/client/query/mod.rs
@@ -1,7 +1,7 @@
 // Clippy generates a false-positive for an empty generated docstring in the query parser code.
 #![allow(clippy::empty_docs)]
+use crate::internal_prelude::*;
 
-use anyhow::{bail, Context, Result};
 use chrono::prelude::*;
 use pest::Parser;
 use pest_derive::Parser;

--- a/pueue/src/client/query/order_by.rs
+++ b/pueue/src/client/query/order_by.rs
@@ -1,5 +1,6 @@
 #![allow(bindings_with_variant_name)]
-use anyhow::Result;
+use crate::internal_prelude::*;
+
 use pest::iterators::Pair;
 
 use super::{QueryResult, Rule};

--- a/pueue/src/daemon/callbacks.rs
+++ b/pueue/src/daemon/callbacks.rs
@@ -1,8 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::collections::HashMap;
 
 use chrono::{DateTime, Local};
 use handlebars::{Handlebars, RenderError};
-use log::{debug, error, info};
 use pueue_lib::{
     log::{get_log_path, read_last_log_file_lines},
     process_helper::compile_shell_command,

--- a/pueue/src/daemon/mod.rs
+++ b/pueue/src/daemon/mod.rs
@@ -1,9 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::{fs::create_dir_all, path::PathBuf};
-
-use anyhow::{bail, Context, Result};
-use log::warn;
 
 use process_handler::initiate_shutdown;
 use pueue_lib::error::Error;

--- a/pueue/src/daemon/network/message_handler/log.rs
+++ b/pueue/src/daemon/network/message_handler/log.rs
@@ -1,9 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
-
-use anyhow::Result;
 
 use pueue_lib::failure_msg;
 use pueue_lib::log::read_and_compress_log_file;

--- a/pueue/src/daemon/network/socket.rs
+++ b/pueue/src/daemon/network/socket.rs
@@ -1,8 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::time::{Duration, SystemTime};
 
-use anyhow::{bail, Context, Result};
 use clap::crate_version;
-use log::{debug, info, warn};
 use tokio::time::sleep;
 
 use pueue_lib::error::Error;

--- a/pueue/src/daemon/pid.rs
+++ b/pueue/src/daemon/pid.rs
@@ -1,9 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
-
-use anyhow::{bail, Context, Result};
-use log::info;
 
 use pueue_lib::error::Error;
 use pueue_lib::process_helper::process_exists;

--- a/pueue/src/daemon/process_handler/finish.rs
+++ b/pueue/src/daemon/process_handler/finish.rs
@@ -1,6 +1,6 @@
-use anyhow::Context;
+use crate::internal_prelude::*;
+
 use chrono::Local;
-use log::info;
 use pueue_lib::log::clean_log_handles;
 use pueue_lib::state::GroupStatus;
 use pueue_lib::task::{TaskResult, TaskStatus};

--- a/pueue/src/daemon/process_handler/kill.rs
+++ b/pueue/src/daemon/process_handler/kill.rs
@@ -1,4 +1,4 @@
-use log::{error, info, warn};
+use crate::internal_prelude::*;
 
 use pueue_lib::{
     network::message::{Signal, TaskSelection},

--- a/pueue/src/daemon/process_handler/mod.rs
+++ b/pueue/src/daemon/process_handler/mod.rs
@@ -1,5 +1,4 @@
-use anyhow::Result;
-use log::{debug, error};
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::{Shutdown, TaskSelection};
 use pueue_lib::process_helper::{send_signal_to_child, ProcessAction};
@@ -23,7 +22,6 @@ macro_rules! ok_or_shutdown {
     ($settings:expr, $state:expr, $result:expr) => {
         match $result {
             Err(err) => {
-                use log::error;
                 use pueue_lib::network::message::Shutdown;
                 use $crate::daemon::process_handler::initiate_shutdown;
                 error!("Initializing graceful shutdown. Encountered error in TaskHandler: {err}");

--- a/pueue/src/daemon/process_handler/pause.rs
+++ b/pueue/src/daemon/process_handler/pause.rs
@@ -1,4 +1,4 @@
-use log::{error, info};
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::TaskSelection;
 use pueue_lib::process_helper::ProcessAction;

--- a/pueue/src/daemon/process_handler/spawn.rs
+++ b/pueue/src/daemon/process_handler/spawn.rs
@@ -1,9 +1,10 @@
+use crate::internal_prelude::*;
+
 use std::io::Write;
 use std::process::Stdio;
 
 use chrono::Local;
 use command_group::CommandGroup;
-use log::{error, info, warn};
 use pueue_lib::log::{create_log_file_handles, get_writable_log_file_handle};
 use pueue_lib::process_helper::compile_shell_command;
 use pueue_lib::settings::Settings;
@@ -160,6 +161,16 @@ pub fn spawn_process(settings: &Settings, state: &mut LockedState, task_id: usiz
     envs.insert("PUEUE_GROUP".into(), group.clone());
     envs.insert("PUEUE_WORKER_ID".into(), worker_id.to_string());
 
+    if !path.exists() {
+        let err = path.try_exists();
+        warn!(
+            message = "Starting a command with a working directory that doesn't seem to exist",
+            help = "Specify the --working-directory to `pueue add` or similar if connecting over TCP/TLS to a remote machine",
+            ?path,
+            ?err
+        );
+    }
+
     // Spawn the actual subprocess
     let spawned_command = command
         .current_dir(path)
@@ -174,14 +185,17 @@ pub fn spawn_process(settings: &Settings, state: &mut LockedState, task_id: usiz
     let child = match spawned_command {
         Ok(child) => child,
         Err(err) => {
-            let error = format!("Failed to spawn child {task_id} with err: {err:?}");
-            error!("{}", error);
+            let error_msg = format!("Failed to spawn child {task_id} with err: {:?}", err);
+            error!(?err, "Failed to spawn child {task_id}");
+            trace!(?command, "Command that failed");
 
             // Write some debug log output to the task's log file.
             // This should always work, but print a datailed error if it didn't work.
             if let Ok(mut file) = get_writable_log_file_handle(task_id, &pueue_directory) {
-                let log_output =
-                    format!("Pueue error, failed to spawn task. Check your command.\n{error}");
+                let log_output = format!(
+                    "Pueue error, failed to spawn task. Check your command.\n{}",
+                    error_msg
+                );
                 let write_result = file.write_all(log_output.as_bytes());
                 if let Err(write_err) = write_result {
                     error!("Failed to write spawn error to task log: {}", write_err);
@@ -195,7 +209,7 @@ pub fn spawn_process(settings: &Settings, state: &mut LockedState, task_id: usiz
                     enqueued_at,
                     start: Local::now(),
                     end: Local::now(),
-                    result: TaskResult::FailedToSpawn(error),
+                    result: TaskResult::FailedToSpawn(error_msg),
                 };
                 task.clone()
             };

--- a/pueue/src/daemon/process_handler/start.rs
+++ b/pueue/src/daemon/process_handler/start.rs
@@ -1,4 +1,4 @@
-use log::{error, info, warn};
+use crate::internal_prelude::*;
 
 use pueue_lib::{
     network::message::TaskSelection, process_helper::ProcessAction, settings::Settings,

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -45,8 +45,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Result};
-use log::{debug, error, info};
+use crate::internal_prelude::*;
 use windows::{
     core::{Free, PCWSTR, PWSTR},
     Win32::{
@@ -233,7 +232,7 @@ pub fn run_service(config_path: Option<PathBuf>, profile: Option<String>) -> Res
             config_path,
             profile,
         })
-        .map_err(|_| anyhow!("static CONFIG set failed"))?;
+        .map_err(|_| eyre!("static CONFIG set failed"))?;
 
     service_dispatcher::start(SERVICE_NAME, ffi_service_main)?;
     Ok(())
@@ -622,7 +621,7 @@ impl Spawner {
 
                 let config = CONFIG
                     .get()
-                    .ok_or_else(|| anyhow!("failed to get CONFIG"))?
+                    .ok_or_else(|| eyre!("failed to get CONFIG"))?
                     .clone();
 
                 if let Some(config) = &config.config_path {

--- a/pueue/src/daemon/state_helper.rs
+++ b/pueue/src/daemon/state_helper.rs
@@ -1,10 +1,10 @@
+use crate::internal_prelude::*;
+
 use std::fs;
 use std::path::Path;
 use std::sync::MutexGuard;
 
-use anyhow::{Context, Result};
 use chrono::prelude::*;
-use log::{debug, info};
 
 use pueue_lib::settings::Settings;
 use pueue_lib::state::{Group, GroupStatus, State, PUEUE_DEFAULT_GROUP};

--- a/pueue/src/daemon/task_handler.rs
+++ b/pueue/src/daemon/task_handler.rs
@@ -1,9 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use anyhow::Result;
 use chrono::prelude::*;
-use log::{error, info};
 
 use pueue_lib::children::Children;
 use pueue_lib::network::message::*;

--- a/pueue/src/lib.rs
+++ b/pueue/src/lib.rs
@@ -2,5 +2,19 @@
 // Ignore it for now.
 #![allow(clippy::assigning_clones)]
 #![doc = include_str!("../README.md")]
+
+pub(crate) mod internal_prelude {
+    #[allow(unused_imports)]
+    pub(crate) use tracing::{debug, error, info, trace, warn};
+
+    pub(crate) use crate::errors::*;
+}
+
+pub(crate) mod errors {
+    pub use color_eyre::eyre::{bail, WrapErr};
+    pub use color_eyre::Result;
+}
+
 pub mod client;
 pub mod daemon;
+pub mod tracing;

--- a/pueue/src/lib.rs
+++ b/pueue/src/lib.rs
@@ -11,7 +11,8 @@ pub(crate) mod internal_prelude {
 }
 
 pub(crate) mod errors {
-    pub use color_eyre::eyre::{bail, WrapErr};
+    #[allow(unused_imports)]
+    pub use color_eyre::eyre::{bail, eyre, WrapErr};
     pub use color_eyre::Result;
 }
 

--- a/pueue/src/tracing.rs
+++ b/pueue/src/tracing.rs
@@ -1,0 +1,56 @@
+use crate::internal_prelude::*;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    field::MakeExt, fmt::time::ChronoLocal, layer::SubscriberExt, util::SubscriberInitExt,
+    EnvFilter, Layer,
+};
+
+pub fn install_tracing(verbosity: u8) -> Result<()> {
+    let mut pretty = false;
+    let level = match verbosity {
+        0 => LevelFilter::WARN,
+        1 => LevelFilter::INFO,
+        2 => LevelFilter::DEBUG,
+        3 => LevelFilter::TRACE,
+        _ => {
+            pretty = true;
+            LevelFilter::TRACE
+        }
+    };
+
+    // tries to find local offset internally
+    let timer = ChronoLocal::new("%H:%M:%S".into());
+
+    type GenericLayer<S> = Box<dyn Layer<S> + Send + Sync>;
+    let fmt_layer: GenericLayer<_> = match pretty {
+        false => Box::new(
+            tracing_subscriber::fmt::layer()
+                .map_fmt_fields(|f| f.debug_alt())
+                .with_timer(timer)
+                .with_writer(std::io::stderr),
+        ),
+        true => Box::new(
+            tracing_subscriber::fmt::layer()
+                .pretty()
+                .with_timer(timer)
+                .with_target(true)
+                .with_thread_ids(false)
+                .with_thread_names(true)
+                .with_level(true)
+                .with_ansi(true)
+                .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
+                .with_writer(std::io::stderr),
+        ),
+    };
+    let filter_layer = EnvFilter::builder()
+        .with_default_directive(level.into())
+        .from_env()
+        .wrap_err("RUST_LOG env variable is invalid")?;
+
+    tracing_subscriber::Registry::default()
+        .with(fmt_layer.with_filter(filter_layer))
+        .with(tracing_error::ErrorLayer::default())
+        .init();
+
+    Ok(())
+}

--- a/pueue/tests/client/helper/compare_output.rs
+++ b/pueue/tests/client/helper/compare_output.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 use std::process::Output;

--- a/pueue/tests/client/helper/compare_output.rs
+++ b/pueue/tests/client/helper/compare_output.rs
@@ -1,7 +1,8 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 use std::process::Output;
 
-use anyhow::{bail, Context, Result};
 use chrono::Local;
 use handlebars::Handlebars;
 use std::fs::read_to_string;

--- a/pueue/tests/client/helper/run.rs
+++ b/pueue/tests/client/helper/run.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 

--- a/pueue/tests/client/helper/run.rs
+++ b/pueue/tests/client/helper/run.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use assert_cmd::prelude::*;
 use std::process::{Command, Output, Stdio};
 

--- a/pueue/tests/client/integration/completions.rs
+++ b/pueue/tests/client/integration/completions.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::process::{Command, Stdio};
 
-use anyhow::{Context, Result};
 use assert_cmd::prelude::*;
 use rstest::rstest;
 

--- a/pueue/tests/client/integration/completions.rs
+++ b/pueue/tests/client/integration/completions.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::process::{Command, Stdio};
 

--- a/pueue/tests/client/integration/configuration.rs
+++ b/pueue/tests/client/integration/configuration.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::{
     collections::HashMap,

--- a/pueue/tests/client/integration/configuration.rs
+++ b/pueue/tests/client/integration/configuration.rs
@@ -1,9 +1,9 @@
+use crate::prelude::*;
+
 use std::{
     collections::HashMap,
     process::{Child, Command, Stdio},
 };
-
-use anyhow::{bail, Context, Result};
 
 use assert_cmd::prelude::CommandCargoExt;
 use pueue_lib::{

--- a/pueue/tests/client/integration/edit.rs
+++ b/pueue/tests/client/integration/edit.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 

--- a/pueue/tests/client/integration/edit.rs
+++ b/pueue/tests/client/integration/edit.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use pueue_lib::{settings::EditMode, task::TaskStatus};
 
 use crate::client::helper::*;

--- a/pueue/tests/client/integration/env.rs
+++ b/pueue/tests/client/integration/env.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use pueue_lib::task::Task;
 
 use crate::client::helper::*;

--- a/pueue/tests/client/integration/env.rs
+++ b/pueue/tests/client/integration/env.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::task::Task;
 

--- a/pueue/tests/client/integration/follow.rs
+++ b/pueue/tests/client/integration/follow.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use rstest::rstest;
 

--- a/pueue/tests/client/integration/follow.rs
+++ b/pueue/tests/client/integration/follow.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
+
 use rstest::rstest;
 
 use pueue_lib::task::Task;

--- a/pueue/tests/client/integration/group.rs
+++ b/pueue/tests/client/integration/group.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::BTreeMap;
 

--- a/pueue/tests/client/integration/group.rs
+++ b/pueue/tests/client/integration/group.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
 use pueue_lib::network::message::*;
 use pueue_lib::state::{Group, GroupStatus};
 

--- a/pueue/tests/client/integration/log.rs
+++ b/pueue/tests/client/integration/log.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/pueue/tests/client/integration/log.rs
+++ b/pueue/tests/client/integration/log.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::{BTreeMap, HashMap};
 
-use anyhow::{Context, Result};
 use rstest::rstest;
 use serde::Deserialize;
 

--- a/pueue/tests/client/integration/restart.rs
+++ b/pueue/tests/client/integration/restart.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 

--- a/pueue/tests/client/integration/restart.rs
+++ b/pueue/tests/client/integration/restart.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 
-use anyhow::Result;
 use assert_matches::assert_matches;
 
 use pueue_lib::task::{Task, TaskResult, TaskStatus};

--- a/pueue/tests/client/integration/status.rs
+++ b/pueue/tests/client/integration/status.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
 
 use pueue_lib::{state::State, task::Task};
 

--- a/pueue/tests/client/integration/status.rs
+++ b/pueue/tests/client/integration/status.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{state::State, task::Task};
 

--- a/pueue/tests/client/integration/wait.rs
+++ b/pueue/tests/client/integration/wait.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::{
     process::Output,

--- a/pueue/tests/client/integration/wait.rs
+++ b/pueue/tests/client/integration/wait.rs
@@ -1,9 +1,10 @@
+use crate::prelude::*;
+
 use std::{
     process::Output,
     thread::{self, JoinHandle},
 };
 
-use anyhow::Result;
 use tokio::time::sleep;
 
 use crate::client::helper::*;

--- a/pueue/tests/client/unit/status_query.rs
+++ b/pueue/tests/client/unit/status_query.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::{collections::HashMap, path::PathBuf};
 

--- a/pueue/tests/client/unit/status_query.rs
+++ b/pueue/tests/client/unit/status_query.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::{collections::HashMap, path::PathBuf};
 
-use anyhow::Result;
 use assert_matches::assert_matches;
 use chrono::{Local, TimeZone};
 use pretty_assertions::assert_eq;
@@ -232,7 +233,7 @@ async fn filter_status(#[case] status_filter: &str, #[case] match_count: usize) 
                 },
                 "Only Failed tasks are allowed"
             ),
-            _ => anyhow::bail!("Got unexpected TaskStatus in filter_status"),
+            _ => bail!("Got unexpected TaskStatus in filter_status"),
         };
     }
 

--- a/pueue/tests/daemon/integration/add.rs
+++ b/pueue/tests/daemon/integration/add.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use assert_matches::assert_matches;
 use chrono::Local;
 

--- a/pueue/tests/daemon/integration/add.rs
+++ b/pueue/tests/daemon/integration/add.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use assert_matches::assert_matches;
 use chrono::Local;

--- a/pueue/tests/daemon/integration/aliases.rs
+++ b/pueue/tests/daemon/integration/aliases.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 

--- a/pueue/tests/daemon/integration/aliases.rs
+++ b/pueue/tests/daemon/integration/aliases.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 
-use anyhow::Result;
 use assert_matches::assert_matches;
 
 use pueue_lib::{network::message::*, task::*};

--- a/pueue/tests/daemon/integration/callback.rs
+++ b/pueue/tests/daemon/integration/callback.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::fs::read_to_string;
 

--- a/pueue/tests/daemon/integration/callback.rs
+++ b/pueue/tests/daemon/integration/callback.rs
@@ -1,6 +1,6 @@
-use std::fs::read_to_string;
+use crate::prelude::*;
 
-use anyhow::{Context, Result};
+use std::fs::read_to_string;
 
 use crate::helper::*;
 

--- a/pueue/tests/daemon/integration/clean.rs
+++ b/pueue/tests/daemon/integration/clean.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use pueue_lib::{network::message::*, task::Task};
 
 use crate::helper::*;

--- a/pueue/tests/daemon/integration/clean.rs
+++ b/pueue/tests/daemon/integration/clean.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{network::message::*, task::Task};
 

--- a/pueue/tests/daemon/integration/dependencies.rs
+++ b/pueue/tests/daemon/integration/dependencies.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::prelude::*;
 
 use pueue_lib::{
     network::message::{KillMessage, TaskSelection},

--- a/pueue/tests/daemon/integration/dependencies.rs
+++ b/pueue/tests/daemon/integration/dependencies.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{
     network::message::{KillMessage, TaskSelection},

--- a/pueue/tests/daemon/integration/edit.rs
+++ b/pueue/tests/daemon/integration/edit.rs
@@ -1,8 +1,8 @@
+use crate::prelude::*;
+
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
 use assert_matches::assert_matches;
-use test_log::test;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::Shared;
@@ -32,7 +32,8 @@ async fn create_edited_task(shared: &Shared) -> Result<Vec<EditableTask>> {
 }
 
 /// Test if adding a normal task works as intended.
-#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tracing_test::traced_test]
 async fn test_edit_flow() -> Result<()> {
     let daemon = daemon().await?;
     let shared = &daemon.settings.shared;

--- a/pueue/tests/daemon/integration/edit.rs
+++ b/pueue/tests/daemon/integration/edit.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::path::PathBuf;
 
@@ -33,7 +33,6 @@ async fn create_edited_task(shared: &Shared) -> Result<Vec<EditableTask>> {
 
 /// Test if adding a normal task works as intended.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[tracing_test::traced_test]
 async fn test_edit_flow() -> Result<()> {
     let daemon = daemon().await?;
     let shared = &daemon.settings.shared;

--- a/pueue/tests/daemon/integration/environment_variables.rs
+++ b/pueue/tests/daemon/integration/environment_variables.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use pueue_lib::task::Task;
 
 use crate::helper::*;

--- a/pueue/tests/daemon/integration/environment_variables.rs
+++ b/pueue/tests/daemon/integration/environment_variables.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::task::Task;
 

--- a/pueue/tests/daemon/integration/group.rs
+++ b/pueue/tests/daemon/integration/group.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::prelude::*;
 
 use pueue_lib::{network::message::*, task::Task};
 

--- a/pueue/tests/daemon/integration/group.rs
+++ b/pueue/tests/daemon/integration/group.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{network::message::*, task::Task};
 

--- a/pueue/tests/daemon/integration/kill.rs
+++ b/pueue/tests/daemon/integration/kill.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pretty_assertions::assert_eq;
 use rstest::rstest;

--- a/pueue/tests/daemon/integration/kill.rs
+++ b/pueue/tests/daemon/integration/kill.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use pretty_assertions::assert_eq;
 use rstest::rstest;
 

--- a/pueue/tests/daemon/integration/log.rs
+++ b/pueue/tests/daemon/integration/log.rs
@@ -1,8 +1,9 @@
+use crate::prelude::*;
+
 use std::fs::read_to_string;
 use std::fs::File;
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
 use tempfile::TempDir;
 
 use pueue_lib::{network::message::*, task::Task};
@@ -111,7 +112,7 @@ async fn test_partial_log() -> Result<()> {
     let output = logs
         .output
         .clone()
-        .context("Didn't find output on TaskLogMessage")?;
+        .ok_or(eyre!("Didn't find output on TaskLogMessage"))?;
     let output = decompress_log(output)?;
 
     // Make sure it's the same
@@ -148,7 +149,7 @@ async fn test_correct_log_order() -> Result<()> {
     let output = logs
         .output
         .clone()
-        .context("Didn't find output on TaskLogMessage")?;
+        .ok_or(eyre!("Didn't find output on TaskLogMessage"))?;
     let output = decompress_log(output)?;
 
     // Make sure it's the same

--- a/pueue/tests/daemon/integration/log.rs
+++ b/pueue/tests/daemon/integration/log.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::fs::read_to_string;
 use std::fs::File;

--- a/pueue/tests/daemon/integration/parallel_tasks.rs
+++ b/pueue/tests/daemon/integration/parallel_tasks.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use assert_matches::assert_matches;
 
 use pueue_lib::{network::message::ParallelMessage, task::*};

--- a/pueue/tests/daemon/integration/parallel_tasks.rs
+++ b/pueue/tests/daemon/integration/parallel_tasks.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use assert_matches::assert_matches;
 

--- a/pueue/tests/daemon/integration/pause.rs
+++ b/pueue/tests/daemon/integration/pause.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
+
 use assert_matches::assert_matches;
 
 use pueue_lib::network::message::*;

--- a/pueue/tests/daemon/integration/pause.rs
+++ b/pueue/tests/daemon/integration/pause.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use assert_matches::assert_matches;
 

--- a/pueue/tests/daemon/integration/priority.rs
+++ b/pueue/tests/daemon/integration/priority.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use rstest::rstest;
 
 use pueue_lib::{network::message::TaskSelection, task::Task};

--- a/pueue/tests/daemon/integration/priority.rs
+++ b/pueue/tests/daemon/integration/priority.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use rstest::rstest;
 

--- a/pueue/tests/daemon/integration/remove.rs
+++ b/pueue/tests/daemon/integration/remove.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use pueue_lib::{network::message::*, task::Task};
 
 use crate::helper::*;

--- a/pueue/tests/daemon/integration/remove.rs
+++ b/pueue/tests/daemon/integration/remove.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{network::message::*, task::Task};
 

--- a/pueue/tests/daemon/integration/reset.rs
+++ b/pueue/tests/daemon/integration/reset.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{network::message::*, state::GroupStatus, task::Task};
 

--- a/pueue/tests/daemon/integration/reset.rs
+++ b/pueue/tests/daemon/integration/reset.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
+
 use pueue_lib::{network::message::*, state::GroupStatus, task::Task};
 
 use crate::helper::*;

--- a/pueue/tests/daemon/integration/restart.rs
+++ b/pueue/tests/daemon/integration/restart.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::path::PathBuf;
 

--- a/pueue/tests/daemon/integration/restart.rs
+++ b/pueue/tests/daemon/integration/restart.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::path::PathBuf;
 
-use anyhow::Result;
 use pueue_lib::{network::message::*, task::Task};
 
 use crate::helper::*;

--- a/pueue/tests/daemon/integration/restore.rs
+++ b/pueue/tests/daemon/integration/restore.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::prelude::*;
 
 use pueue_lib::network::message::TaskSelection;
 use pueue_lib::state::GroupStatus;

--- a/pueue/tests/daemon/integration/restore.rs
+++ b/pueue/tests/daemon/integration/restore.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::TaskSelection;
 use pueue_lib::state::GroupStatus;

--- a/pueue/tests/daemon/integration/shutdown.rs
+++ b/pueue/tests/daemon/integration/shutdown.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use crate::helper::*;
 

--- a/pueue/tests/daemon/integration/shutdown.rs
+++ b/pueue/tests/daemon/integration/shutdown.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use crate::prelude::*;
 
 use crate::helper::*;
 

--- a/pueue/tests/daemon/integration/socket_permissions.rs
+++ b/pueue/tests/daemon/integration/socket_permissions.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;

--- a/pueue/tests/daemon/integration/socket_permissions.rs
+++ b/pueue/tests/daemon/integration/socket_permissions.rs
@@ -1,8 +1,7 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
-
-use anyhow::Context;
 
 use crate::helper::*;
 

--- a/pueue/tests/daemon/integration/spawn.rs
+++ b/pueue/tests/daemon/integration/spawn.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::io::Read;
 
-use anyhow::{Context, Result};
 use rstest::rstest;
 
 use pueue_lib::{

--- a/pueue/tests/daemon/integration/spawn.rs
+++ b/pueue/tests/daemon/integration/spawn.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::io::Read;
 

--- a/pueue/tests/daemon/integration/start.rs
+++ b/pueue/tests/daemon/integration/start.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use crate::prelude::*;
+
 use rstest::rstest;
 
 use pueue_lib::{network::message::*, task::*};

--- a/pueue/tests/daemon/integration/start.rs
+++ b/pueue/tests/daemon/integration/start.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use rstest::rstest;
 

--- a/pueue/tests/daemon/integration/stashed.rs
+++ b/pueue/tests/daemon/integration/stashed.rs
@@ -1,4 +1,5 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
+
 use chrono::{DateTime, Local, TimeDelta};
 use rstest::rstest;
 

--- a/pueue/tests/daemon/integration/stashed.rs
+++ b/pueue/tests/daemon/integration/stashed.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use chrono::{DateTime, Local, TimeDelta};
 use rstest::rstest;

--- a/pueue/tests/daemon/integration/worker_environment_variables.rs
+++ b/pueue/tests/daemon/integration/worker_environment_variables.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::{network::message::TaskSelection, state::PUEUE_DEFAULT_GROUP, task::Task};
 

--- a/pueue/tests/daemon/integration/worker_environment_variables.rs
+++ b/pueue/tests/daemon/integration/worker_environment_variables.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::prelude::*;
 
 use pueue_lib::{network::message::TaskSelection, state::PUEUE_DEFAULT_GROUP, task::Task};
 

--- a/pueue/tests/daemon/state_backward_compatibility.rs
+++ b/pueue/tests/daemon/state_backward_compatibility.rs
@@ -1,7 +1,8 @@
+use crate::prelude::*;
+
 use std::fs::File;
 use std::io::prelude::*;
 
-use anyhow::{Context, Result};
 use pueue::daemon::state_helper::restore_state;
 use tempfile::TempDir;
 

--- a/pueue/tests/daemon/state_backward_compatibility.rs
+++ b/pueue/tests/daemon/state_backward_compatibility.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::fs::File;
 use std::io::prelude::*;

--- a/pueue/tests/helper/asserts.rs
+++ b/pueue/tests/helper/asserts.rs
@@ -1,4 +1,5 @@
-use anyhow::{bail, Result};
+use crate::prelude::*;
+
 use assert_matches::assert_matches;
 
 use pueue_lib::settings::Shared;

--- a/pueue/tests/helper/asserts.rs
+++ b/pueue/tests/helper/asserts.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use assert_matches::assert_matches;
 

--- a/pueue/tests/helper/daemon.rs
+++ b/pueue/tests/helper/daemon.rs
@@ -1,9 +1,10 @@
+use crate::prelude::*;
+
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::process::Child;
 
-use anyhow::{anyhow, bail, Context, Result};
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;
 
@@ -49,7 +50,7 @@ pub async fn get_pid(pid_path: &Path) -> Result<i32> {
 
         let pid = content
             .parse::<i32>()
-            .map_err(|_| anyhow!("Couldn't parse value: {content}"))?;
+            .map_err(|_| eyre!("Couldn't parse value: {content}"))?;
         return Ok(pid);
     }
 

--- a/pueue/tests/helper/daemon.rs
+++ b/pueue/tests/helper/daemon.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::fs::File;
 use std::io::Read;

--- a/pueue/tests/helper/factories/group.rs
+++ b/pueue/tests/helper/factories/group.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/factories/group.rs
+++ b/pueue/tests/helper/factories/group.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/factories/task.rs
+++ b/pueue/tests/helper/factories/task.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/factories/task.rs
+++ b/pueue/tests/helper/factories/task.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use crate::prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/fixtures.rs
+++ b/pueue/tests/helper/fixtures.rs
@@ -1,3 +1,5 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 use std::env::temp_dir;
 use std::fs::{canonicalize, File};
@@ -5,7 +7,6 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
-use anyhow::{bail, Context, Result};
 use assert_cmd::prelude::*;
 use tempfile::{Builder, TempDir};
 use tokio::io::{self, AsyncWriteExt};

--- a/pueue/tests/helper/fixtures.rs
+++ b/pueue/tests/helper/fixtures.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 use std::env::temp_dir;

--- a/pueue/tests/helper/lockfile.rs
+++ b/pueue/tests/helper/lockfile.rs
@@ -1,9 +1,9 @@
+use crate::prelude::*;
+
 use std::{
     fs::{remove_file, File},
     path::{Path, PathBuf},
 };
-
-use anyhow::{Context, Result};
 
 use super::{daemon_base_setup, daemon_with_settings, PueueDaemon};
 

--- a/pueue/tests/helper/lockfile.rs
+++ b/pueue/tests/helper/lockfile.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::{
     fs::{remove_file, File},

--- a/pueue/tests/helper/log.rs
+++ b/pueue/tests/helper/log.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::io::Read;
 

--- a/pueue/tests/helper/log.rs
+++ b/pueue/tests/helper/log.rs
@@ -1,6 +1,7 @@
+use crate::prelude::*;
+
 use std::io::Read;
 
-use anyhow::{bail, Context, Result};
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;
 use snap::read::FrameDecoder;
@@ -36,10 +37,10 @@ pub async fn get_task_log(shared: &Shared, task_id: usize, lines: Option<usize>)
 
     let log = logs
         .remove(&task_id)
-        .context("Didn't find log of requested task")?;
+        .ok_or(eyre!("Didn't find log of requested task"))?;
     let bytes = log
         .output
-        .context("Didn't get log output even though requested.")?;
+        .ok_or(eyre!("Didn't get log output even though requested."))?;
 
     decompress_log(bytes)
 }

--- a/pueue/tests/helper/mod.rs
+++ b/pueue/tests/helper/mod.rs
@@ -1,5 +1,5 @@
 //! This module contains helper functions, which are used by both, the client and daemon tests.
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use tokio::io::{self, AsyncWriteExt};
 

--- a/pueue/tests/helper/mod.rs
+++ b/pueue/tests/helper/mod.rs
@@ -1,7 +1,6 @@
 //! This module contains helper functions, which are used by both, the client and daemon tests.
-use ::log::{warn, LevelFilter};
-use anyhow::Result;
-use simplelog::{Config, ConfigBuilder, TermLogger, TerminalMode};
+use crate::prelude::*;
+
 use tokio::io::{self, AsyncWriteExt};
 
 pub use pueue_lib::state::PUEUE_DEFAULT_GROUP;
@@ -34,26 +33,8 @@ const TIMEOUT: u64 = 5000;
 /// Use this function to enable log output for in-runtime daemon output.
 #[allow(dead_code)]
 pub fn enable_logger() {
-    let level = LevelFilter::Debug;
-
-    // Try to initialize the logger with the timezone set to the Local time of the machine.
-    let mut builder = ConfigBuilder::new();
-    let logger_config = match builder.set_time_offset_to_local() {
-        Err(_) => {
-            warn!("Failed to determine the local time of this machine. Fallback to UTC.");
-            Config::default()
-        }
-        Ok(builder) => builder.build(),
-    };
-
-    // Init a terminal logger
-    TermLogger::init(
-        level,
-        logger_config.clone(),
-        TerminalMode::Stderr,
-        simplelog::ColorChoice::Auto,
-    )
-    .unwrap()
+    pueue::tracing::install_tracing(3)
+        .expect("Couldn't init tracing for test, have you initialised tracing twice?");
 }
 
 /// A helper function to sleep for ms time.

--- a/pueue/tests/helper/network.rs
+++ b/pueue/tests/helper/network.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::network::protocol::{

--- a/pueue/tests/helper/network.rs
+++ b/pueue/tests/helper/network.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Result};
+use crate::prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::network::protocol::{
@@ -18,12 +18,12 @@ where
     // Check if we can receive the response from the daemon
     internal_send_message(message, &mut stream)
         .await
-        .map_err(|err| anyhow!("Failed to send message: {err}"))?;
+        .map_err(|err| eyre!("Failed to send message: {err}"))?;
 
     // Check if we can receive the response from the daemon
     receive_message(&mut stream)
         .await
-        .map_err(|err| anyhow!("Failed to receive message: {err}"))
+        .map_err(|err| eyre!("Failed to receive message: {err}"))
 }
 
 /// Create a new stream that already finished the handshake and secret exchange.

--- a/pueue/tests/helper/state.rs
+++ b/pueue/tests/helper/state.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/state.rs
+++ b/pueue/tests/helper/state.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use crate::prelude::*;
 
 use pueue_lib::network::message::*;
 use pueue_lib::settings::*;

--- a/pueue/tests/helper/task.rs
+++ b/pueue/tests/helper/task.rs
@@ -1,7 +1,7 @@
+use crate::prelude::*;
+
 use std::collections::HashMap;
 use std::env::vars;
-
-use anyhow::{anyhow, Context, Result};
 
 use chrono::{DateTime, Local};
 use pueue_lib::network::message::*;
@@ -66,7 +66,7 @@ pub async fn get_task(shared: &Shared, task_id: usize) -> Result<Task> {
     let task = state
         .tasks
         .get(&0)
-        .ok_or_else(|| anyhow!("Couldn't find task {task_id}"))?;
+        .ok_or_else(|| eyre!("Couldn't find task {task_id}"))?;
 
     Ok(task.clone())
 }

--- a/pueue/tests/helper/task.rs
+++ b/pueue/tests/helper/task.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use std::collections::HashMap;
 use std::env::vars;

--- a/pueue/tests/helper/wait.rs
+++ b/pueue/tests/helper/wait.rs
@@ -4,7 +4,7 @@
 ///
 /// Using continuous lookups, we can allow long waiting times, while still having fast tests if
 /// things don't take that long.
-use anyhow::{bail, Result};
+use crate::prelude::*;
 
 use pueue_lib::settings::Shared;
 use pueue_lib::state::GroupStatus;

--- a/pueue/tests/helper/wait.rs
+++ b/pueue/tests/helper/wait.rs
@@ -4,7 +4,7 @@
 ///
 /// Using continuous lookups, we can allow long waiting times, while still having fast tests if
 /// things don't take that long.
-use crate::prelude::*;
+use crate::internal_prelude::*;
 
 use pueue_lib::settings::Shared;
 use pueue_lib::state::GroupStatus;

--- a/pueue/tests/tests.rs
+++ b/pueue/tests/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-mod prelude {
+mod internal_prelude {
     pub use color_eyre::eyre::{bail, eyre, WrapErr};
     pub use color_eyre::Result;
 }

--- a/pueue/tests/tests.rs
+++ b/pueue/tests/tests.rs
@@ -1,4 +1,10 @@
 #[cfg(unix)]
+mod prelude {
+    pub use color_eyre::eyre::{bail, eyre, WrapErr};
+    pub use color_eyre::Result;
+}
+
+#[cfg(unix)]
 mod helper;
 
 #[cfg(unix)]

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres **somewhat** to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The concept of SemVer is applied to the daemon/client API, but not the library API itself.
 
+## [0.27.0] - 2024-12-01
+
+### Added
+
+- Introduce re-usable `Children` Process representation.
+
+### Removed
+
+- Remove unused `reset_task_log_directory`
+- Add `EnvMessage` to set/unset environment variables on tasks.
+- `netbsd` support
+
+### Changed
+
+- Rework how `reset` works. `Reset` now works on a per-group basis.
+  Full reset simply means that all groups are to be reset.
+- Move **all** state into the `State` struct.
+  This prevents concurrency issues and fixes many issues.
+  The new runtime-dependant fields aren't serialized.
+- Rework `TaskState` representation enum to include all runtime-dependant fields.
+  As a result, several fields have been removed from `Task.
+- Make `Stash` Message payload a struct.
+- Make `EditRestore`, `EditRequest` Message payload a vector of task ids.
+- Make `Edit` Message payload a vector the new `EditableTask`.
+- Change editing structs so that all values are always set (no more optionals
+- Change `ResetMessage` to use new `ResetTarget` enum.
+
+### Fix
+
+- Unix socket permission handling
+
 ## [0.26.0] - 2024-03-22
 
 ### Added
@@ -54,7 +85,6 @@ The concept of SemVer is applied to the daemon/client API, but not the library A
 
 This version was skipped due to a error during release :).
 
-
 ## [0.21.3] - 2023-02-12
 
 ### Changed
@@ -66,7 +96,7 @@ This version was skipped due to a error during release :).
 ### Fix
 
 - Point to a new patched fork of `darwin-libproc`, as the original has been deleted.
-    This fixes the development builts for pueue on Apple platforms.
+  This fixes the development builts for pueue on Apple platforms.
 
 ## [0.21.0] - 2022-12-12
 
@@ -78,7 +108,7 @@ This version was skipped due to a error during release :).
 - Make `EditMessage::path` and `EditMessage::command` optional.
 - The `children` flag has been removed for the `Start`-,`Pause`-,`Kill`- and `ResetMessage`.
 - No longer support TLS 1.2 certificates, only accept version 1.3.
-    All generated certificates were 1.3 anyway, so there shouldn't be any breakage, except users created their own certs.
+  All generated certificates were 1.3 anyway, so there shouldn't be any breakage, except users created their own certs.
 
 ### Added
 
@@ -94,7 +124,7 @@ This version was skipped due to a error during release :).
 
 - The module structure of the platform specific networking code has been streamlined.
 - The process handling code has been moved from the daemon to `pueue_lib`. See [#336](https://github.com/Nukesor/pueue/issues/336).
-    The reason for this is, that the client will need some of these process handling capabilitites to spawn shell commands when editing tasks.
+  The reason for this is, that the client will need some of these process handling capabilitites to spawn shell commands when editing tasks.
 
 ## [0.20.0] - 2022-07-21
 
@@ -106,15 +136,15 @@ This version was skipped due to a error during release :).
 
 - Breaking change: Backward compatibility logic for the old group structure in the main state.
 - Breaking change:
-    The `State` no longer owns a copy of the current settings.
-    This became possible due to the group configuration no longer being part of the configuration file.
+  The `State` no longer owns a copy of the current settings.
+  This became possible due to the group configuration no longer being part of the configuration file.
 
 ### Fixed
 
 - The networking logic wasn't able to handle rapid successiv messages until now.
-    If two messages were sent in quick succession, the client would receive both messages in one go.
-    The reason for this was simply that the receiving buffer was always of a size of 1400 Bytes, even if the actual payload was much smaller.
-    This wasn't a problem until now as there was no scenario where two messages were send immediately one after another.
+  If two messages were sent in quick succession, the client would receive both messages in one go.
+  The reason for this was simply that the receiving buffer was always of a size of 1400 Bytes, even if the actual payload was much smaller.
+  This wasn't a problem until now as there was no scenario where two messages were send immediately one after another.
 
 ## [0.19.6] - unreleased
 
@@ -187,7 +217,7 @@ This version was skipped due to a error during release :).
 - **Breaking:** The unix socket is now located in the `runtime_directory` by default [#243](https://github.com/Nukesor/pueue/issues/243).
 - **Breaking:** `Shared::pueue_directory` changed from `PathBuf` to `Option<PathBuf>`.
 - **Breaking:** `Settings::read_with_defaults` no longer a boolean as first parameter.
-    Instead, it returns a tuple of `(Settings, bool)` with the boolean indicating whether a config file has been found.
+  Instead, it returns a tuple of `(Settings, bool)` with the boolean indicating whether a config file has been found.
 - **Breaking:** The type of `State.group` changed from `BTreeMap<String, GroupStatus>` to the new `BTreeMap<String, Group>` struct.
 - **Breaking:** The `GroupResponseMessage` now also uses the new `Group` struct.
 
@@ -296,7 +326,7 @@ Several non-backward compatible breaking API changes to prevent impossible state
 - `~` is now respected in configuration paths by [dadav](https://github.com/dadav) for [Pueue #191](https://github.com/Nukesor/pueue/issues/191).
 - New function `read_last_log_file_lines` for [#196](https://github.com/Nukesor/pueue/issues/196).
 - Add `callback_log_lines` setting for Daemon, specifying the amount of lines returned to the callback. [#196](https://github.com/Nukesor/pueue/issues/196).
-- Support for other `apple` platforms by [althiometer](https://github.com/althiometer)
+- Support for other `apple` platforms.
 - Added backward compatibility tests for v0.12.2 state.
 - Added SignalMessage and Signal enum for a list of all supported Unix signals.
 
@@ -309,7 +339,7 @@ Several non-backward compatible breaking API changes to prevent impossible state
 ### Changed
 
 - Clippy adjustment: Transform `&PathBuf` to `&Path` in function parameter types.
-    This should be reverse-compatible, since `&PathBuf` dereferences to `&Path`.
+  This should be reverse-compatible, since `&PathBuf` dereferences to `&Path`.
 
 ## [0.12.1] - 09-02-2021
 
@@ -337,7 +367,7 @@ Moved into a stand-alone repository for better maintainability.
 ### Changed
 
 - Use `127.0.0.1` instead of `localhost` as default host.
-    This prevents any unforseen consequences if somebody deletes the default `localhost` entry from their `/etc/hosts` file.
+  This prevents any unforseen consequences if somebody deletes the default `localhost` entry from their `/etc/hosts` file.
 
 ## [0.11.0] - 18-01-2020
 

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -6,37 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres **somewhat** to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The concept of SemVer is applied to the daemon/client API, but not the library API itself.
 
-## [0.27.0] - 2024-12-01
-
-### Added
-
-- Introduce re-usable `Children` Process representation.
-
-### Removed
-
-- Remove unused `reset_task_log_directory`
-- Add `EnvMessage` to set/unset environment variables on tasks.
-- `netbsd` support
-
-### Changed
-
-- Rework how `reset` works. `Reset` now works on a per-group basis.
-  Full reset simply means that all groups are to be reset.
-- Move **all** state into the `State` struct.
-  This prevents concurrency issues and fixes many issues.
-  The new runtime-dependant fields aren't serialized.
-- Rework `TaskState` representation enum to include all runtime-dependant fields.
-  As a result, several fields have been removed from `Task.
-- Make `Stash` Message payload a struct.
-- Make `EditRestore`, `EditRequest` Message payload a vector of task ids.
-- Make `Edit` Message payload a vector the new `EditableTask`.
-- Change editing structs so that all values are always set (no more optionals
-- Change `ResetMessage` to use new `ResetTarget` enum.
-
-### Fix
-
-- Unix socket permission handling
-
 ## [0.26.0] - 2024-03-22
 
 ### Added
@@ -85,6 +54,7 @@ The concept of SemVer is applied to the daemon/client API, but not the library A
 
 This version was skipped due to a error during release :).
 
+
 ## [0.21.3] - 2023-02-12
 
 ### Changed
@@ -96,7 +66,7 @@ This version was skipped due to a error during release :).
 ### Fix
 
 - Point to a new patched fork of `darwin-libproc`, as the original has been deleted.
-  This fixes the development builts for pueue on Apple platforms.
+    This fixes the development builts for pueue on Apple platforms.
 
 ## [0.21.0] - 2022-12-12
 
@@ -108,7 +78,7 @@ This version was skipped due to a error during release :).
 - Make `EditMessage::path` and `EditMessage::command` optional.
 - The `children` flag has been removed for the `Start`-,`Pause`-,`Kill`- and `ResetMessage`.
 - No longer support TLS 1.2 certificates, only accept version 1.3.
-  All generated certificates were 1.3 anyway, so there shouldn't be any breakage, except users created their own certs.
+    All generated certificates were 1.3 anyway, so there shouldn't be any breakage, except users created their own certs.
 
 ### Added
 
@@ -124,7 +94,7 @@ This version was skipped due to a error during release :).
 
 - The module structure of the platform specific networking code has been streamlined.
 - The process handling code has been moved from the daemon to `pueue_lib`. See [#336](https://github.com/Nukesor/pueue/issues/336).
-  The reason for this is, that the client will need some of these process handling capabilitites to spawn shell commands when editing tasks.
+    The reason for this is, that the client will need some of these process handling capabilitites to spawn shell commands when editing tasks.
 
 ## [0.20.0] - 2022-07-21
 
@@ -136,15 +106,15 @@ This version was skipped due to a error during release :).
 
 - Breaking change: Backward compatibility logic for the old group structure in the main state.
 - Breaking change:
-  The `State` no longer owns a copy of the current settings.
-  This became possible due to the group configuration no longer being part of the configuration file.
+    The `State` no longer owns a copy of the current settings.
+    This became possible due to the group configuration no longer being part of the configuration file.
 
 ### Fixed
 
 - The networking logic wasn't able to handle rapid successiv messages until now.
-  If two messages were sent in quick succession, the client would receive both messages in one go.
-  The reason for this was simply that the receiving buffer was always of a size of 1400 Bytes, even if the actual payload was much smaller.
-  This wasn't a problem until now as there was no scenario where two messages were send immediately one after another.
+    If two messages were sent in quick succession, the client would receive both messages in one go.
+    The reason for this was simply that the receiving buffer was always of a size of 1400 Bytes, even if the actual payload was much smaller.
+    This wasn't a problem until now as there was no scenario where two messages were send immediately one after another.
 
 ## [0.19.6] - unreleased
 
@@ -217,7 +187,7 @@ This version was skipped due to a error during release :).
 - **Breaking:** The unix socket is now located in the `runtime_directory` by default [#243](https://github.com/Nukesor/pueue/issues/243).
 - **Breaking:** `Shared::pueue_directory` changed from `PathBuf` to `Option<PathBuf>`.
 - **Breaking:** `Settings::read_with_defaults` no longer a boolean as first parameter.
-  Instead, it returns a tuple of `(Settings, bool)` with the boolean indicating whether a config file has been found.
+    Instead, it returns a tuple of `(Settings, bool)` with the boolean indicating whether a config file has been found.
 - **Breaking:** The type of `State.group` changed from `BTreeMap<String, GroupStatus>` to the new `BTreeMap<String, Group>` struct.
 - **Breaking:** The `GroupResponseMessage` now also uses the new `Group` struct.
 
@@ -326,7 +296,7 @@ Several non-backward compatible breaking API changes to prevent impossible state
 - `~` is now respected in configuration paths by [dadav](https://github.com/dadav) for [Pueue #191](https://github.com/Nukesor/pueue/issues/191).
 - New function `read_last_log_file_lines` for [#196](https://github.com/Nukesor/pueue/issues/196).
 - Add `callback_log_lines` setting for Daemon, specifying the amount of lines returned to the callback. [#196](https://github.com/Nukesor/pueue/issues/196).
-- Support for other `apple` platforms.
+- Support for other `apple` platforms by [althiometer](https://github.com/althiometer)
 - Added backward compatibility tests for v0.12.2 state.
 - Added SignalMessage and Signal enum for a list of all supported Unix signals.
 
@@ -339,7 +309,7 @@ Several non-backward compatible breaking API changes to prevent impossible state
 ### Changed
 
 - Clippy adjustment: Transform `&PathBuf` to `&Path` in function parameter types.
-  This should be reverse-compatible, since `&PathBuf` dereferences to `&Path`.
+    This should be reverse-compatible, since `&PathBuf` dereferences to `&Path`.
 
 ## [0.12.1] - 09-02-2021
 
@@ -367,7 +337,7 @@ Moved into a stand-alone repository for better maintainability.
 ### Changed
 
 - Use `127.0.0.1` instead of `localhost` as default host.
-  This prevents any unforseen consequences if somebody deletes the default `localhost` entry from their `/etc/hosts` file.
+    This prevents any unforseen consequences if somebody deletes the default `localhost` entry from their `/etc/hosts` file.
 
 ## [0.11.0] - 18-01-2020
 

--- a/pueue_lib/Cargo.toml
+++ b/pueue_lib/Cargo.toml
@@ -15,14 +15,13 @@ rust-version.workspace = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-anyhow = "1.0"
 async-trait = "0.1"
 byteorder = "1.5"
 chrono.workspace = true
+color-eyre.workspace = true
 command-group.workspace = true
 dirs = "6.0"
 handlebars.workspace = true
-log.workspace = true
 rand = "0.8"
 rcgen = "0.13"
 rev_buf_reader = "0.3"
@@ -43,9 +42,9 @@ strum.workspace = true
 thiserror = "2"
 tokio = { workspace = true, features = ["io-util", "macros", "net"] }
 tokio-rustls = { version = "0.26", default-features = false }
+tracing.workspace = true
 
 [dev-dependencies]
-anyhow.workspace = true
 better-panic.workspace = true
 portpicker = "0.1"
 pretty_assertions.workspace = true

--- a/pueue_lib/src/aliasing.rs
+++ b/pueue_lib/src/aliasing.rs
@@ -1,8 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
-
-use log::info;
 
 use crate::error::Error;
 use crate::settings::Settings;

--- a/pueue_lib/src/lib.rs
+++ b/pueue_lib/src/lib.rs
@@ -1,7 +1,8 @@
 #![doc = include_str!("../README.md")]
 
 pub(crate) mod internal_prelude {
-    #[allow(unused_imports)]
+    #![allow(unused_imports)]
+    pub use color_eyre::{eyre::bail, Result};
     pub use tracing::{debug, error, info, trace, warn};
 }
 

--- a/pueue_lib/src/lib.rs
+++ b/pueue_lib/src/lib.rs
@@ -1,5 +1,10 @@
 #![doc = include_str!("../README.md")]
 
+pub(crate) mod internal_prelude {
+    #[allow(unused_imports)]
+    pub use tracing::{debug, error, info, trace, warn};
+}
+
 /// Shared module for internal logic!
 /// Contains helper for command aliasing.
 pub mod aliasing;

--- a/pueue_lib/src/log.rs
+++ b/pueue_lib/src/log.rs
@@ -1,8 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::fs::{remove_file, File};
 use std::io::{self, prelude::*, Read, SeekFrom};
 use std::path::{Path, PathBuf};
 
-use log::error;
 use rev_buf_reader::RevBufReader;
 use snap::write::FrameEncoder;
 

--- a/pueue_lib/src/network/certificate.rs
+++ b/pueue_lib/src/network/certificate.rs
@@ -1,8 +1,9 @@
+use crate::internal_prelude::*;
+
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-use log::info;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 
 use crate::error::Error;

--- a/pueue_lib/src/network/protocol.rs
+++ b/pueue_lib/src/network/protocol.rs
@@ -1,7 +1,8 @@
+use crate::internal_prelude::*;
+
 use std::io::Cursor;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use log::debug;
 use serde_cbor::de::from_slice;
 use serde_cbor::ser::to_vec;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/pueue_lib/src/network/socket/unix.rs
+++ b/pueue_lib/src/network/socket/unix.rs
@@ -1,9 +1,10 @@
+use crate::internal_prelude::*;
+
 use std::convert::TryFrom;
 use std::fs::{set_permissions, Permissions};
 use std::os::unix::fs::PermissionsExt;
 
 use async_trait::async_trait;
-use log::info;
 use rustls::pki_types::ServerName;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream, UnixListener, UnixSocket, UnixStream};

--- a/pueue_lib/src/network/tls.rs
+++ b/pueue_lib/src/network/tls.rs
@@ -53,7 +53,6 @@ fn load_certs<'a>(path: &Path) -> Result<Vec<CertificateDer<'a>>, Error> {
         .collect::<Result<Vec<_>, std::io::Error>>()
         .map_err(|_| Error::CertificateFailure("Failed to parse daemon certificate.".into()))?
         .into_iter()
-        .map(CertificateDer::from)
         .collect();
 
     Ok(certs)
@@ -98,7 +97,6 @@ fn load_ca<'a>(path: &Path) -> Result<CertificateDer<'a>, Error> {
         .collect::<Result<Vec<_>, std::io::Error>>()
         .map_err(|_| Error::CertificateFailure("Failed to parse daemon certificate.".into()))?
         .into_iter()
-        .map(CertificateDer::from)
         .next()
         .ok_or_else(|| Error::CertificateFailure("Couldn't find CA certificate in file".into()))?;
 

--- a/pueue_lib/src/process_helper/mod.rs
+++ b/pueue_lib/src/process_helper/mod.rs
@@ -3,6 +3,7 @@
 //! The submodules of this module represent the different implementations for
 //! each supported platform.
 //! Depending on the target, the respective platform is read and loaded into this scope.
+use crate::internal_prelude::*;
 
 use std::{collections::HashMap, process::Command};
 
@@ -92,12 +93,14 @@ pub fn compile_shell_command(settings: &Settings, command: &str) -> Command {
 
     // Inject custom environment variables.
     if !settings.daemon.env_vars.is_empty() {
-        log::info!(
+        info!(
             "Inject environment variables: {:?}",
             &settings.daemon.env_vars
         );
         command.envs(&settings.daemon.env_vars);
     }
+
+    debug!(message = "Prepared command before spawn", ?command);
 
     command
 }

--- a/pueue_lib/src/process_helper/unix.rs
+++ b/pueue_lib/src/process_helper/unix.rs
@@ -1,9 +1,10 @@
+use crate::internal_prelude::*;
+
 // We allow anyhow in here, as this is a module that'll be strictly used internally.
 // As soon as it's obvious that this is code is intended to be exposed to library users, we have to
 // go ahead and replace any `anyhow` usage by proper error handling via our own Error type.
-use anyhow::Result;
+use color_eyre::Result;
 use command_group::{GroupChild, Signal, UnixChildExt};
-use log::info;
 
 use crate::settings::Settings;
 
@@ -44,14 +45,15 @@ pub fn kill_child(task_id: usize, child: &mut GroupChild) -> std::io::Result<()>
 
 #[cfg(test)]
 mod tests {
+    use crate::internal_prelude::*;
+
     use std::process::Command;
     use std::thread::sleep;
     use std::time::Duration;
 
-    use anyhow::Result;
+    use color_eyre::Result;
     use command_group::CommandGroup;
     use libproc::processes::{pids_by_type, ProcFilter};
-    use log::warn;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/pueue_lib/src/process_helper/unix.rs
+++ b/pueue_lib/src/process_helper/unix.rs
@@ -1,6 +1,6 @@
 use crate::internal_prelude::*;
 
-// We allow anyhow in here, as this is a module that'll be strictly used internally.
+// We allow color_eyre in here, as this is a module that'll be strictly used internally.
 // As soon as it's obvious that this is code is intended to be exposed to library users, we have to
 // go ahead and replace any `anyhow` usage by proper error handling via our own Error type.
 use color_eyre::Result;

--- a/pueue_lib/src/process_helper/windows.rs
+++ b/pueue_lib/src/process_helper/windows.rs
@@ -1,9 +1,8 @@
 // We allow color_eyre in here, as this is a module that'll be strictly used internally.
 // As soon as it's obvious that this is code is intended to be exposed to library users, we have to
 // go ahead and replace any `anyhow` usage by proper error handling via our own Error type.
-use color_eyre::{bail, Result};
+use crate::internal_prelude::*;
 use command_group::GroupChild;
-use tracing::{error, info, warn};
 use winapi::shared::minwindef::FALSE;
 use winapi::shared::ntdef::NULL;
 use winapi::um::errhandlingapi::GetLastError;

--- a/pueue_lib/src/process_helper/windows.rs
+++ b/pueue_lib/src/process_helper/windows.rs
@@ -1,9 +1,9 @@
-// We allow anyhow in here, as this is a module that'll be strictly used internally.
+// We allow color_eyre in here, as this is a module that'll be strictly used internally.
 // As soon as it's obvious that this is code is intended to be exposed to library users, we have to
 // go ahead and replace any `anyhow` usage by proper error handling via our own Error type.
-use anyhow::{bail, Result};
+use color_eyre::{bail, Result};
 use command_group::GroupChild;
-use log::{error, info, warn};
+use tracing::{error, info, warn};
 use winapi::shared::minwindef::FALSE;
 use winapi::shared::ntdef::NULL;
 use winapi::um::errhandlingapi::GetLastError;

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -1,9 +1,10 @@
+use crate::internal_prelude::*;
+
 use std::collections::HashMap;
 use std::fs::{create_dir_all, File};
 use std::io::{prelude::*, BufReader};
 use std::path::{Path, PathBuf};
 
-use log::info;
 use serde::{Deserialize, Serialize};
 use shellexpand::tilde;
 

--- a/pueue_lib/tests/settings_backward_compatibility.rs
+++ b/pueue_lib/tests/settings_backward_compatibility.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use color_eyre::{eyre::WrapErr, Result};
 
 use pueue_lib::settings::Settings;
 
@@ -24,7 +24,7 @@ fn test_restore_from_old_state() -> Result<()> {
 
     // Open v0.15.0 file and ensure the settings file can be read.
     let (_settings, config_found) = Settings::read(&Some(old_settings_path))
-        .context("Failed to read old config with defaults:")?;
+        .wrap_err("Failed to read old config with defaults:")?;
 
     assert!(config_found);
 

--- a/pueue_lib/tests/state_backward_compatibility.rs
+++ b/pueue_lib/tests/state_backward_compatibility.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf};
 
-use anyhow::{Context, Result};
+use color_eyre::{eyre::WrapErr, Result};
 
 use pueue_lib::state::{GroupStatus, State, PUEUE_DEFAULT_GROUP};
 
@@ -24,9 +24,9 @@ fn test_restore_from_old_state() -> Result<()> {
         .join("v4.0.0_state.json");
 
     // Try to load the file.
-    let data = fs::read_to_string(path).context("State restore: Failed to read file")?;
+    let data = fs::read_to_string(path).wrap_err("State restore: Failed to read file")?;
     // Try to deserialize the state file.
-    let state: State = serde_json::from_str(&data).context("Failed to deserialize state.")?;
+    let state: State = serde_json::from_str(&data).wrap_err("Failed to deserialize state.")?;
 
     // Make sure the groups are loaded.
     assert!(

--- a/pueue_lib/tests/tls_socket.rs
+++ b/pueue_lib/tests/tls_socket.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use color_eyre::Result;
 use pretty_assertions::assert_eq;
 use serde_cbor::de::from_slice;
 use serde_cbor::ser::to_vec;

--- a/pueue_lib/tests/unix_socket.rs
+++ b/pueue_lib/tests/unix_socket.rs
@@ -3,7 +3,7 @@ mod helper;
 
 #[cfg(not(target_os = "windows"))]
 mod tests {
-    use anyhow::Result;
+    use color_eyre::Result;
     use pretty_assertions::assert_eq;
     use serde_cbor::de::from_slice;
     use serde_cbor::ser::to_vec;


### PR DESCRIPTION
These changes make errors go from this:
![image](https://github.com/user-attachments/assets/a6b91b40-edb9-42ad-a799-4437a01ea3b0)
To this:
![image](https://github.com/user-attachments/assets/a9d1804d-6807-4eb6-bf5e-1cd0cfa9377b)

And logs from this:
![image](https://github.com/user-attachments/assets/f60be018-6c35-4503-a6c2-3360b722e693)
To this:
![image](https://github.com/user-attachments/assets/7c359671-9cc6-4f52-9317-11d6488711c8)

## Breaking changes:
Maybe `anyhow` was accidentally exposed somewhere? `color-eyre` was not exposed anywhere that `anyhow` wasn't, so for library usage this is a breaking change
The default logging implementation used only logs to stderr, I don't know if there was some logic in the old implementation to send some logs to stdout and some to stderr, but its now all consistent to stderr

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.

Due to my unfortunately lacking `git` skills, there was an old PR with a branch with a rebase mistake I'm not bothered to learn how to fix [here](https://github.com/Nukesor/pueue/pull/602)