### PR TITLE
Split message enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Upon updating Pueue and restarting the daemon, the previous state will be wiped,
   Pueue now allows editing all properties a task in one editor session. There're two modes to do so: `toml` and `files`.
 - Revisited, fixed and cleaned up CLI help texts.
 - Print most of Pueue's info/log messages to `stderr`. Only keep useful stuff like json and task log output on `stdout`.
-- **Breaking**: Ported from `anyhow::Error` to `color_eyre::Report`, which shouldn't break non-lib compatability
+- **Breaking**: Ported from `anyhow` to `color_eyre` for prettier log output.
 
 ### Add
 

--- a/pueue/src/client/commands/mod.rs
+++ b/pueue/src/client/commands/mod.rs
@@ -7,9 +7,10 @@
 
 use crate::internal_prelude::*;
 
+use pueue_lib::network::message::Response;
 use pueue_lib::network::protocol::*;
 use pueue_lib::state::State;
-use pueue_lib::{network::message::Message, task::Task};
+use pueue_lib::{network::message::Request, task::Task};
 
 mod edit;
 mod format_state;
@@ -27,13 +28,13 @@ pub use wait::{wait, WaitTargetStatus};
 // The current daemon state is often needed in more complex commands.
 pub async fn get_state(stream: &mut GenericStream) -> Result<State> {
     // Create the message payload and send it to the daemon.
-    send_message(Message::Status, stream).await?;
+    send_request(Request::Status, stream).await?;
 
     // Check if we can receive the response from the daemon
-    let message = receive_message(stream).await?;
+    let response = receive_response(stream).await?;
 
-    match message {
-        Message::StatusResponse(state) => Ok(*state),
+    match response {
+        Response::Status(state) => Ok(*state),
         _ => unreachable!(),
     }
 }
@@ -41,13 +42,13 @@ pub async fn get_state(stream: &mut GenericStream) -> Result<State> {
 // This is a helper function for easy retrieval of a single task from the daemon state.
 pub async fn get_task(stream: &mut GenericStream, task_id: usize) -> Result<Option<Task>> {
     // Create the message payload and send it to the daemon.
-    send_message(Message::Status, stream).await?;
+    send_request(Request::Status, stream).await?;
 
     // Check if we can receive the response from the daemon
-    let message = receive_message(stream).await?;
+    let response = receive_response(stream).await?;
 
-    let state = match message {
-        Message::StatusResponse(state) => state,
+    let state = match response {
+        Response::Status(state) => state,
         _ => unreachable!(),
     };
 

--- a/pueue/src/client/commands/restart.rs
+++ b/pueue/src/client/commands/restart.rs
@@ -146,16 +146,16 @@ pub async fn restart(
         };
 
         // Send the cloned task to the daemon and abort on any failure messages.
-        send_message(add_task_message, stream).await?;
-        if let Message::Failure(message) = receive_message(stream).await? {
+        send_request(add_task_message, stream).await?;
+        if let Response::Failure(message) = receive_response(stream).await? {
             bail!(message);
         };
     }
 
     // Send the singular in-place restart message to the daemon.
     if in_place {
-        send_message(restart_message, stream).await?;
-        if let Message::Failure(message) = receive_message(stream).await? {
+        send_request(restart_message, stream).await?;
+        if let Response::Failure(message) = receive_response(stream).await? {
             bail!(message);
         };
     }

--- a/pueue/src/client/display/group.rs
+++ b/pueue/src/client/display/group.rs
@@ -1,7 +1,7 @@
 use crossterm::style::{Attribute, Color};
 
 use pueue_lib::{
-    network::message::GroupResponseMessage,
+    network::message::response::GroupResponseMessage,
     state::{Group, GroupStatus},
 };
 

--- a/pueue/src/daemon/network/message_handler/add.rs
+++ b/pueue/src/daemon/network/message_handler/add.rs
@@ -13,10 +13,10 @@ use crate::ok_or_save_state_failure;
 /// Invoked when calling `pueue add`.
 /// Queues a new task to the state.
 /// If the start_immediately flag is set, send a StartMessage to the task handler.
-pub fn add_task(settings: &Settings, state: &SharedState, message: AddMessage) -> Message {
+pub fn add_task(settings: &Settings, state: &SharedState, message: AddMessage) -> Response {
     let mut state = state.lock().unwrap();
-    if let Err(message) = ensure_group_exists(&mut state, &message.group) {
-        return message;
+    if let Err(response) = ensure_group_exists(&mut state, &message.group) {
+        return response;
     }
 
     // Ensure that specified dependencies actually exist.

--- a/pueue/src/daemon/network/message_handler/clean.rs
+++ b/pueue/src/daemon/network/message_handler/clean.rs
@@ -24,7 +24,7 @@ fn construct_success_clean_message(message: CleanMessage) -> String {
 
 /// Invoked when calling `pueue clean`.
 /// Remove all failed or done tasks from the state.
-pub fn clean(settings: &Settings, state: &SharedState, message: CleanMessage) -> Message {
+pub fn clean(settings: &Settings, state: &SharedState, message: CleanMessage) -> Response {
     let mut state = state.lock().unwrap();
 
     let filtered_tasks =
@@ -64,7 +64,7 @@ pub fn clean(settings: &Settings, state: &SharedState, message: CleanMessage) ->
 
     ok_or_save_state_failure!(save_state(&state, settings));
 
-    create_success_message(construct_success_clean_message(message))
+    create_success_response(construct_success_clean_message(message))
 }
 
 #[cfg(test)]
@@ -125,8 +125,8 @@ mod tests {
         let message = clean(&settings, &state, get_message(false, None));
 
         // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        assert!(matches!(message, Response::Success(_)));
+        if let Response::Success(text) = message {
             assert_eq!(text, "All finished tasks have been removed");
         };
 
@@ -142,8 +142,8 @@ mod tests {
         let message = clean(&settings, &state, get_message(false, None));
 
         // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        assert!(matches!(message, Response::Success(_)));
+        if let Response::Success(text) = message {
             assert_eq!(text, "All finished tasks have been removed");
         };
 
@@ -160,8 +160,8 @@ mod tests {
         let message = clean(&settings, &state, get_message(true, None));
 
         // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        assert!(matches!(message, Response::Success(_)));
+        if let Response::Success(text) = message {
             assert_eq!(text, "All successfully finished tasks have been removed");
         };
 
@@ -179,9 +179,9 @@ mod tests {
         let message = clean(&settings, &state, get_message(false, Some("other".into())));
 
         // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
+        assert!(matches!(message, Response::Success(_)));
 
-        if let Message::Success(text) = message {
+        if let Response::Success(text) = message {
             assert_eq!(
                 text,
                 "All finished tasks have been removed from group 'other'"
@@ -202,9 +202,9 @@ mod tests {
         let message = clean(&settings, &state, get_message(true, Some("other".into())));
 
         // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
+        assert!(matches!(message, Response::Success(_)));
 
-        if let Message::Success(text) = message {
+        if let Response::Success(text) = message {
             assert_eq!(
                 text,
                 "All successfully finished tasks have been removed from group 'other'"

--- a/pueue/src/daemon/network/message_handler/edit.rs
+++ b/pueue/src/daemon/network/message_handler/edit.rs
@@ -11,7 +11,7 @@ use crate::ok_or_save_state_failure;
 /// Invoked when calling `pueue edit`.
 /// If a user wants to edit a message, we need to send him the current command.
 /// Lock the task to prevent execution, before the user has finished editing the command.
-pub fn edit_request(state: &SharedState, task_ids: Vec<usize>) -> Message {
+pub fn edit_request(state: &SharedState, task_ids: Vec<usize>) -> Response {
     // Check whether the task exists and is queued/stashed. Abort if that's not the case.
     let mut state = state.lock().unwrap();
     let mut editable_tasks: Vec<EditableTask> = Vec::new();
@@ -19,7 +19,7 @@ pub fn edit_request(state: &SharedState, task_ids: Vec<usize>) -> Message {
         match state.tasks.get_mut(&task_id) {
             Some(task) => {
                 if !task.is_queued() && !task.is_stashed() {
-                    return create_failure_message("You can only edit a queued/stashed task");
+                    return create_failure_response("You can only edit a queued/stashed task");
                 }
                 task.status = TaskStatus::Locked {
                     previous_status: Box::new(task.status.clone()),
@@ -27,11 +27,11 @@ pub fn edit_request(state: &SharedState, task_ids: Vec<usize>) -> Message {
 
                 editable_tasks.push(EditableTask::from(&*task));
             }
-            None => return create_failure_message("No task with this id."),
+            None => return create_failure_response("No task with this id."),
         }
     }
 
-    Message::EditResponse(editable_tasks)
+    Response::Edit(editable_tasks)
 }
 
 /// Invoked after closing the editor on `pueue edit`.
@@ -40,14 +40,14 @@ pub fn edit(
     settings: &Settings,
     state: &SharedState,
     editable_tasks: Vec<EditableTask>,
-) -> Message {
+) -> Response {
     // Check whether the task exists and is locked. Abort if that's not the case.
     let mut state = state.lock().unwrap();
     for editable_task in editable_tasks {
         match state.tasks.get_mut(&editable_task.id) {
             Some(task) => {
                 let TaskStatus::Locked { previous_status } = &task.status else {
-                    return create_failure_message(format!(
+                    return create_failure_response(format!(
                         "Task {} is no longer locked.",
                         editable_task.id
                     ));
@@ -69,11 +69,11 @@ pub fn edit(
         }
     }
 
-    create_success_message("All tasks have been updated")
+    create_success_response("All tasks have been updated")
 }
 
 /// Invoked if a client fails to edit a task and asks the daemon to restore the task's status.
-pub fn edit_restore(state: &SharedState, task_ids: Vec<usize>) -> Message {
+pub fn edit_restore(state: &SharedState, task_ids: Vec<usize>) -> Response {
     // Check whether the task exists and is queued/stashed. Abort if that's not the case.
     let mut state = state.lock().unwrap();
     let mut failed_tasks = Vec::new();
@@ -96,7 +96,7 @@ pub fn edit_restore(state: &SharedState, task_ids: Vec<usize>) -> Message {
     if !failed_tasks.is_empty() {
         let mut error_msg = String::from("Some tasks couldn't be unlocked:\n");
         error_msg.push_str(&failed_tasks.join("\n"));
-        return create_failure_message(error_msg);
+        return create_failure_response(error_msg);
     }
 
     success_msg!(

--- a/pueue/src/daemon/network/message_handler/enqueue.rs
+++ b/pueue/src/daemon/network/message_handler/enqueue.rs
@@ -12,7 +12,7 @@ use crate::daemon::network::response_helper::*;
 
 /// Invoked when calling `pueue enqueue`.
 /// Enqueue specific stashed tasks.
-pub fn enqueue(settings: &Settings, state: &SharedState, message: EnqueueMessage) -> Message {
+pub fn enqueue(settings: &Settings, state: &SharedState, message: EnqueueMessage) -> Response {
     let mut state = state.lock().unwrap();
     // Get the affected task ids, based on the task selection.
     let selected_task_ids = match message.tasks {

--- a/pueue/src/daemon/network/message_handler/group.rs
+++ b/pueue/src/daemon/network/message_handler/group.rs
@@ -22,7 +22,7 @@ use crate::{
 /// - Show groups
 /// - Add group
 /// - Remove group
-pub fn group(settings: &Settings, state: &SharedState, message: GroupMessage) -> Message {
+pub fn group(settings: &Settings, state: &SharedState, message: GroupMessage) -> Response {
     let mut state = state.lock().unwrap();
 
     match message {

--- a/pueue/src/daemon/network/message_handler/kill.rs
+++ b/pueue/src/daemon/network/message_handler/kill.rs
@@ -9,13 +9,13 @@ use crate::daemon::{
 
 /// Invoked when calling `pueue kill`.
 /// Forward the kill message to the task handler, which then kills the process.
-pub fn kill(settings: &Settings, state: &SharedState, message: KillMessage) -> Message {
+pub fn kill(settings: &Settings, state: &SharedState, message: KillMessage) -> Response {
     let mut state = state.lock().unwrap();
 
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {
-        if let Err(message) = ensure_group_exists(&mut state, group) {
-            return message;
+        if let Err(response) = ensure_group_exists(&mut state, group) {
+            return response;
         }
     }
 
@@ -53,7 +53,7 @@ pub fn kill(settings: &Settings, state: &SharedState, message: KillMessage) -> M
     };
 
     // Actually execute the command
-    if let Message::Success(_) = response {
+    if let Response::Success(_) = response {
         process_handler::kill::kill(settings, &mut state, message.tasks, true, message.signal);
     }
 

--- a/pueue/src/daemon/network/message_handler/mod.rs
+++ b/pueue/src/daemon/network/message_handler/mod.rs
@@ -2,10 +2,14 @@ use std::fmt::Display;
 
 use pueue_lib::failure_msg;
 use pueue_lib::network::message::*;
+use pueue_lib::network::protocol::send_response;
+use pueue_lib::network::socket::GenericStream;
 use pueue_lib::settings::Settings;
 use pueue_lib::state::SharedState;
 
 use crate::daemon::network::response_helper::*;
+use crate::daemon::process_handler::initiate_shutdown;
+use crate::internal_prelude::*;
 
 mod add;
 mod clean;
@@ -27,40 +31,69 @@ mod switch;
 
 pub use log::follow_log;
 
-pub fn handle_message(message: Message, state: &SharedState, settings: &Settings) -> Message {
-    match message {
-        Message::Add(message) => add::add_task(settings, state, message),
-        Message::Clean(message) => clean::clean(settings, state, message),
-        Message::Edit(editable_tasks) => edit::edit(settings, state, editable_tasks),
-        Message::EditRequest(task_ids) => edit::edit_request(state, task_ids),
-        Message::EditRestore(task_ids) => edit::edit_restore(state, task_ids),
-        Message::Env(message) => env::env(settings, state, message),
-        Message::Enqueue(message) => enqueue::enqueue(settings, state, message),
-        Message::Group(message) => group::group(settings, state, message),
-        Message::Kill(message) => kill::kill(settings, state, message),
-        Message::Log(message) => log::get_log(settings, state, message),
-        Message::Parallel(message) => parallel::set_parallel_tasks(message, state),
-        Message::Pause(message) => pause::pause(settings, state, message),
-        Message::Remove(task_ids) => remove::remove(settings, state, task_ids),
-        Message::Reset(message) => reset::reset(settings, state, message),
-        Message::Restart(message) => restart::restart_multiple(settings, state, message),
-        Message::Send(message) => send::send(state, message),
-        Message::Start(message) => start::start(settings, state, message),
-        Message::Stash(message) => stash::stash(settings, state, message),
-        Message::Switch(message) => switch::switch(settings, state, message),
-        Message::Status => get_status(state),
-        _ => create_failure_message("Not yet implemented"),
-    }
+pub async fn handle_request(
+    stream: &mut GenericStream,
+    request: Request,
+    state: &SharedState,
+    settings: &Settings,
+) -> Result<()> {
+    let response = match request {
+        // The client requested the output of a task.
+        // Since this involves streaming content, we have to do some special handling.
+        Request::StreamRequest(payload) => {
+            let pueue_directory = settings.shared.pueue_directory();
+            follow_log(&pueue_directory, stream, state, payload).await?
+        }
+        // To initiated a shutdown, a flag in Pueue's state is set that informs the TaskHandler
+        // to perform a graceful shutdown.
+        //
+        // However, this is an edge-case as we have respond to the client first.
+        // Otherwise it might happen, that the daemon shuts down too fast and we aren't
+        // capable of actually sending the message back to the client.
+        Request::DaemonShutdown(shutdown_type) => {
+            let response = create_success_response("Daemon is shutting down");
+            send_response(response, stream).await?;
+
+            let mut state = state.lock().unwrap();
+            initiate_shutdown(settings, &mut state, shutdown_type);
+
+            return Ok(());
+        }
+        Request::Add(message) => add::add_task(settings, state, message),
+        Request::Clean(message) => clean::clean(settings, state, message),
+        Request::Edit(editable_tasks) => edit::edit(settings, state, editable_tasks),
+        Request::EditRequest(task_ids) => edit::edit_request(state, task_ids),
+        Request::EditRestore(task_ids) => edit::edit_restore(state, task_ids),
+        Request::Env(message) => env::env(settings, state, message),
+        Request::Enqueue(message) => enqueue::enqueue(settings, state, message),
+        Request::Group(message) => group::group(settings, state, message),
+        Request::Kill(message) => kill::kill(settings, state, message),
+        Request::Log(message) => log::get_log(settings, state, message),
+        Request::Parallel(message) => parallel::set_parallel_tasks(message, state),
+        Request::Pause(message) => pause::pause(settings, state, message),
+        Request::Remove(task_ids) => remove::remove(settings, state, task_ids),
+        Request::Reset(message) => reset::reset(settings, state, message),
+        Request::Restart(message) => restart::restart_multiple(settings, state, message),
+        Request::Send(message) => send::send(state, message),
+        Request::Start(message) => start::start(settings, state, message),
+        Request::Stash(message) => stash::stash(settings, state, message),
+        Request::Switch(message) => switch::switch(settings, state, message),
+        Request::Status => get_status(state),
+    };
+
+    send_response(response, stream).await?;
+
+    Ok(())
 }
 
 /// Invoked when calling `pueue status`.
 /// Return the current state.
-fn get_status(state: &SharedState) -> Message {
+fn get_status(state: &SharedState) -> Response {
     let state = state.lock().unwrap().clone();
-    Message::StatusResponse(Box::new(state))
+    Response::Status(Box::new(state))
 }
 
-fn ok_or_failure_message<T, E: Display>(result: Result<T, E>) -> Result<T, Message> {
+fn ok_or_failure_message<T, E: Display>(result: Result<T, E>) -> Result<T, Response> {
     match result {
         Ok(inner) => Ok(inner),
         Err(error) => Err(failure_msg!("Failed to save state. This is a bug: {error}")),

--- a/pueue/src/daemon/network/message_handler/parallel.rs
+++ b/pueue/src/daemon/network/message_handler/parallel.rs
@@ -5,11 +5,11 @@ use pueue_lib::success_msg;
 use crate::daemon::network::response_helper::*;
 
 /// Set the parallel tasks for a specific group.
-pub fn set_parallel_tasks(message: ParallelMessage, state: &SharedState) -> Message {
+pub fn set_parallel_tasks(message: ParallelMessage, state: &SharedState) -> Response {
     let mut state = state.lock().unwrap();
     let group = match ensure_group_exists(&mut state, &message.group) {
         Ok(group) => group,
-        Err(message) => return message,
+        Err(response) => return response,
     };
 
     group.parallel_tasks = message.parallel_tasks;

--- a/pueue/src/daemon/network/message_handler/pause.rs
+++ b/pueue/src/daemon/network/message_handler/pause.rs
@@ -8,12 +8,12 @@ use crate::daemon::process_handler;
 
 /// Invoked when calling `pueue pause`.
 /// Forward the pause message to the task handler, which then pauses groups/tasks/everything.
-pub fn pause(settings: &Settings, state: &SharedState, message: PauseMessage) -> Message {
+pub fn pause(settings: &Settings, state: &SharedState, message: PauseMessage) -> Response {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {
-        if let Err(message) = ensure_group_exists(&mut state, group) {
-            return message;
+        if let Err(response) = ensure_group_exists(&mut state, group) {
+            return response;
         }
     }
 
@@ -32,7 +32,7 @@ pub fn pause(settings: &Settings, state: &SharedState, message: PauseMessage) ->
     };
 
     // Actually execute the command
-    if let Message::Success(_) = response {
+    if let Response::Success(_) = response {
         process_handler::pause::pause(settings, &mut state, message.tasks, message.wait);
     }
 

--- a/pueue/src/daemon/network/message_handler/remove.rs
+++ b/pueue/src/daemon/network/message_handler/remove.rs
@@ -12,7 +12,7 @@ use crate::ok_or_save_state_failure;
 /// Invoked when calling `pueue remove`.
 /// Remove tasks from the queue.
 /// We have to ensure that those tasks aren't running!
-pub fn remove(settings: &Settings, state: &SharedState, task_ids: Vec<usize>) -> Message {
+pub fn remove(settings: &Settings, state: &SharedState, task_ids: Vec<usize>) -> Response {
     let mut state = state.lock().unwrap();
 
     // Filter all running tasks, since we cannot remove them.
@@ -60,11 +60,11 @@ mod tests {
 
         // 3 and 4 aren't allowed to be removed, since they're running.
         // The rest will succeed.
-        let message = remove(&settings, &state, vec![0, 1, 2, 3, 4]);
+        let response = remove(&settings, &state, vec![0, 1, 2, 3, 4]);
 
-        // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Success(_)));
+        if let Response::Success(text) = response {
             assert_eq!(
                 text,
                 "Tasks removed from list: 0, 1, 2\nThe command failed for tasks: 3, 4"
@@ -93,11 +93,11 @@ mod tests {
         }
 
         // Make sure we cannot remove a task with dependencies.
-        let message = remove(&settings, &state, vec![1]);
+        let response = remove(&settings, &state, vec![1]);
 
-        // Return message is correct
-        assert!(matches!(message, Message::Failure(_)));
-        if let Message::Failure(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Failure(_)));
+        if let Response::Failure(text) = response {
             assert_eq!(text, "The command failed for tasks: 1");
         };
 
@@ -107,11 +107,11 @@ mod tests {
         }
 
         // Make sure we cannot remove a task with recursive dependencies.
-        let message = remove(&settings, &state, vec![1, 5]);
+        let response = remove(&settings, &state, vec![1, 5]);
 
-        // Return message is correct
-        assert!(matches!(message, Message::Failure(_)));
-        if let Message::Failure(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Failure(_)));
+        if let Response::Failure(text) = response {
             assert_eq!(text, "The command failed for tasks: 1, 5");
         };
 
@@ -121,11 +121,11 @@ mod tests {
         }
 
         // Make sure we can remove tasks with dependencies if all dependencies are specified.
-        let message = remove(&settings, &state, vec![1, 5, 6]);
+        let response = remove(&settings, &state, vec![1, 5, 6]);
 
-        // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Success(_)));
+        if let Response::Success(text) = response {
             assert_eq!(text, "Tasks removed from list: 1, 5, 6");
         };
 

--- a/pueue/src/daemon/network/message_handler/reset.rs
+++ b/pueue/src/daemon/network/message_handler/reset.rs
@@ -7,7 +7,7 @@ use crate::daemon::process_handler;
 /// Invoked when calling `pueue reset`.
 /// Kill all children by using the `kill` function.
 /// Set the full_reset flag, which will prevent new tasks from being spawned.
-pub fn reset(settings: &Settings, state: &SharedState, message: ResetMessage) -> Message {
+pub fn reset(settings: &Settings, state: &SharedState, message: ResetMessage) -> Response {
     let mut state = state.lock().unwrap();
 
     match message.target {
@@ -42,5 +42,5 @@ pub fn reset(settings: &Settings, state: &SharedState, message: ResetMessage) ->
             }
         }
     }
-    create_success_message("Everything is being reset right now.")
+    create_success_response("Everything is being reset right now.")
 }

--- a/pueue/src/daemon/network/message_handler/restart.rs
+++ b/pueue/src/daemon/network/message_handler/restart.rs
@@ -21,7 +21,7 @@ pub fn restart_multiple(
     settings: &Settings,
     state: &SharedState,
     message: RestartMessage,
-) -> Message {
+) -> Response {
     let task_ids: Vec<usize> = message.tasks.iter().map(|task| task.task_id).collect();
     let mut state = state.lock().unwrap();
 

--- a/pueue/src/daemon/network/message_handler/send.rs
+++ b/pueue/src/daemon/network/message_handler/send.rs
@@ -6,7 +6,7 @@ use pueue_lib::{failure_msg, network::message::*};
 /// Invoked when calling `pueue send`.
 /// The message will be forwarded to the task handler, which then sends the user input to the process.
 /// In here we only do some error handling.
-pub fn send(state: &SharedState, message: SendMessage) -> Message {
+pub fn send(state: &SharedState, message: SendMessage) -> Response {
     let task_id = message.task_id;
     let mut state = state.lock().unwrap();
 
@@ -24,5 +24,5 @@ pub fn send(state: &SharedState, message: SendMessage) -> Message {
         };
     }
 
-    create_success_message("Message is being send to the process.")
+    create_success_response("Message is being send to the process.")
 }

--- a/pueue/src/daemon/network/message_handler/start.rs
+++ b/pueue/src/daemon/network/message_handler/start.rs
@@ -9,12 +9,12 @@ use crate::daemon::process_handler;
 
 /// Invoked when calling `pueue start`.
 /// Forward the start message to the task handler, which then starts the process(es).
-pub fn start(settings: &Settings, state: &SharedState, message: StartMessage) -> Message {
+pub fn start(settings: &Settings, state: &SharedState, message: StartMessage) -> Response {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {
-        if let Err(message) = ensure_group_exists(&mut state, group) {
-            return message;
+        if let Err(response) = ensure_group_exists(&mut state, group) {
+            return response;
         }
     }
 
@@ -38,7 +38,7 @@ pub fn start(settings: &Settings, state: &SharedState, message: StartMessage) ->
         TaskSelection::All => success_msg!("All groups are being resumed."),
     };
 
-    if let Message::Success(_) = response {
+    if let Response::Success(_) = response {
         process_handler::start::start(settings, &mut state, message.tasks);
     }
 

--- a/pueue/src/daemon/network/message_handler/stash.rs
+++ b/pueue/src/daemon/network/message_handler/stash.rs
@@ -8,7 +8,7 @@ use crate::daemon::network::response_helper::*;
 /// Invoked when calling `pueue stash`.
 /// Stash specific queued tasks.
 /// They won't be executed until they're enqueued or explicitly started.
-pub fn stash(settings: &Settings, state: &SharedState, message: StashMessage) -> Message {
+pub fn stash(settings: &Settings, state: &SharedState, message: StashMessage) -> Response {
     let mut state = state.lock().unwrap();
     // Get the affected task ids, based on the task selection.
     let selected_task_ids = match message.tasks {

--- a/pueue/src/daemon/network/message_handler/switch.rs
+++ b/pueue/src/daemon/network/message_handler/switch.rs
@@ -11,7 +11,7 @@ use crate::ok_or_save_state_failure;
 /// Invoked when calling `pueue switch`.
 /// Switch the position of two tasks in the upcoming queue.
 /// We have to ensure that those tasks are either `Queued` or `Stashed`
-pub fn switch(settings: &Settings, state: &SharedState, message: SwitchMessage) -> Message {
+pub fn switch(settings: &Settings, state: &SharedState, message: SwitchMessage) -> Response {
     let mut state = state.lock().unwrap();
 
     let task_ids = [message.task_id_1, message.task_id_2];
@@ -62,7 +62,7 @@ pub fn switch(settings: &Settings, state: &SharedState, message: SwitchMessage) 
     }
 
     ok_or_save_state_failure!(save_state(&state, settings));
-    create_success_message("Tasks have been switched")
+    create_success_response("Tasks have been switched")
 }
 
 #[cfg(test)]
@@ -118,11 +118,11 @@ mod tests {
     fn switch_normal() {
         let (state, settings, _tempdir) = get_test_state();
 
-        let message = switch(&settings, &state, get_message(1, 2));
+        let response = switch(&settings, &state, get_message(1, 2));
 
-        // Return message is correct
-        assert!(matches!(message, Message::Success(_)));
-        if let Message::Success(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Success(_)));
+        if let Response::Success(text) = response {
             assert_eq!(text, "Tasks have been switched");
         };
 
@@ -136,11 +136,11 @@ mod tests {
     fn switch_task_with_itself() {
         let (state, settings, _tempdir) = get_test_state();
 
-        let message = switch(&settings, &state, get_message(1, 1));
+        let response = switch(&settings, &state, get_message(1, 1));
 
-        // Return message is correct
-        assert!(matches!(message, Message::Failure(_)));
-        if let Message::Failure(text) = message {
+        // Response is correct
+        assert!(matches!(response, Response::Failure(_)));
+        if let Response::Failure(text) = response {
             assert_eq!(text, "You cannot switch a task with itself.");
         };
     }
@@ -188,11 +188,11 @@ mod tests {
         ];
 
         for ids in combinations {
-            let message = switch(&settings, &state, get_message(ids.0, ids.1));
+            let response = switch(&settings, &state, get_message(ids.0, ids.1));
 
-            // Assert, that we get a Failure message with the correct text.
-            assert!(matches!(message, Message::Failure(_)));
-            if let Message::Failure(text) = message {
+            // Assert, that we get a failure with the correct text.
+            assert!(matches!(response, Response::Failure(_)));
+            if let Response::Failure(text) = response {
                 assert_eq!(text, "Tasks have to be either queued or stashed.");
             };
         }

--- a/pueue/tests/client/integration/edit.rs
+++ b/pueue/tests/client/integration/edit.rs
@@ -15,7 +15,7 @@ async fn edit_task_directory() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -49,7 +49,7 @@ async fn edit_all_task_properties() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -85,7 +85,7 @@ async fn edit_delete_label() -> Result<()> {
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
     message.label = Some("Testlabel".to_owned());
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -112,7 +112,7 @@ async fn edit_change_priority() -> Result<()> {
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
     message.priority = Some(0);
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -139,7 +139,7 @@ async fn fail_to_edit_task() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 
@@ -174,7 +174,7 @@ async fn edit_task_toml() -> Result<()> {
     // Create a stashed message which we'll edit later on.
     let mut message = create_add_message(shared, "this is a test");
     message.stashed = true;
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add stashed task.")?;
 

--- a/pueue/tests/client/integration/group.rs
+++ b/pueue/tests/client/integration/group.rs
@@ -40,7 +40,7 @@ async fn colored() -> Result<()> {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
     };
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to send message")?;
 

--- a/pueue/tests/daemon/integration/add.rs
+++ b/pueue/tests/daemon/integration/add.rs
@@ -50,7 +50,7 @@ async fn test_stashed_add() -> Result<()> {
     // Tell the daemon to add a task in stashed state.
     let mut message = create_add_message(shared, "sleep 60");
     message.stashed = true;
-    assert_success(send_message(shared, message).await?);
+    assert_success(send_request(shared, message).await?);
 
     // Make sure the task is actually stashed.
     assert_task_condition(shared, 0, Task::is_stashed, "The task should be stashed.").await?;

--- a/pueue/tests/daemon/integration/aliases.rs
+++ b/pueue/tests/daemon/integration/aliases.rs
@@ -86,7 +86,7 @@ async fn test_restart_with_alias() -> Result<()> {
         start_immediately: true,
         stashed: false,
     };
-    send_message(shared, message).await?;
+    send_request(shared, message).await?;
     let task = wait_for_task_condition(shared, 0, Task::is_done).await?;
 
     // The task finished successfully and its command has replaced the alias.

--- a/pueue/tests/daemon/integration/clean.rs
+++ b/pueue/tests/daemon/integration/clean.rs
@@ -22,7 +22,7 @@ async fn test_normal_clean() -> Result<()> {
         successful_only: false,
         group: None,
     };
-    send_message(shared, clean_message).await?;
+    send_request(shared, clean_message).await?;
 
     // Assert that task 0 and 1 have both been removed
     let state = get_state(shared).await?;
@@ -50,7 +50,7 @@ async fn test_successful_only_clean() -> Result<()> {
         successful_only: true,
         group: None,
     };
-    send_message(shared, clean_message).await?;
+    send_request(shared, clean_message).await?;
 
     // Assert that task 0 is still there, as it failed.
     let state = get_state(shared).await?;
@@ -83,7 +83,7 @@ async fn test_clean_in_selected_group() -> Result<()> {
         successful_only: false,
         group: Some("other".to_string()),
     };
-    send_message(shared, clean_message).await?;
+    send_request(shared, clean_message).await?;
 
     // Assert that task 0 and 1 are still there
     let state = get_state(shared).await?;
@@ -121,7 +121,7 @@ async fn test_clean_successful_only_in_selected_group() -> Result<()> {
         successful_only: true,
         group: Some("other".to_string()),
     };
-    send_message(shared, clean_message).await?;
+    send_request(shared, clean_message).await?;
 
     let state = get_state(shared).await?;
     // group default

--- a/pueue/tests/daemon/integration/dependencies.rs
+++ b/pueue/tests/daemon/integration/dependencies.rs
@@ -52,7 +52,7 @@ async fn test_failing_dependency() -> Result<()> {
 
     // Now we kill the first task.
     // This should result in the second task failing.
-    send_message(
+    send_request(
         shared,
         KillMessage {
             tasks: TaskSelection::TaskIds(vec![0]),

--- a/pueue/tests/daemon/integration/edit.rs
+++ b/pueue/tests/daemon/integration/edit.rs
@@ -23,8 +23,8 @@ async fn create_edited_task(shared: &Shared) -> Result<Vec<EditableTask>> {
     );
 
     // Send a request to edit that task
-    let response = send_message(shared, Message::EditRequest(vec![0])).await?;
-    if let Message::EditResponse(payload) = response {
+    let response = send_request(shared, Request::EditRequest(vec![0])).await?;
+    if let Response::Edit(payload) = response {
         Ok(payload)
     } else {
         bail!("Didn't receive EditResponse after requesting edit.")
@@ -69,7 +69,7 @@ async fn test_edit_flow() -> Result<()> {
     editable_task.priority = 99;
 
     // Send the final message of the protocol and actually change the task.
-    let response = send_message(shared, Message::Edit(vec![editable_task])).await?;
+    let response = send_request(shared, Request::Edit(vec![editable_task])).await?;
     assert_success(response);
 
     // Make sure the task has been changed and enqueued.

--- a/pueue/tests/daemon/integration/group.rs
+++ b/pueue/tests/daemon/integration/group.rs
@@ -18,11 +18,11 @@ async fn test_add_and_remove() -> Result<()> {
         name: "testgroup".to_string(),
         parallel_tasks: None,
     };
-    assert_failure(send_message(shared, add_message).await?);
+    assert_failure(send_request(shared, add_message).await?);
 
     // Remove the newly added group and wait for the deletion to be processed.
     let remove_message = GroupMessage::Remove("testgroup".to_string());
-    assert_success(send_message(shared, remove_message.clone()).await?);
+    assert_success(send_request(shared, remove_message.clone()).await?);
     wait_for_group_absence(shared, "testgroup").await?;
 
     // Make sure it got removed
@@ -38,7 +38,7 @@ async fn test_cannot_delete_default() -> Result<()> {
     let daemon = daemon().await?;
 
     let message = GroupMessage::Remove(PUEUE_DEFAULT_GROUP.to_string());
-    assert_failure(send_message(&daemon.settings.shared, message).await?);
+    assert_failure(send_request(&daemon.settings.shared, message).await?);
 
     Ok(())
 }
@@ -49,7 +49,7 @@ async fn test_cannot_delete_non_existing() -> Result<()> {
     let daemon = daemon().await?;
 
     let message = GroupMessage::Remove("doesnt_exist".to_string());
-    assert_failure(send_message(&daemon.settings.shared, message).await?);
+    assert_failure(send_request(&daemon.settings.shared, message).await?);
 
     Ok(())
 }
@@ -69,15 +69,15 @@ async fn test_cannot_delete_group_with_tasks() -> Result<()> {
 
     // We shouldn't be capable of removing that group
     let message = GroupMessage::Remove("testgroup".to_string());
-    assert_failure(send_message(shared, message).await?);
+    assert_failure(send_request(shared, message).await?);
 
     // Remove the task from the group
-    let remove_message = Message::Remove(vec![0]);
-    send_message(shared, remove_message).await?;
+    let remove_message = Request::Remove(vec![0]);
+    send_request(shared, remove_message).await?;
 
     // Removal should now work.
     let message = GroupMessage::Remove("testgroup".to_string());
-    assert_success(send_message(shared, message).await?);
+    assert_success(send_request(shared, message).await?);
 
     Ok(())
 }

--- a/pueue/tests/daemon/integration/kill.rs
+++ b/pueue/tests/daemon/integration/kill.rs
@@ -67,7 +67,7 @@ async fn test_kill_tasks_with_pause(
     }
 
     // Send the kill message
-    send_message(shared, kill_message).await?;
+    send_request(shared, kill_message).await?;
 
     // Make sure all tasks get killed
     for id in 0..3 {
@@ -146,7 +146,7 @@ async fn test_kill_tasks_without_pause(#[case] kill_message: KillMessage) -> Res
     add_group_with_slots(shared, "testgroup", 1).await?;
 
     // Send the kill message
-    send_message(shared, kill_message).await?;
+    send_request(shared, kill_message).await?;
 
     // Make sure all tasks get killed
     for id in 0..3 {

--- a/pueue/tests/daemon/integration/log.rs
+++ b/pueue/tests/daemon/integration/log.rs
@@ -101,10 +101,10 @@ async fn test_partial_log() -> Result<()> {
         send_logs: true,
         lines: Some(5),
     };
-    let response = send_message(shared, Message::Log(log_message)).await?;
+    let response = send_request(shared, Request::Log(log_message)).await?;
     let logs = match response {
-        Message::LogResponse(logs) => logs,
-        _ => bail!("Received non LogResponse: {:#?}", response),
+        Response::Log(logs) => logs,
+        _ => bail!("Received non Log Response: {:#?}", response),
     };
 
     // Get the received output
@@ -138,10 +138,10 @@ async fn test_correct_log_order() -> Result<()> {
         send_logs: true,
         lines: None,
     };
-    let response = send_message(shared, Message::Log(log_message)).await?;
+    let response = send_request(shared, Request::Log(log_message)).await?;
     let logs = match response {
-        Message::LogResponse(logs) => logs,
-        _ => bail!("Received non LogResponse: {:#?}", response),
+        Response::Log(logs) => logs,
+        _ => bail!("Received non Log Response: {:#?}", response),
     };
 
     // Get the received output
@@ -181,10 +181,10 @@ async fn logs_of_group() -> Result<()> {
         send_logs: true,
         lines: None,
     };
-    let response = send_message(shared, message).await?;
+    let response = send_request(shared, message).await?;
     let logs = match response {
-        Message::LogResponse(logs) => logs,
-        _ => bail!("Didn't get log response response in get_state"),
+        Response::Log(logs) => logs,
+        _ => bail!("Didn't get log response in get_state"),
     };
 
     assert_eq!(logs.len(), 1, "Sould only receive a single log entry.");
@@ -215,10 +215,10 @@ async fn logs_for_all() -> Result<()> {
         send_logs: true,
         lines: None,
     };
-    let response = send_message(shared, message).await?;
+    let response = send_request(shared, message).await?;
     let logs = match response {
-        Message::LogResponse(logs) => logs,
-        _ => bail!("Didn't get log response response in get_state"),
+        Response::Log(logs) => logs,
+        _ => bail!("Didn't get log response in get_state"),
     };
 
     assert_eq!(logs.len(), 2, "Sould receive all log entries.");

--- a/pueue/tests/daemon/integration/parallel_tasks.rs
+++ b/pueue/tests/daemon/integration/parallel_tasks.rs
@@ -87,7 +87,7 @@ async fn test_unlimited_parallel_tasks() -> Result<()> {
         group: "testgroup".to_string(),
         parallel_tasks: 0,
     };
-    assert_success(send_message(shared, message).await?);
+    assert_success(send_request(shared, message).await?);
 
     // Make sure all other tasks are started as well in quick succession.
     for task_id in 1..10 {

--- a/pueue/tests/daemon/integration/pause.rs
+++ b/pueue/tests/daemon/integration/pause.rs
@@ -80,7 +80,7 @@ async fn test_pause_with_wait() -> Result<()> {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
     };
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to send message")?;
 

--- a/pueue/tests/daemon/integration/remove.rs
+++ b/pueue/tests/daemon/integration/remove.rs
@@ -32,7 +32,7 @@ async fn test_normal_remove() -> Result<()> {
     pause_tasks(shared, TaskSelection::TaskIds(vec![3])).await?;
 
     // Stash task 5
-    send_message(
+    send_request(
         shared,
         StashMessage {
             tasks: TaskSelection::TaskIds(vec![5]),
@@ -41,8 +41,8 @@ async fn test_normal_remove() -> Result<()> {
     )
     .await?;
 
-    let remove_message = Message::Remove(vec![0, 1, 2, 3, 4, 5]);
-    send_message(shared, remove_message).await?;
+    let remove_message = Request::Remove(vec![0, 1, 2, 3, 4, 5]);
+    send_request(shared, remove_message).await?;
 
     // Ensure that every task that isn't currently running can be removed
     let state = get_state(shared).await?;

--- a/pueue/tests/daemon/integration/reset.rs
+++ b/pueue/tests/daemon/integration/reset.rs
@@ -18,7 +18,7 @@ async fn test_reset() -> Result<()> {
     wait_for_task_condition(shared, 2, Task::is_running).await?;
 
     // Reset all groups of the daemon
-    send_message(
+    send_request(
         shared,
         ResetMessage {
             target: ResetTarget::All,
@@ -64,7 +64,7 @@ async fn test_reset_single_group() -> Result<()> {
     wait_for_task_condition(shared, 2, Task::is_running).await?;
 
     // Reset only the test_2 of the daemon.
-    send_message(
+    send_request(
         shared,
         ResetMessage {
             target: ResetTarget::Groups(vec!["test_2".to_string()]),
@@ -106,7 +106,7 @@ async fn test_reset_multiple_groups() -> Result<()> {
     wait_for_task_condition(shared, 2, Task::is_running).await?;
 
     // Reset only the test_2 of the daemon.
-    send_message(
+    send_request(
         shared,
         ResetMessage {
             target: ResetTarget::Groups(vec!["test_2".to_string(), "test_3".to_string()]),

--- a/pueue/tests/daemon/integration/restart.rs
+++ b/pueue/tests/daemon/integration/restart.rs
@@ -31,7 +31,7 @@ async fn test_restart_in_place() -> Result<()> {
         start_immediately: false,
         stashed: false,
     };
-    assert_success(send_message(shared, restart_message).await?);
+    assert_success(send_request(shared, restart_message).await?);
 
     let state = get_state(shared).await?;
     assert_eq!(state.tasks.len(), 1, "No new task should be created");
@@ -77,7 +77,7 @@ async fn test_cannot_restart_running() -> Result<()> {
         start_immediately: false,
         stashed: false,
     };
-    assert_failure(send_message(shared, restart_message).await?);
+    assert_failure(send_request(shared, restart_message).await?);
 
     Ok(())
 }

--- a/pueue/tests/daemon/integration/start.rs
+++ b/pueue/tests/daemon/integration/start.rs
@@ -60,7 +60,7 @@ async fn test_start_tasks(#[case] start_message: StartMessage) -> Result<()> {
     }
 
     // Send the kill message
-    send_message(shared, start_message).await?;
+    send_request(shared, start_message).await?;
 
     // Ensure all tasks are running
     for id in 0..3 {

--- a/pueue/tests/daemon/integration/stashed.rs
+++ b/pueue/tests/daemon/integration/stashed.rs
@@ -38,7 +38,7 @@ async fn test_enqueued_tasks(#[case] enqueue_at: Option<DateTime<Local>>) -> Res
         tasks: TaskSelection::TaskIds(vec![0]),
         enqueue_at: None,
     };
-    send_message(shared, enqueue_message)
+    send_request(shared, enqueue_message)
         .await
         .context("Failed to to add task message")?;
 
@@ -92,7 +92,7 @@ async fn test_stash_queued_task() -> Result<()> {
     add_task(shared, "sleep 10").await?;
 
     // Stash the task
-    send_message(
+    send_request(
         shared,
         StashMessage {
             tasks: TaskSelection::TaskIds(vec![0]),

--- a/pueue/tests/helper/asserts.rs
+++ b/pueue/tests/helper/asserts.rs
@@ -7,21 +7,21 @@ use pueue_lib::state::State;
 use pueue_lib::task::Task;
 use pueue_lib::{network::message::*, state::GroupStatus};
 
-use super::{get_state, send_message};
+use super::{get_state, send_request};
 
 /// Assert that a message is a successful message.
-pub fn assert_success(message: Message) {
+pub fn assert_success(response: Response) {
     assert!(
-        message.response_success(),
-        "Expected to get successful message, got {message:?}",
+        response.success(),
+        "Expected to get successful message, got {response:?}",
     );
 }
 
 /// Assert that a message is a failure message.
-pub fn assert_failure(message: Message) {
+pub fn assert_failure(message: Response) {
     assert_matches!(
         message,
-        Message::Failure(_),
+        Response::Failure(_),
         "Expected to get FailureMessage, got {message:?}",
     );
 }
@@ -101,7 +101,7 @@ pub async fn assert_worker_envs(
     );
 
     // Get the log output for the task.
-    let response = send_message(
+    let response = send_request(
         shared,
         LogRequestMessage {
             tasks: TaskSelection::TaskIds(vec![task_id]),
@@ -111,7 +111,7 @@ pub async fn assert_worker_envs(
     )
     .await?;
 
-    let Message::LogResponse(message) = response else {
+    let Response::Log(message) = response else {
         bail!("Expected LogResponse got {response:?}")
     };
 

--- a/pueue/tests/helper/daemon.rs
+++ b/pueue/tests/helper/daemon.rs
@@ -11,10 +11,10 @@ use pueue_lib::settings::*;
 use super::*;
 
 /// Send the Shutdown message to the test daemon.
-pub async fn shutdown_daemon(shared: &Shared) -> Result<Message> {
+pub async fn shutdown_daemon(shared: &Shared) -> Result<Response> {
     let message = Shutdown::Graceful;
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to send Shutdown message")
 }

--- a/pueue/tests/helper/factories/group.rs
+++ b/pueue/tests/helper/factories/group.rs
@@ -11,7 +11,7 @@ pub async fn add_group_with_slots(shared: &Shared, group_name: &str, slots: usiz
         name: group_name.to_string(),
         parallel_tasks: Some(slots),
     };
-    assert_success(send_message(shared, add_message.clone()).await?);
+    assert_success(send_request(shared, add_message.clone()).await?);
     wait_for_group(shared, group_name).await?;
 
     Ok(())

--- a/pueue/tests/helper/factories/task.rs
+++ b/pueue/tests/helper/factories/task.rs
@@ -6,18 +6,18 @@ use pueue_lib::settings::*;
 use crate::helper::*;
 
 /// Adds a task to the test daemon.
-pub async fn add_task(shared: &Shared, command: &str) -> Result<Message> {
-    send_message(shared, create_add_message(shared, command))
+pub async fn add_task(shared: &Shared, command: &str) -> Result<Response> {
+    send_request(shared, create_add_message(shared, command))
         .await
         .context("Failed to to add task.")
 }
 
 /// Adds a task to the test daemon and starts it immediately.
-pub async fn add_and_start_task(shared: &Shared, command: &str) -> Result<Message> {
+pub async fn add_and_start_task(shared: &Shared, command: &str) -> Result<Response> {
     let mut message = create_add_message(shared, command);
     message.start_immediately = true;
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add task.")
 }
@@ -27,11 +27,11 @@ pub async fn add_task_with_priority(
     shared: &Shared,
     command: &str,
     priority: i32,
-) -> Result<Message> {
+) -> Result<Response> {
     let mut message = create_add_message(shared, command);
     message.priority = Some(priority);
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add task.")
 }
@@ -41,11 +41,11 @@ pub async fn add_task_with_dependencies(
     shared: &Shared,
     command: &str,
     dependencies: Vec<usize>,
-) -> Result<Message> {
+) -> Result<Response> {
     let mut message = create_add_message(shared, command);
     message.dependencies = dependencies;
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add task.")
 }
@@ -55,24 +55,28 @@ pub async fn add_task_to_group<C: ToString, G: ToString>(
     shared: &Shared,
     command: C,
     group: G,
-) -> Result<Message> {
+) -> Result<Response> {
     let mut message = create_add_message(shared, command);
     message.group = group.to_string();
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add task to group.")
 }
 
 /// Mini wrapper around add_task, which creates a task that echos PUEUE's worker environment
 /// variables to `stdout`.
-pub async fn add_env_task(shared: &Shared, command: &str) -> Result<Message> {
+pub async fn add_env_task(shared: &Shared, command: &str) -> Result<Response> {
     let command = format!("echo WORKER_ID: $PUEUE_WORKER_ID; echo GROUP: $PUEUE_GROUP; {command}");
     add_task(shared, &command).await
 }
 
 /// Just like [add_env_task], but the task get's added to specific group.
-pub async fn add_env_task_to_group(shared: &Shared, command: &str, group: &str) -> Result<Message> {
+pub async fn add_env_task_to_group(
+    shared: &Shared,
+    command: &str,
+    group: &str,
+) -> Result<Response> {
     let command = format!("echo WORKER_ID: $PUEUE_WORKER_ID; echo GROUP: $PUEUE_GROUP; {command}");
     add_task_to_group(shared, &command, group).await
 }

--- a/pueue/tests/helper/log.rs
+++ b/pueue/tests/helper/log.rs
@@ -28,10 +28,10 @@ pub async fn get_task_log(shared: &Shared, task_id: usize, lines: Option<usize>)
         send_logs: true,
         lines,
     };
-    let response = send_message(shared, message).await?;
+    let response = send_request(shared, message).await?;
 
     let mut logs = match response {
-        Message::LogResponse(logs) => logs,
+        Response::Log(logs) => logs,
         _ => bail!("Didn't get log response response in get_state"),
     };
 

--- a/pueue/tests/helper/network.rs
+++ b/pueue/tests/helper/network.rs
@@ -9,9 +9,9 @@ use pueue_lib::network::secret::read_shared_secret;
 use pueue_lib::settings::Shared;
 
 /// This is a small convenience wrapper that sends a message and immediately returns the response.
-pub async fn send_message<T>(shared: &Shared, message: T) -> Result<Message>
+pub async fn send_request<T>(shared: &Shared, message: T) -> Result<Response>
 where
-    T: Into<Message>,
+    T: Into<Request>,
 {
     let mut stream = get_authenticated_stream(shared).await?;
 

--- a/pueue/tests/helper/state.rs
+++ b/pueue/tests/helper/state.rs
@@ -8,9 +8,9 @@ use super::*;
 
 /// Convenience function for getting the current state from the daemon.
 pub async fn get_state(shared: &Shared) -> Result<Box<State>> {
-    let response = send_message(shared, Message::Status).await?;
+    let response = send_request(shared, Request::Status).await?;
     match response {
-        Message::StatusResponse(state) => Ok(state),
+        Response::Status(state) => Ok(state),
         _ => bail!("Didn't get status response in get_state"),
     }
 }

--- a/pueue/tests/helper/task.rs
+++ b/pueue/tests/helper/task.rs
@@ -32,30 +32,30 @@ pub async fn create_stashed_task(
     shared: &Shared,
     command: &str,
     enqueue_at: Option<DateTime<Local>>,
-) -> Result<Message> {
+) -> Result<Response> {
     let mut message = create_add_message(shared, command);
     message.stashed = true;
     message.enqueue_at = enqueue_at;
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to to add task message")
 }
 
 /// Helper to either continue the daemon or start specific tasks
-pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Message> {
+pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Response> {
     let message = StartMessage { tasks };
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to send Start tasks message")
 }
 
 /// Helper to pause the default group of the daemon
-pub async fn pause_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Message> {
+pub async fn pause_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Response> {
     let message = PauseMessage { tasks, wait: false };
 
-    send_message(shared, message)
+    send_request(shared, message)
         .await
         .context("Failed to send Pause message")
 }

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres **somewhat** to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The concept of SemVer is applied to the daemon/client API, but not the library API itself.
 
+## [0.28.0] - unreleased
+
+### Changed
+
+- **Breaking**: Split the `Message` enum into a `Response` and `Request` enum. Requests are sent **to** the daemon, responses are sent **from** the daemon.
+
 ## [0.27.0] - 2024-12-01
 
 ### Added

--- a/pueue_lib/src/network/message/mod.rs
+++ b/pueue_lib/src/network/message/mod.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::task::Task;
+
+pub mod request;
+pub mod response;
+
+pub use request::*;
+pub use response::*;
+
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+pub struct EditableTask {
+    pub id: usize,
+    pub command: String,
+    pub path: PathBuf,
+    pub label: Option<String>,
+    pub priority: i32,
+}
+
+impl From<&Task> for EditableTask {
+    /// Create an editable tasks from any [Task]]
+    fn from(value: &Task) -> Self {
+        EditableTask {
+            id: value.id,
+            command: value.command.clone(),
+            path: value.path.clone(),
+            label: value.label.clone(),
+            priority: value.priority,
+        }
+    }
+}
+
+impl EditableTask {
+    /// Merge a [EditableTask] back into a [Task].
+    pub fn into_task(self, task: &mut Task) {
+        task.command = self.command;
+        task.path = self.path;
+        task.label = self.label;
+        task.priority = self.priority;
+    }
+}

--- a/pueue_lib/src/network/message/response.rs
+++ b/pueue_lib/src/network/message/response.rs
@@ -1,0 +1,119 @@
+use std::collections::BTreeMap;
+
+use chrono::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    state::{Group, State},
+    task::Task,
+};
+
+use super::EditableTask;
+
+/// Macro to simplify creating success_messages
+#[macro_export]
+macro_rules! success_msg {
+    ($($arg:tt)*) => {{
+        create_success_response(format!($($arg)*))
+    }}
+}
+
+/// Macro to simplify creating failure_messages
+#[macro_export]
+macro_rules! failure_msg {
+    ($($arg:tt)*) => {{
+        create_failure_response(format!($($arg)*))
+    }}
+}
+
+pub fn create_success_response<T: ToString>(text: T) -> Response {
+    Response::Success(text.to_string())
+}
+
+pub fn create_failure_response<T: ToString>(text: T) -> Response {
+    Response::Failure(text.to_string())
+}
+
+/// Macro to simplify creating [From] implementations for each variant-contained
+/// Response; e.g. `impl_into_response!(AddMessage, Response::Add)` to make it possible
+/// to use `AddMessage { }.into()` and get a `Message::Add()` value.
+macro_rules! impl_into_response {
+    ($inner:ty, $variant:expr) => {
+        impl From<$inner> for Response {
+            fn from(message: $inner) -> Self {
+                $variant(message)
+            }
+        }
+    };
+}
+
+/// This is the message for messages sent **to** the daemon. \
+/// Everything that's send by the client is represented using by this enum.
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+pub enum Response {
+    AddedTask(AddedTaskMessage),
+
+    /// The daemon locked the tasks and responds with the tasks' details.
+    Edit(Vec<EditableTask>),
+
+    Status(Box<State>),
+
+    /// The log returned from the daemon for a bunch of [`Task`]s
+    /// This is the response to [`Request::Log`]
+    Log(BTreeMap<usize, TaskLogMessage>),
+
+    Group(GroupResponseMessage),
+
+    /// The next chunk of output, that's send to the client.
+    Stream(String),
+
+    Success(String),
+    Failure(String),
+
+    /// Simply notify the client that the connection is now closed.
+    /// This is used to, for instance, close a `follow` stream if the task finished.
+    Close,
+}
+
+impl Response {
+    pub fn success(&self) -> bool {
+        matches!(&self, Self::AddedTask(_) | Self::Success(_))
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
+pub struct AddedTaskMessage {
+    pub task_id: usize,
+    pub enqueue_at: Option<DateTime<Local>>,
+    pub group_is_paused: bool,
+}
+impl_into_response!(AddedTaskMessage, Response::AddedTask);
+
+/// Helper struct for sending tasks and their log output to the client.
+#[derive(PartialEq, Eq, Clone, Deserialize, Serialize)]
+pub struct TaskLogMessage {
+    pub task: Task,
+    /// Indicates whether the log output has been truncated or not.
+    pub output_complete: bool,
+    pub output: Option<Vec<u8>>,
+}
+impl_into_response!(BTreeMap<usize, TaskLogMessage>, Response::Log);
+
+/// We use a custom `Debug` implementation for [TaskLogMessage], as the `output` field
+/// has too much info in it and renders log output unreadable.
+impl std::fmt::Debug for TaskLogMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskLogMessage")
+            .field("task", &self.task)
+            .field("output_complete", &self.output_complete)
+            .field("output", &"hidden")
+            .finish()
+    }
+}
+
+/// Group info send by the daemon.
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+pub struct GroupResponseMessage {
+    pub groups: BTreeMap<String, Group>,
+}
+impl_into_response!(GroupResponseMessage, Response::Group);

--- a/pueue_lib/src/network/protocol.rs
+++ b/pueue_lib/src/network/protocol.rs
@@ -3,29 +3,54 @@ use crate::internal_prelude::*;
 use std::io::Cursor;
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_cbor::de::from_slice;
 use serde_cbor::ser::to_vec;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::error::Error;
-use crate::network::message::*;
 
+use super::message::{request::Request, response::Response};
 // Reexport all stream/socket related stuff for convenience purposes
 pub use super::socket::*;
 
 // We choose a packet size of 1280 to be on the safe site regarding IPv6 MTU.
 pub const PACKET_SIZE: usize = 1280;
 
+/// Convenience wrapper around `send_message` to directly send [`Request`]s.
+pub async fn send_request<T>(message: T, stream: &mut GenericStream) -> Result<(), Error>
+where
+    T: Into<Request>,
+    T: Serialize + std::fmt::Debug,
+{
+    send_message::<_, Request>(message, stream).await
+}
+
+/// Convenience wrapper around `send_message` to directly send [`Response`]s.
+pub async fn send_response<T>(message: T, stream: &mut GenericStream) -> Result<(), Error>
+where
+    T: Into<Response>,
+    T: Serialize + std::fmt::Debug,
+{
+    send_message::<_, Response>(message, stream).await
+}
+
 /// Convenience wrapper around send_bytes.
 /// Deserialize a message and feed the bytes into send_bytes.
-pub async fn send_message<T>(message: T, stream: &mut GenericStream) -> Result<(), Error>
+///
+/// This function is designed to be used with the inner values of the `Request`
+/// or `Response` enums.
+/// If there's no inner variant, you might need to anotate the type:
+/// `send_message::<_, Request>(Request::Status, &mut stream)`
+pub async fn send_message<O, T>(message: O, stream: &mut GenericStream) -> Result<(), Error>
 where
-    T: Into<Message>,
+    O: Into<T>,
+    T: Serialize + std::fmt::Debug,
 {
-    let message: Message = message.into();
+    let message: T = message.into();
     debug!("Sending message: {message:#?}",);
     // Prepare command for transfer and determine message byte size
-    let payload = to_vec(&message).map_err(|err| Error::MessageDeserialization(err.to_string()))?;
+    let payload = to_vec(&message).map_err(|err| Error::MessageSerialization(err.to_string()))?;
 
     send_bytes(&payload, stream).await
 }
@@ -114,15 +139,27 @@ pub async fn receive_bytes(stream: &mut GenericStream) -> Result<Vec<u8>, Error>
     Ok(payload_bytes)
 }
 
+/// Convenience wrapper that wraps `receive_message` for [`Request`]s
+pub async fn receive_request(stream: &mut GenericStream) -> Result<Request, Error> {
+    receive_message::<Request>(stream).await
+}
+
+/// Convenience wrapper that wraps `receive_message` for [`Response`]s
+pub async fn receive_response(stream: &mut GenericStream) -> Result<Response, Error> {
+    receive_message::<Response>(stream).await
+}
+
 /// Convenience wrapper that receives a message and converts it into a Message.
-pub async fn receive_message(stream: &mut GenericStream) -> Result<Message, Error> {
+pub async fn receive_message<T: DeserializeOwned + std::fmt::Debug>(
+    stream: &mut GenericStream,
+) -> Result<T, Error> {
     let payload_bytes = receive_bytes(stream).await?;
     if payload_bytes.is_empty() {
         return Err(Error::EmptyPayload);
     }
 
     // Deserialize the message.
-    let message: Message =
+    let message: T =
         from_slice(&payload_bytes).map_err(|err| Error::MessageDeserialization(err.to_string()))?;
     debug!("Received message: {message:#?}");
 
@@ -139,6 +176,7 @@ mod test {
     use tokio::task;
 
     use super::*;
+    use crate::network::message::request::{Request, SendMessage};
     use crate::network::socket::Stream as PueueStream;
 
     // Implement generic Listener/Stream traits, so we can test stuff on normal TCP
@@ -158,8 +196,12 @@ mod test {
 
         // The message that should be sent
         let payload = "a".repeat(100_000);
-        let message = create_success_message(payload);
-        let original_bytes = to_vec(&message).expect("Failed to serialize message.");
+        let request: Request = SendMessage {
+            task_id: 0,
+            input: payload,
+        }
+        .into();
+        let original_bytes = to_vec(&request).expect("Failed to serialize message.");
 
         let listener: GenericListener = Box::new(listener);
 
@@ -171,17 +213,17 @@ mod test {
             let mut stream = listener.accept().await.unwrap();
             let message_bytes = receive_bytes(&mut stream).await.unwrap();
 
-            let message: Message = from_slice(&message_bytes).unwrap();
+            let message: Request = from_slice(&message_bytes).unwrap();
 
-            send_message(message, &mut stream).await.unwrap();
+            send_request(message, &mut stream).await.unwrap();
         });
 
         let mut client: GenericStream = Box::new(TcpStream::connect(&addr).await?);
 
         // Create a client that sends a message and instantly receives it
-        send_message(message, &mut client).await?;
+        send_request(request, &mut client).await?;
         let response_bytes = receive_bytes(&mut client).await?;
-        let _message: Message = from_slice(&response_bytes)
+        let _message: Request = from_slice(&response_bytes)
             .map_err(|err| Error::MessageDeserialization(err.to_string()))?;
 
         assert_eq!(response_bytes, original_bytes);
@@ -205,10 +247,8 @@ mod test {
         task::spawn(async move {
             let mut stream = listener.accept().await.unwrap();
 
-            send_message(create_success_message("message_a"), &mut stream)
-                .await
-                .unwrap();
-            send_message(create_success_message("message_b"), &mut stream)
+            send_request(Request::Status, &mut stream).await.unwrap();
+            send_request(Request::Remove(vec![0, 2, 3]), &mut stream)
                 .await
                 .unwrap();
         });
@@ -222,8 +262,8 @@ mod test {
         let message_a = receive_message(&mut client).await.expect("First message");
         let message_b = receive_message(&mut client).await.expect("Second message");
 
-        assert_eq!(Message::Success("message_a".to_string()), message_a);
-        assert_eq!(Message::Success("message_b".to_string()), message_b);
+        assert_eq!(Request::Status, message_a);
+        assert_eq!(Request::Remove(vec![0, 2, 3]), message_b);
 
         Ok(())
     }

--- a/pueue_lib/src/process_helper/mod.rs
+++ b/pueue_lib/src/process_helper/mod.rs
@@ -7,7 +7,7 @@ use crate::internal_prelude::*;
 
 use std::{collections::HashMap, process::Command};
 
-use crate::{network::message::Signal as InternalSignal, settings::Settings};
+use crate::{network::message::request::Signal as InternalSignal, settings::Settings};
 
 // Unix specific process handling
 // Shared between Linux and Apple

--- a/pueue_lib/src/state.rs
+++ b/pueue_lib/src/state.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::children::Children;
 use crate::error::Error;
-use crate::network::message::Shutdown;
+use crate::network::message::request::Shutdown;
 use crate::task::{Task, TaskStatus};
 
 pub const PUEUE_DEFAULT_GROUP: &str = "default";

--- a/pueue_lib/tests/tls_socket.rs
+++ b/pueue_lib/tests/tls_socket.rs
@@ -20,7 +20,7 @@ async fn test_tls_socket() -> Result<()> {
     create_certificates(&shared_settings).unwrap();
 
     let listener = get_listener(&shared_settings).await.unwrap();
-    let message = create_success_message("This is a test");
+    let message = Request::Status;
     let original_bytes = to_vec(&message).expect("Failed to serialize message.");
 
     // Spawn a sub thread that:
@@ -31,17 +31,17 @@ async fn test_tls_socket() -> Result<()> {
         let mut stream = listener.accept().await.unwrap();
         let message_bytes = receive_bytes(&mut stream).await.unwrap();
 
-        let message: Message = from_slice(&message_bytes).unwrap();
+        let message: Request = from_slice(&message_bytes).unwrap();
 
-        send_message(message, &mut stream).await.unwrap();
+        send_request(message, &mut stream).await.unwrap();
     });
 
     let mut client = get_client_stream(&shared_settings).await.unwrap();
 
     // Create a client that sends a message and instantly receives it
-    send_message(message, &mut client).await.unwrap();
+    send_request(message, &mut client).await.unwrap();
     let response_bytes = receive_bytes(&mut client).await.unwrap();
-    let _message: Message = from_slice(&response_bytes).unwrap();
+    let _message: Request = from_slice(&response_bytes).unwrap();
 
     assert_eq!(response_bytes, original_bytes);
 

--- a/pueue_lib/tests/unix_socket.rs
+++ b/pueue_lib/tests/unix_socket.rs
@@ -21,7 +21,7 @@ mod tests {
         let (shared_settings, _tempdir) = helper::get_shared_settings(true);
 
         let listener = get_listener(&shared_settings).await?;
-        let message = create_success_message("This is a test");
+        let message = Request::Status;
         let original_bytes = to_vec(&message).expect("Failed to serialize message.");
 
         // Spawn a sub thread that:
@@ -32,17 +32,17 @@ mod tests {
             let mut stream = listener.accept().await.unwrap();
             let message_bytes = receive_bytes(&mut stream).await.unwrap();
 
-            let message: Message = from_slice(&message_bytes).unwrap();
+            let message: Request = from_slice(&message_bytes).unwrap();
 
-            send_message(message, &mut stream).await.unwrap();
+            send_request(message, &mut stream).await.unwrap();
         });
 
         let mut client = get_client_stream(&shared_settings).await?;
 
         // Create a client that sends a message and instantly receives it
-        send_message(message, &mut client).await?;
+        send_request(message, &mut client).await?;
         let response_bytes = receive_bytes(&mut client).await?;
-        let _message: Message = from_slice(&response_bytes)?;
+        let _message: Request = from_slice(&response_bytes)?;
 
         assert_eq!(response_bytes, original_bytes);
 


### PR DESCRIPTION
Split the message enum into two enums, namely `Request` and `Response`. Making message handling much easier, more clear and exhaustive.