### PR TITLE
Streamline message names and preparations for multiple followed tasks

### DIFF
--- a/pueue/src/client/commands/add.rs
+++ b/pueue/src/client/commands/add.rs
@@ -10,7 +10,7 @@ use pueue_lib::{
     Request, Response,
     client::Client,
     format::format_datetime,
-    network::message::{AddMessage, AddedTaskMessage},
+    network::message::{AddRequest, AddedTaskResponse},
 };
 
 use super::{follow as follow_cmd, group_or_default, handle_response};
@@ -51,7 +51,7 @@ pub async fn add_task(
     }
 
     // Add the message to the daemon.
-    let message = Request::Add(AddMessage {
+    let message = Request::Add(AddRequest {
         command: command.join(" "),
         path,
         // Catch the current environment for later injection into the task's process.
@@ -70,7 +70,7 @@ pub async fn add_task(
     let response = client.receive_response().await?;
 
     // Make sure the task has been added, otherwise handle the response and return.
-    let Response::AddedTask(AddedTaskMessage {
+    let Response::AddedTask(AddedTaskResponse {
         task_id,
         enqueue_at,
         group_is_paused,

--- a/pueue/src/client/commands/clean.rs
+++ b/pueue/src/client/commands/clean.rs
@@ -13,7 +13,7 @@ pub async fn clean(
     successful_only: bool,
 ) -> Result<()> {
     client
-        .send_request(CleanMessage {
+        .send_request(CleanRequest {
             successful_only,
             group,
         })

--- a/pueue/src/client/commands/edit.rs
+++ b/pueue/src/client/commands/edit.rs
@@ -64,7 +64,9 @@ pub async fn edit(client: &mut Client, style: &OutputStyle, task_ids: Vec<usize>
     };
 
     // Send the edited tasks back to the daemon.
-    client.send_request(Request::Edit(editable_tasks)).await?;
+    client
+        .send_request(Request::EditedTasks(editable_tasks))
+        .await?;
 
     let response = client.receive_response().await?;
     handle_response(style, response)?;

--- a/pueue/src/client/commands/enqueue.rs
+++ b/pueue/src/client/commands/enqueue.rs
@@ -14,7 +14,7 @@ pub async fn enqueue(
     delay_until: Option<DateTime<Local>>,
 ) -> Result<()> {
     client
-        .send_request(EnqueueMessage {
+        .send_request(EnqueueRequest {
             tasks: selection_from_params(all, group, task_ids),
             enqueue_at: delay_until,
         })

--- a/pueue/src/client/commands/env.rs
+++ b/pueue/src/client/commands/env.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{client::Client, network::message::EnvMessage};
+use pueue_lib::{client::Client, network::message::EnvRequest};
 
 use super::handle_response;
 use crate::{
@@ -13,12 +13,12 @@ pub async fn env(client: &mut Client, style: &OutputStyle, cmd: EnvCommand) -> R
             task_id,
             key,
             value,
-        } => EnvMessage::Set {
+        } => EnvRequest::Set {
             task_id,
             key,
             value,
         },
-        EnvCommand::Unset { task_id, key } => EnvMessage::Unset { task_id, key },
+        EnvCommand::Unset { task_id, key } => EnvRequest::Unset { task_id, key },
     };
 
     client.send_request(request).await?;

--- a/pueue/src/client/commands/follow.rs
+++ b/pueue/src/client/commands/follow.rs
@@ -7,7 +7,7 @@ use pueue_lib::{
     Response,
     client::Client,
     log::{get_log_file_handle, get_log_path, seek_to_last_lines},
-    network::message::StreamRequestMessage,
+    network::message::StreamRequest,
 };
 use tokio::time::sleep;
 
@@ -53,7 +53,7 @@ pub async fn remote_follow(
 ) -> Result<()> {
     // Request the log stream.
     client
-        .send_request(StreamRequestMessage { task_id, lines })
+        .send_request(StreamRequest { task_id, lines })
         .await?;
 
     // Receive the stream until the connection is closed, breaks or another failure appears.

--- a/pueue/src/client/commands/group.rs
+++ b/pueue/src/client/commands/group.rs
@@ -14,12 +14,12 @@ pub async fn group(
     json: bool,
 ) -> Result<()> {
     let request = match cmd {
-        Some(GroupCommand::Add { name, parallel }) => GroupMessage::Add {
+        Some(GroupCommand::Add { name, parallel }) => GroupRequest::Add {
             name: name.to_owned(),
             parallel_tasks: parallel.to_owned(),
         },
-        Some(GroupCommand::Remove { name }) => GroupMessage::Remove(name.to_owned()),
-        None => GroupMessage::List,
+        Some(GroupCommand::Remove { name }) => GroupRequest::Remove(name.to_owned()),
+        None => GroupRequest::List,
     };
 
     client.send_request(request).await?;
@@ -37,7 +37,7 @@ pub async fn group(
 
 /// Print some info about the daemon's current groups.
 /// This is used when calling `pueue group`.
-pub fn format_groups(message: GroupResponseMessage, style: &OutputStyle, json: bool) -> String {
+pub fn format_groups(message: GroupResponse, style: &OutputStyle, json: bool) -> String {
     if json {
         return serde_json::to_string(&message.groups).unwrap();
     }

--- a/pueue/src/client/commands/kill.rs
+++ b/pueue/src/client/commands/kill.rs
@@ -19,7 +19,7 @@ pub async fn kill(
     }
 
     client
-        .send_request(KillMessage {
+        .send_request(KillRequest {
             tasks: selection_from_params(all, group, task_ids),
             signal,
         })

--- a/pueue/src/client/commands/log/json.rs
+++ b/pueue/src/client/commands/log/json.rs
@@ -5,7 +5,7 @@ use std::{
 
 use pueue_lib::{
     log::{get_log_file_handle, read_last_lines},
-    network::message::TaskLogMessage,
+    network::message::TaskLogResponse,
     settings::Settings,
     task::Task,
 };
@@ -19,16 +19,18 @@ pub struct TaskLog {
     pub output: String,
 }
 
+/// Print some log output in JSON serialized form.
+///
+/// If the log isn't read from the disk but rather received from the daemon, we have to
+/// convert the received [TaskLogResponse] into a proper JSON serializable format.
+/// Output in [TaskLogResponse], is usually compressed, so we need to decompress it first.
 pub fn print_log_json(
-    task_log_messages: BTreeMap<usize, TaskLogMessage>,
+    task_log_messages: BTreeMap<usize, TaskLogResponse>,
     settings: &Settings,
     lines: Option<usize>,
 ) {
     let mut tasks: BTreeMap<usize, Task> = BTreeMap::new();
     let mut task_log: BTreeMap<usize, String> = BTreeMap::new();
-    // Convert the TaskLogMessage into a proper JSON serializable format.
-    // Output in TaskLogMessages, if it exists, is compressed.
-    // We need to decompress and convert to normal strings.
     for (id, message) in task_log_messages {
         tasks.insert(id, message.task);
 

--- a/pueue/src/client/commands/log/mod.rs
+++ b/pueue/src/client/commands/log/mod.rs
@@ -2,7 +2,7 @@ use comfy_table::{Attribute as ComfyAttribute, Cell, CellAlignment, Table};
 use crossterm::style::Color;
 use pueue_lib::{
     client::Client,
-    network::message::{TaskLogMessage, TaskSelection, *},
+    network::message::{TaskLogResponse, TaskSelection, *},
     settings::Settings,
     task::{Task, TaskResult, TaskStatus},
 };
@@ -35,7 +35,7 @@ pub async fn print_logs(
     let selection = selection_from_params(all, group.clone(), task_ids.clone());
 
     client
-        .send_request(LogRequestMessage {
+        .send_request(LogRequest {
             tasks: selection.clone(),
             send_logs: !client.settings.client.read_local_logs,
             lines,
@@ -119,7 +119,7 @@ fn determine_log_line_amount(full: bool, lines: &Option<usize>) -> Option<usize>
 ///         `None` implicates that everything should be printed.
 ///         This is only important, if we read local lines.
 fn print_log(
-    message: &TaskLogMessage,
+    message: &TaskLogResponse,
     style: &OutputStyle,
     settings: &Settings,
     lines: Option<usize>,

--- a/pueue/src/client/commands/log/remote.rs
+++ b/pueue/src/client/commands/log/remote.rs
@@ -1,16 +1,14 @@
 use std::io;
 
 use crossterm::style::{Attribute, Color};
-use pueue_lib::network::message::TaskLogMessage;
+use pueue_lib::network::message::TaskLogResponse;
 use snap::read::FrameDecoder;
 
 use super::OutputStyle;
 use crate::internal_prelude::*;
 
 /// Prints log output received from the daemon.
-/// We can safely call .unwrap() on output in here, since this
-/// branch is always called after ensuring that it is `Some`.
-pub fn print_remote_log(task_log: &TaskLogMessage, style: &OutputStyle, lines: Option<usize>) {
+pub fn print_remote_log(task_log: &TaskLogResponse, style: &OutputStyle, lines: Option<usize>) {
     if let Some(bytes) = task_log.output.as_ref() {
         if !bytes.is_empty() {
             // Add a hint if we should limit the output to X lines **and** there are actually more

--- a/pueue/src/client/commands/parallel.rs
+++ b/pueue/src/client/commands/parallel.rs
@@ -13,13 +13,13 @@ pub async fn parallel(
     let request: Request = match parallel_tasks {
         Some(parallel_tasks) => {
             let group = group_or_default(&group);
-            ParallelMessage {
+            ParallelRequest {
                 parallel_tasks,
                 group,
             }
             .into()
         }
-        None => GroupMessage::List.into(),
+        None => GroupRequest::List.into(),
     };
 
     client.send_request(request).await?;

--- a/pueue/src/client/commands/pause.rs
+++ b/pueue/src/client/commands/pause.rs
@@ -15,7 +15,7 @@ pub async fn pause(
     wait: bool,
 ) -> Result<()> {
     client
-        .send_request(PauseMessage {
+        .send_request(PauseRequest {
             tasks: selection_from_params(all, group, task_ids),
             wait,
         })

--- a/pueue/src/client/commands/reset.rs
+++ b/pueue/src/client/commands/reset.rs
@@ -44,7 +44,7 @@ pub async fn reset(
         ResetTarget::Groups(groups.clone())
     };
 
-    client.send_request(ResetMessage { target }).await?;
+    client.send_request(ResetRequest { target }).await?;
     let response = client.receive_response().await?;
 
     handle_response(style, response)

--- a/pueue/src/client/commands/restart.rs
+++ b/pueue/src/client/commands/restart.rs
@@ -11,7 +11,7 @@ use crate::{
     internal_prelude::*,
 };
 
-/// When restarting tasks, the remote state is queried and a [AddMessage]
+/// When restarting tasks, the remote state is queried and a [AddRequest]
 /// is create from the existing task in the state.
 ///
 /// This is done on the client-side, so we can easily edit the task before restarting it.
@@ -89,7 +89,7 @@ pub async fn restart(
 
     // Build a RestartMessage, if the tasks should be replaced instead of creating a copy of the
     // original task. This is only important, if replace is `True`.
-    let mut restart_message = RestartMessage {
+    let mut restart_message = RestartRequest {
         tasks: Vec::new(),
         stashed,
         start_immediately,
@@ -135,9 +135,9 @@ pub async fn restart(
         }
 
         // In case we don't do in-place restarts, we have to add a new task.
-        // Create a AddMessage to send the task to the daemon from the updated info and the old
+        // Create an request to send the task to the daemon from the updated info and the old
         // task.
-        let add_task_message = AddMessage {
+        let add_task_message = AddRequest {
             command: task.command,
             path: task.path,
             envs: task.envs.clone(),

--- a/pueue/src/client/commands/send.rs
+++ b/pueue/src/client/commands/send.rs
@@ -10,7 +10,7 @@ pub async fn send(
     task_id: usize,
     input: String,
 ) -> Result<()> {
-    client.send_request(SendMessage { task_id, input }).await?;
+    client.send_request(SendRequest { task_id, input }).await?;
 
     let response = client.receive_response().await?;
 

--- a/pueue/src/client/commands/shutdown.rs
+++ b/pueue/src/client/commands/shutdown.rs
@@ -5,7 +5,7 @@ use crate::{client::style::OutputStyle, internal_prelude::*};
 
 /// Initiate a daemon shutdown
 pub async fn shutdown(client: &mut Client, style: &OutputStyle) -> Result<()> {
-    client.send_request(Shutdown::Graceful).await?;
+    client.send_request(ShutdownRequest::Graceful).await?;
 
     let response = client.receive_response().await?;
 

--- a/pueue/src/client/commands/start.rs
+++ b/pueue/src/client/commands/start.rs
@@ -17,7 +17,7 @@ pub async fn start(
     all: bool,
 ) -> Result<()> {
     client
-        .send_request(StartMessage {
+        .send_request(StartRequest {
             tasks: selection_from_params(all, group, task_ids),
         })
         .await?;

--- a/pueue/src/client/commands/stash.rs
+++ b/pueue/src/client/commands/stash.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local};
-use pueue_lib::{client::Client, network::message::StashMessage};
+use pueue_lib::{client::Client, network::message::StashRequest};
 
 use super::{handle_response, selection_from_params};
 use crate::{client::style::OutputStyle, internal_prelude::*};
@@ -15,7 +15,7 @@ pub async fn stash(
 ) -> Result<()> {
     let selection = selection_from_params(all, group, task_ids);
     client
-        .send_request(StashMessage {
+        .send_request(StashRequest {
             tasks: selection,
             enqueue_at: delay_until,
         })

--- a/pueue/src/client/commands/switch.rs
+++ b/pueue/src/client/commands/switch.rs
@@ -11,7 +11,7 @@ pub async fn switch(
     task_id_2: usize,
 ) -> Result<()> {
     client
-        .send_request(SwitchMessage {
+        .send_request(SwitchRequest {
             task_id_1,
             task_id_2,
         })

--- a/pueue/src/client/commands/wait.rs
+++ b/pueue/src/client/commands/wait.rs
@@ -72,8 +72,6 @@ pub async fn wait(
             return Ok(());
         }
 
-        // Get current time for log output
-
         // Iterate over all matching tasks
         for task in tasks.iter() {
             // Get the previous status of the task.

--- a/pueue/src/daemon/callbacks.rs
+++ b/pueue/src/daemon/callbacks.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use chrono::{DateTime, Local};
 use handlebars::{Handlebars, RenderError};
 use pueue_lib::{
+    Settings, Task, TaskResult, TaskStatus,
     log::{get_log_path, read_last_log_file_lines},
-    settings::Settings,
-    task::{Task, TaskResult, TaskStatus},
 };
 
 use crate::{

--- a/pueue/src/daemon/internal_state/state.rs
+++ b/pueue/src/daemon/internal_state/state.rs
@@ -11,7 +11,7 @@ use flate2::Compression;
 use pueue_lib::{
     Group, GroupStatus, Settings, State, TaskResult,
     error::Error,
-    network::message::request::Shutdown,
+    network::message::request::ShutdownRequest,
     state::{FilteredTasks, PUEUE_DEFAULT_GROUP},
     task::{Task, TaskStatus},
 };
@@ -53,7 +53,7 @@ pub struct InternalState {
     /// Depending on the shutdown type, we're exiting with different exitcodes.
     /// This is runtime state and won't be serialised to disk.
     #[serde(default, skip)]
-    pub shutdown: Option<Shutdown>,
+    pub shutdown: Option<ShutdownRequest>,
 
     /// Pueue's subprocess and worker pool representation.
     /// Take a look at [Children] for more info.

--- a/pueue/src/daemon/mod.rs
+++ b/pueue/src/daemon/mod.rs
@@ -6,12 +6,12 @@ use std::{
 
 use process_handler::initiate_shutdown;
 use pueue_lib::{
+    Settings,
     error::Error,
     network::{
-        certificate::create_certificates, message::Shutdown, protocol::socket_cleanup,
+        certificate::create_certificates, message::ShutdownRequest, protocol::socket_cleanup,
         secret::init_shared_secret,
     },
-    settings::Settings,
 };
 use tokio::try_join;
 
@@ -150,7 +150,7 @@ fn setup_signal_panic_handling(settings: &Settings, state: SharedState) -> Resul
     // The actual program exit will be done via the TaskHandler.
     ctrlc::set_handler(move || {
         let mut state = state_clone.lock().unwrap();
-        initiate_shutdown(&settings_clone, &mut state, Shutdown::Graceful);
+        initiate_shutdown(&settings_clone, &mut state, ShutdownRequest::Graceful);
     })?;
 
     // Try to do some final cleanup, even if we panic.

--- a/pueue/src/daemon/network/message_handler/add.rs
+++ b/pueue/src/daemon/network/message_handler/add.rs
@@ -1,11 +1,7 @@
 use chrono::Local;
 use pueue_lib::{
-    aliasing::insert_alias,
-    failure_msg,
+    GroupStatus, Settings, Task, TaskStatus, aliasing::insert_alias, failure_msg,
     network::message::*,
-    settings::Settings,
-    state::GroupStatus,
-    task::{Task, TaskStatus},
 };
 
 use crate::{
@@ -17,10 +13,13 @@ use crate::{
     ok_or_save_state_failure,
 };
 
+#[cfg(doc)]
+use pueue_lib::State;
+
 /// Invoked when calling `pueue add`.
-/// Queues a new task to the state.
+/// Queues a new [Task] to the [State].
 /// If the start_immediately flag is set, send a StartMessage to the task handler.
-pub fn add_task(settings: &Settings, state: &SharedState, message: AddMessage) -> Response {
+pub fn add_task(settings: &Settings, state: &SharedState, message: AddRequest) -> Response {
     let mut state = state.lock().unwrap();
     if let Err(response) = ensure_group_exists(&mut state, &message.group) {
         return response;
@@ -86,7 +85,7 @@ pub fn add_task(settings: &Settings, state: &SharedState, message: AddMessage) -
         process_handler::start::start(settings, &mut state, TaskSelection::TaskIds(vec![task_id]));
     }
 
-    AddedTaskMessage {
+    AddedTaskResponse {
         task_id,
         enqueue_at: message.enqueue_at,
         group_is_paused,

--- a/pueue/src/daemon/network/message_handler/clean.rs
+++ b/pueue/src/daemon/network/message_handler/clean.rs
@@ -1,13 +1,9 @@
-use pueue_lib::{
-    log::clean_log_handles,
-    network::message::*,
-    task::{TaskResult, TaskStatus},
-};
+use pueue_lib::{TaskResult, TaskStatus, log::clean_log_handles, network::message::*};
 
 use super::*;
 use crate::{daemon::internal_state::SharedState, ok_or_save_state_failure};
 
-fn construct_success_clean_message(message: CleanMessage) -> String {
+fn construct_success_clean_message(message: CleanRequest) -> String {
     let successful_only_fix = if message.successful_only {
         " successfully"
     } else {
@@ -24,7 +20,7 @@ fn construct_success_clean_message(message: CleanMessage) -> String {
 
 /// Invoked when calling `pueue clean`.
 /// Remove all failed or done tasks from the state.
-pub fn clean(settings: &Settings, state: &SharedState, message: CleanMessage) -> Response {
+pub fn clean(settings: &Settings, state: &SharedState, message: CleanRequest) -> Response {
     let mut state = state.lock().unwrap();
 
     let filtered_tasks =
@@ -75,8 +71,8 @@ mod tests {
     use super::{super::fixtures::*, *};
     use crate::daemon::internal_state::state::InternalState;
 
-    fn get_message(successful_only: bool, group: Option<String>) -> CleanMessage {
-        CleanMessage {
+    fn get_message(successful_only: bool, group: Option<String>) -> CleanRequest {
+        CleanRequest {
             successful_only,
             group,
         }

--- a/pueue/src/daemon/network/message_handler/edit.rs
+++ b/pueue/src/daemon/network/message_handler/edit.rs
@@ -1,5 +1,5 @@
 use pueue_lib::{
-    aliasing::insert_alias, failure_msg, network::message::*, success_msg, task::TaskStatus,
+    TaskStatus, aliasing::insert_alias, failure_msg, network::message::*, success_msg,
 };
 
 use super::*;

--- a/pueue/src/daemon/network/message_handler/enqueue.rs
+++ b/pueue/src/daemon/network/message_handler/enqueue.rs
@@ -1,17 +1,13 @@
 use chrono::Local;
 use pueue_lib::{
-    format::format_datetime,
-    network::message::*,
-    settings::Settings,
-    success_msg,
-    task::{Task, TaskStatus},
+    Settings, Task, TaskStatus, format::format_datetime, network::message::*, success_msg,
 };
 
 use crate::daemon::{internal_state::SharedState, network::response_helper::*};
 
 /// Invoked when calling `pueue enqueue`.
 /// Enqueue specific stashed tasks.
-pub fn enqueue(settings: &Settings, state: &SharedState, message: EnqueueMessage) -> Response {
+pub fn enqueue(settings: &Settings, state: &SharedState, message: EnqueueRequest) -> Response {
     let mut state = state.lock().unwrap();
     // Get the affected task ids, based on the task selection.
     let selected_tasks = match message.tasks {

--- a/pueue/src/daemon/network/message_handler/env.rs
+++ b/pueue/src/daemon/network/message_handler/env.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::*, settings::Settings};
+use pueue_lib::{Settings, network::message::*};
 
 use crate::{
     daemon::{internal_state::SharedState, network::message_handler::ok_or_failure_message},
@@ -9,11 +9,11 @@ use crate::{
 /// Manage environment variables for tasks.
 /// - Set environment variables
 /// - Unset environment variables
-pub fn env(settings: &Settings, state: &SharedState, message: EnvMessage) -> Response {
+pub fn env(settings: &Settings, state: &SharedState, message: EnvRequest) -> Response {
     let mut state = state.lock().unwrap();
 
     let message = match message {
-        EnvMessage::Set {
+        EnvRequest::Set {
             task_id,
             key,
             value,
@@ -30,7 +30,7 @@ pub fn env(settings: &Settings, state: &SharedState, message: EnvMessage) -> Res
 
             create_success_response("Environment variable set.")
         }
-        EnvMessage::Unset { task_id, key } => {
+        EnvRequest::Unset { task_id, key } => {
             let Some(task) = state.tasks_mut().get_mut(&task_id) else {
                 return create_failure_response(format!("No task with id {task_id}"));
             };

--- a/pueue/src/daemon/network/message_handler/kill.rs
+++ b/pueue/src/daemon/network/message_handler/kill.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::*, settings::Settings, success_msg, task::Task};
+use pueue_lib::{Settings, Task, network::message::*, success_msg};
 
 use crate::daemon::{
     internal_state::SharedState,
@@ -8,7 +8,7 @@ use crate::daemon::{
 
 /// Invoked when calling `pueue kill`.
 /// Forward the kill message to the task handler, which then kills the process.
-pub fn kill(settings: &Settings, state: &SharedState, message: KillMessage) -> Response {
+pub fn kill(settings: &Settings, state: &SharedState, message: KillRequest) -> Response {
     let mut state = state.lock().unwrap();
 
     // If a group is selected, make sure it exists.

--- a/pueue/src/daemon/network/message_handler/mod.rs
+++ b/pueue/src/daemon/network/message_handler/mod.rs
@@ -1,9 +1,8 @@
 use std::fmt::Display;
 
 use pueue_lib::{
-    failure_msg,
+    Settings, failure_msg,
     network::{message::*, protocol::send_response, socket::GenericStream},
-    settings::Settings,
 };
 
 use crate::{
@@ -40,7 +39,7 @@ pub async fn handle_request(
     let response = match request {
         // The client requested the output of a task.
         // Since this involves streaming content, we have to do some special handling.
-        Request::StreamRequest(payload) => {
+        Request::Stream(payload) => {
             let pueue_directory = settings.shared.pueue_directory();
             follow_log(&pueue_directory, stream, state, payload).await?
         }
@@ -61,7 +60,7 @@ pub async fn handle_request(
         }
         Request::Add(message) => add::add_task(settings, state, message),
         Request::Clean(message) => clean::clean(settings, state, message),
-        Request::Edit(editable_tasks) => edit::edit(settings, state, editable_tasks),
+        Request::EditedTasks(editable_tasks) => edit::edit(settings, state, editable_tasks),
         Request::EditRequest(task_ids) => edit::edit_request(state, task_ids),
         Request::EditRestore(task_ids) => edit::edit_restore(state, task_ids),
         Request::Env(message) => env::env(settings, state, message),

--- a/pueue/src/daemon/network/message_handler/parallel.rs
+++ b/pueue/src/daemon/network/message_handler/parallel.rs
@@ -3,7 +3,7 @@ use pueue_lib::{network::message::*, success_msg};
 use crate::daemon::{internal_state::SharedState, network::response_helper::*};
 
 /// Set the parallel tasks for a specific group.
-pub fn set_parallel_tasks(message: ParallelMessage, state: &SharedState) -> Response {
+pub fn set_parallel_tasks(message: ParallelRequest, state: &SharedState) -> Response {
     let mut state = state.lock().unwrap();
     let group = match ensure_group_exists(&mut state, &message.group) {
         Ok(group) => group,

--- a/pueue/src/daemon/network/message_handler/pause.rs
+++ b/pueue/src/daemon/network/message_handler/pause.rs
@@ -1,10 +1,10 @@
-use pueue_lib::{network::message::*, settings::Settings, success_msg, task::TaskStatus};
+use pueue_lib::{Settings, TaskStatus, network::message::*, success_msg};
 
 use crate::daemon::{internal_state::SharedState, network::response_helper::*, process_handler};
 
 /// Invoked when calling `pueue pause`.
 /// Forward the pause message to the task handler, which then pauses groups/tasks/everything.
-pub fn pause(settings: &Settings, state: &SharedState, message: PauseMessage) -> Response {
+pub fn pause(settings: &Settings, state: &SharedState, message: PauseRequest) -> Response {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {

--- a/pueue/src/daemon/network/message_handler/remove.rs
+++ b/pueue/src/daemon/network/message_handler/remove.rs
@@ -1,9 +1,4 @@
-use pueue_lib::{
-    log::clean_log_handles,
-    network::message::*,
-    settings::Settings,
-    task::{Task, TaskStatus},
-};
+use pueue_lib::{Settings, Task, TaskStatus, log::clean_log_handles, network::message::*};
 
 use super::ok_or_failure_message;
 use crate::{

--- a/pueue/src/daemon/network/message_handler/reset.rs
+++ b/pueue/src/daemon/network/message_handler/reset.rs
@@ -1,11 +1,11 @@
-use pueue_lib::{failure_msg, network::message::*, settings::Settings, state::GroupStatus};
+use pueue_lib::{GroupStatus, Settings, failure_msg, network::message::*};
 
 use crate::daemon::{internal_state::SharedState, process_handler};
 
 /// Invoked when calling `pueue reset`.
 /// Kill all children by using the `kill` function.
 /// Set the full_reset flag, which will prevent new tasks from being spawned.
-pub fn reset(settings: &Settings, state: &SharedState, message: ResetMessage) -> Response {
+pub fn reset(settings: &Settings, state: &SharedState, message: ResetRequest) -> Response {
     let mut state = state.lock().unwrap();
 
     match message.target {

--- a/pueue/src/daemon/network/message_handler/restart.rs
+++ b/pueue/src/daemon/network/message_handler/restart.rs
@@ -1,10 +1,5 @@
 use chrono::Local;
-use pueue_lib::{
-    aliasing::insert_alias,
-    network::message::*,
-    settings::Settings,
-    task::{Task, TaskStatus},
-};
+use pueue_lib::{Settings, Task, TaskStatus, aliasing::insert_alias, network::message::*};
 
 use crate::daemon::{
     internal_state::{SharedState, state::LockedState},
@@ -19,7 +14,7 @@ use crate::daemon::{
 pub fn restart_multiple(
     settings: &Settings,
     state: &SharedState,
-    message: RestartMessage,
+    message: RestartRequest,
 ) -> Response {
     let task_ids: Vec<usize> = message.tasks.iter().map(|task| task.task_id).collect();
     let mut state = state.lock().unwrap();

--- a/pueue/src/daemon/network/message_handler/send.rs
+++ b/pueue/src/daemon/network/message_handler/send.rs
@@ -7,7 +7,7 @@ use crate::daemon::internal_state::SharedState;
 /// Invoked when calling `pueue send`.
 /// The message will be forwarded to the task handler, which then sends the user input to the
 /// process. In here we only do some error handling.
-pub fn send(state: &SharedState, message: SendMessage) -> Response {
+pub fn send(state: &SharedState, message: SendRequest) -> Response {
     let task_id = message.task_id;
     let mut state = state.lock().unwrap();
 

--- a/pueue/src/daemon/network/message_handler/start.rs
+++ b/pueue/src/daemon/network/message_handler/start.rs
@@ -1,10 +1,10 @@
-use pueue_lib::{network::message::*, settings::Settings, success_msg, task::TaskStatus};
+use pueue_lib::{Settings, TaskStatus, network::message::*, success_msg};
 
 use crate::daemon::{internal_state::SharedState, network::response_helper::*, process_handler};
 
 /// Invoked when calling `pueue start`.
 /// Forward the start message to the task handler, which then starts the process(es).
-pub fn start(settings: &Settings, state: &SharedState, message: StartMessage) -> Response {
+pub fn start(settings: &Settings, state: &SharedState, message: StartRequest) -> Response {
     let mut state = state.lock().unwrap();
     // If a group is selected, make sure it exists.
     if let TaskSelection::Group(group) = &message.tasks {

--- a/pueue/src/daemon/network/message_handler/stash.rs
+++ b/pueue/src/daemon/network/message_handler/stash.rs
@@ -1,6 +1,5 @@
 use pueue_lib::{
-    Task, format::format_datetime, network::message::*, settings::Settings, success_msg,
-    task::TaskStatus,
+    Settings, Task, TaskStatus, format::format_datetime, network::message::*, success_msg,
 };
 
 use crate::daemon::{internal_state::SharedState, network::response_helper::*};
@@ -8,7 +7,7 @@ use crate::daemon::{internal_state::SharedState, network::response_helper::*};
 /// Invoked when calling `pueue stash`.
 /// Stash specific queued tasks.
 /// They won't be executed until they're enqueued or explicitly started.
-pub fn stash(settings: &Settings, state: &SharedState, message: StashMessage) -> Response {
+pub fn stash(settings: &Settings, state: &SharedState, message: StashRequest) -> Response {
     let mut state = state.lock().unwrap();
     // Get the affected task ids, based on the task selection.
     let selected_tasks = match message.tasks {

--- a/pueue/src/daemon/network/message_handler/switch.rs
+++ b/pueue/src/daemon/network/message_handler/switch.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{failure_msg, network::message::*, settings::Settings, task::TaskStatus};
+use pueue_lib::{Settings, TaskStatus, failure_msg, network::message::*};
 
 use super::ok_or_failure_message;
 use crate::{daemon::internal_state::SharedState, ok_or_save_state_failure};
@@ -6,7 +6,7 @@ use crate::{daemon::internal_state::SharedState, ok_or_save_state_failure};
 /// Invoked when calling `pueue switch`.
 /// Switch the position of two tasks in the upcoming queue.
 /// We have to ensure that those tasks are either `Queued` or `Stashed`
-pub fn switch(settings: &Settings, state: &SharedState, message: SwitchMessage) -> Response {
+pub fn switch(settings: &Settings, state: &SharedState, message: SwitchRequest) -> Response {
     let mut state = state.lock().unwrap();
 
     let task_ids = [message.task_id_1, message.task_id_2];
@@ -67,8 +67,8 @@ mod tests {
 
     use super::{super::fixtures::*, *};
 
-    fn get_message(task_id_1: usize, task_id_2: usize) -> SwitchMessage {
-        SwitchMessage {
+    fn get_message(task_id_1: usize, task_id_2: usize) -> SwitchRequest {
+        SwitchRequest {
             task_id_1,
             task_id_2,
         }

--- a/pueue/src/daemon/network/response_helper.rs
+++ b/pueue/src/daemon/network/response_helper.rs
@@ -1,7 +1,7 @@
 use pueue_lib::{
-    network::message::{Response, create_failure_response, create_success_response},
-    state::{FilteredTasks, Group},
-    task::Task,
+    Group, Response, Task,
+    network::message::{create_failure_response, create_success_response},
+    state::FilteredTasks,
 };
 
 use crate::daemon::internal_state::state::LockedState;

--- a/pueue/src/daemon/network/socket.rs
+++ b/pueue/src/daemon/network/socket.rs
@@ -1,10 +1,8 @@
 use std::time::{Duration, SystemTime};
 
 use pueue_lib::{
-    PROTOCOL_VERSION,
-    error::Error,
+    Error, PROTOCOL_VERSION, Settings,
     network::{message::*, protocol::*, secret::read_shared_secret},
-    settings::Settings,
 };
 use tokio::time::sleep;
 

--- a/pueue/src/daemon/pid.rs
+++ b/pueue/src/daemon/pid.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use pueue_lib::error::Error;
+use pueue_lib::Error;
 
 use crate::{internal_prelude::*, process_helper::process_exists};
 

--- a/pueue/src/daemon/process_handler/finish.rs
+++ b/pueue/src/daemon/process_handler/finish.rs
@@ -1,10 +1,5 @@
 use chrono::Local;
-use pueue_lib::{
-    log::clean_log_handles,
-    settings::Settings,
-    state::GroupStatus,
-    task::{TaskResult, TaskStatus},
-};
+use pueue_lib::{GroupStatus, Settings, TaskResult, TaskStatus, log::clean_log_handles};
 
 use crate::{
     daemon::{callbacks::spawn_callback, internal_state::state::LockedState},

--- a/pueue/src/daemon/process_handler/kill.rs
+++ b/pueue/src/daemon/process_handler/kill.rs
@@ -1,8 +1,6 @@
 use pueue_lib::{
+    GroupStatus, Settings, Task, TaskStatus,
     network::message::{Signal, TaskSelection},
-    settings::Settings,
-    state::GroupStatus,
-    task::{Task, TaskStatus},
 };
 
 use crate::{

--- a/pueue/src/daemon/process_handler/pause.rs
+++ b/pueue/src/daemon/process_handler/pause.rs
@@ -1,6 +1,4 @@
-use pueue_lib::{
-    network::message::TaskSelection, settings::Settings, state::GroupStatus, task::TaskStatus,
-};
+use pueue_lib::{GroupStatus, Settings, TaskStatus, network::message::TaskSelection};
 
 use crate::{
     daemon::{internal_state::state::LockedState, process_handler::perform_action},

--- a/pueue/src/daemon/process_handler/spawn.rs
+++ b/pueue/src/daemon/process_handler/spawn.rs
@@ -3,10 +3,8 @@ use std::{io::Write, process::Stdio};
 use chrono::Local;
 use command_group::CommandGroup;
 use pueue_lib::{
+    GroupStatus, Settings, Task, TaskResult, TaskStatus,
     log::{create_log_file_handles, get_writable_log_file_handle},
-    settings::Settings,
-    state::GroupStatus,
-    task::{Task, TaskResult, TaskStatus},
 };
 
 use crate::{

--- a/pueue/src/daemon/process_handler/start.rs
+++ b/pueue/src/daemon/process_handler/start.rs
@@ -1,6 +1,4 @@
-use pueue_lib::{
-    network::message::TaskSelection, settings::Settings, state::GroupStatus, task::TaskStatus,
-};
+use pueue_lib::{GroupStatus, Settings, TaskStatus, network::message::TaskSelection};
 
 use crate::{
     daemon::{

--- a/pueue/src/daemon/task_handler.rs
+++ b/pueue/src/daemon/task_handler.rs
@@ -2,10 +2,8 @@ use std::{collections::BTreeMap, time::Duration};
 
 use chrono::prelude::*;
 use pueue_lib::{
+    Group, GroupStatus, Settings, TaskResult, TaskStatus,
     network::{message::*, protocol::socket_cleanup},
-    settings::Settings,
-    state::{Group, GroupStatus},
-    task::{TaskResult, TaskStatus},
 };
 
 use crate::{
@@ -90,7 +88,7 @@ fn handle_shutdown(settings: &Settings, state: &mut LockedState) {
 
     // Actually exit the program the way we're supposed to.
     // Depending on the current shutdown type, we exit with different exit codes.
-    if matches!(state.shutdown, Some(Shutdown::Emergency)) {
+    if matches!(state.shutdown, Some(ShutdownRequest::Emergency)) {
         std::process::exit(1);
     }
     std::process::exit(0);

--- a/pueue/src/process_helper/mod.rs
+++ b/pueue/src/process_helper/mod.rs
@@ -5,7 +5,7 @@
 //! Depending on the target, the respective platform is read and loaded into this scope.
 use std::{collections::HashMap, process::Command};
 
-use pueue_lib::{network::message::request::Signal as InternalSignal, settings::Settings};
+use pueue_lib::{Settings, network::message::request::Signal as InternalSignal};
 
 use crate::internal_prelude::*;
 

--- a/pueue/src/process_helper/unix.rs
+++ b/pueue/src/process_helper/unix.rs
@@ -4,7 +4,7 @@
 // type.
 use color_eyre::Result;
 use command_group::{GroupChild, Signal, UnixChildExt};
-use pueue_lib::settings::Settings;
+use pueue_lib::Settings;
 
 use crate::internal_prelude::*;
 

--- a/pueue/tests/client/integration/configuration.rs
+++ b/pueue/tests/client/integration/configuration.rs
@@ -5,8 +5,8 @@ use std::{
 
 use assert_cmd::prelude::CommandCargoExt;
 use pueue_lib::{
+    State,
     settings::{PUEUE_CONFIG_PATH_ENV, Shared},
-    state::State,
 };
 
 use crate::{helper::*, internal_prelude::*};

--- a/pueue/tests/client/integration/env.rs
+++ b/pueue/tests/client/integration/env.rs
@@ -1,4 +1,4 @@
-use pueue_lib::task::Task;
+use pueue_lib::Task;
 
 use crate::{client::helper::*, internal_prelude::*};
 

--- a/pueue/tests/client/integration/follow.rs
+++ b/pueue/tests/client/integration/follow.rs
@@ -153,9 +153,9 @@ async fn fail_on_non_existing(#[case] read_local_logs: bool) -> Result<()> {
 //     tokio::task::spawn(async move {
 //         sleep_ms(2000).await;
 //         // Reset the daemon
-//         send_message(&moved_shared, ResetMessage {})
+//         send_request(&moved_shared, ResetRequest {})
 //             .await
-//             .expect("Failed to send Start tasks message");
+//             .expect("Failed to send reset request");
 //     });
 //
 //     // Execute `follow` and remove the task

--- a/pueue/tests/client/integration/group.rs
+++ b/pueue/tests/client/integration/group.rs
@@ -1,9 +1,6 @@
 use std::collections::BTreeMap;
 
-use pueue_lib::{
-    network::message::*,
-    state::{Group, GroupStatus},
-};
+use pueue_lib::{Group, GroupStatus, network::message::*};
 
 use crate::{client::helper::*, internal_prelude::*};
 
@@ -36,7 +33,7 @@ async fn colored() -> Result<()> {
 
     // Pauses the default queue while waiting for tasks
     // We do this to ensure that paused groups are properly colored.
-    let message = PauseMessage {
+    let message = PauseRequest {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
     };

--- a/pueue/tests/client/integration/log.rs
+++ b/pueue/tests/client/integration/log.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use pueue_lib::task::Task;
+use pueue_lib::Task;
 use rstest::rstest;
 use serde::Deserialize;
 

--- a/pueue/tests/client/integration/restart.rs
+++ b/pueue/tests/client/integration/restart.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use assert_matches::assert_matches;
-use pueue_lib::task::{Task, TaskResult, TaskStatus};
+use pueue_lib::{Task, TaskResult, TaskStatus};
 
 use crate::{client::helper::*, internal_prelude::*};
 

--- a/pueue/tests/client/integration/status.rs
+++ b/pueue/tests/client/integration/status.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{state::State, task::Task};
+use pueue_lib::{State, Task};
 
 use crate::{client::helper::*, internal_prelude::*};
 

--- a/pueue/tests/daemon/integration/aliases.rs
+++ b/pueue/tests/daemon/integration/aliases.rs
@@ -72,7 +72,7 @@ async fn test_restart_with_alias() -> Result<()> {
     create_test_alias_file(daemon.tempdir.path(), aliases)?;
 
     // Restart the task while editing its command.
-    let message = RestartMessage {
+    let message = RestartRequest {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: "replaced_cmd test".to_string(),

--- a/pueue/tests/daemon/integration/clean.rs
+++ b/pueue/tests/daemon/integration/clean.rs
@@ -16,7 +16,7 @@ async fn test_normal_clean() -> Result<()> {
     wait_for_task_condition(shared, 2, Task::is_running).await?;
 
     // Send the clean message
-    let clean_message = CleanMessage {
+    let clean_message = CleanRequest {
         successful_only: false,
         group: None,
     };
@@ -44,7 +44,7 @@ async fn test_successful_only_clean() -> Result<()> {
     wait_for_task_condition(shared, 1, Task::is_done).await?;
 
     // Send the clean message
-    let clean_message = CleanMessage {
+    let clean_message = CleanRequest {
         successful_only: true,
         group: None,
     };
@@ -77,7 +77,7 @@ async fn test_clean_in_selected_group() -> Result<()> {
     wait_for_task_condition(shared, 6, Task::is_running).await?;
 
     // Send the clean message
-    let clean_message = CleanMessage {
+    let clean_message = CleanRequest {
         successful_only: false,
         group: Some("other".to_string()),
     };
@@ -115,7 +115,7 @@ async fn test_clean_successful_only_in_selected_group() -> Result<()> {
     wait_for_task_condition(shared, 6, Task::is_running).await?;
 
     // Send the clean message
-    let clean_message = CleanMessage {
+    let clean_message = CleanRequest {
         successful_only: true,
         group: Some("other".to_string()),
     };

--- a/pueue/tests/daemon/integration/dependencies.rs
+++ b/pueue/tests/daemon/integration/dependencies.rs
@@ -1,5 +1,5 @@
 use pueue_lib::{
-    network::message::{KillMessage, TaskSelection},
+    network::message::{KillRequest, TaskSelection},
     task::*,
 };
 
@@ -52,7 +52,7 @@ async fn test_failing_dependency() -> Result<()> {
     // This should result in the second task failing.
     send_request(
         shared,
-        KillMessage {
+        KillRequest {
             tasks: TaskSelection::TaskIds(vec![0]),
             signal: None,
         },

--- a/pueue/tests/daemon/integration/edit.rs
+++ b/pueue/tests/daemon/integration/edit.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use assert_matches::assert_matches;
-use pueue_lib::{network::message::*, settings::Shared, state::GroupStatus, task::*};
+use pueue_lib::{GroupStatus, network::message::*, settings::Shared, task::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -63,7 +63,7 @@ async fn test_edit_flow() -> Result<()> {
     editable_task.priority = 99;
 
     // Send the final message of the protocol and actually change the task.
-    let response = send_request(shared, Request::Edit(vec![editable_task])).await?;
+    let response = send_request(shared, Request::EditedTasks(vec![editable_task])).await?;
     assert_success(response);
 
     // Make sure the task has been changed and enqueued.

--- a/pueue/tests/daemon/integration/kill.rs
+++ b/pueue/tests/daemon/integration/kill.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use pueue_lib::{network::message::*, state::GroupStatus, task::*};
+use pueue_lib::{GroupStatus, network::message::*, task::*};
 use rstest::rstest;
 
 use crate::{helper::*, internal_prelude::*};
@@ -16,26 +16,26 @@ use crate::{helper::*, internal_prelude::*};
 /// This is security measure to prevent unwanted task execution in an emergency.
 #[rstest]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::All,
         signal: None,
     }, true
 )]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         signal: None,
     }, true
 )]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::TaskIds(vec![0, 1, 2]),
         signal: None,
     }, false
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_kill_tasks_with_pause(
-    #[case] kill_message: KillMessage,
+    #[case] kill_message: KillRequest,
     #[case] group_should_pause: bool,
 ) -> Result<()> {
     let daemon = daemon().await?;
@@ -100,25 +100,25 @@ async fn test_kill_tasks_with_pause(
 /// - Via specific ids.
 #[rstest]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::All,
         signal: None,
     }
 )]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         signal: None,
     }
 )]
 #[case(
-    KillMessage {
+    KillRequest {
         tasks: TaskSelection::TaskIds(vec![0, 1, 2]),
         signal: None,
     }
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_kill_tasks_without_pause(#[case] kill_message: KillMessage) -> Result<()> {
+async fn test_kill_tasks_without_pause(#[case] kill_message: KillRequest) -> Result<()> {
     let daemon = daemon().await?;
     let shared = &daemon.settings.shared;
 

--- a/pueue/tests/daemon/integration/log.rs
+++ b/pueue/tests/daemon/integration/log.rs
@@ -3,7 +3,7 @@ use std::{
     path::Path,
 };
 
-use pueue_lib::{network::message::*, task::Task};
+use pueue_lib::{Task, network::message::*};
 use tempfile::TempDir;
 
 use crate::{helper::*, internal_prelude::*};
@@ -94,7 +94,7 @@ async fn test_partial_log() -> Result<()> {
     println!("Actual log file contents: \n{content}");
 
     // Request a partial log for task 0
-    let log_message = LogRequestMessage {
+    let log_message = LogRequest {
         tasks: TaskSelection::TaskIds(vec![0]),
         send_logs: true,
         lines: Some(5),
@@ -110,7 +110,7 @@ async fn test_partial_log() -> Result<()> {
     let output = logs
         .output
         .clone()
-        .ok_or(eyre!("Didn't find output on TaskLogMessage"))?;
+        .ok_or(eyre!("Didn't find output on TaskLogResponse"))?;
     let output = decompress_log(output)?;
 
     // Make sure it's the same
@@ -131,7 +131,7 @@ async fn test_correct_log_order() -> Result<()> {
     wait_for_task_condition(shared, 0, Task::is_done).await?;
 
     // Request all log lines
-    let log_message = LogRequestMessage {
+    let log_message = LogRequest {
         tasks: TaskSelection::TaskIds(vec![0]),
         send_logs: true,
         lines: None,
@@ -147,7 +147,7 @@ async fn test_correct_log_order() -> Result<()> {
     let output = logs
         .output
         .clone()
-        .ok_or(eyre!("Didn't find output on TaskLogMessage"))?;
+        .ok_or(eyre!("Didn't find output on TaskLogResponse"))?;
     let output = decompress_log(output)?;
 
     // Make sure it's the same
@@ -174,7 +174,7 @@ async fn logs_of_group() -> Result<()> {
     wait_for_task_condition(shared, 1, Task::is_done).await?;
 
     // Request the task's logs.
-    let message = LogRequestMessage {
+    let message = LogRequest {
         tasks: TaskSelection::Group("test_2".to_string()),
         send_logs: true,
         lines: None,
@@ -208,7 +208,7 @@ async fn logs_for_all() -> Result<()> {
     wait_for_task_condition(shared, 1, Task::is_done).await?;
 
     // Request the task's logs.
-    let message = LogRequestMessage {
+    let message = LogRequest {
         tasks: TaskSelection::All,
         send_logs: true,
         lines: None,

--- a/pueue/tests/daemon/integration/parallel_tasks.rs
+++ b/pueue/tests/daemon/integration/parallel_tasks.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use pueue_lib::{network::message::ParallelMessage, task::*};
+use pueue_lib::{network::message::ParallelRequest, task::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -80,7 +80,7 @@ async fn test_unlimited_parallel_tasks() -> Result<()> {
     wait_for_task_condition(shared, 0, Task::is_running).await?;
 
     // Update the parallel limit of the group to 0
-    let message = ParallelMessage {
+    let message = ParallelRequest {
         group: "testgroup".to_string(),
         parallel_tasks: 0,
     };

--- a/pueue/tests/daemon/integration/pause.rs
+++ b/pueue/tests/daemon/integration/pause.rs
@@ -1,5 +1,5 @@
 use assert_matches::assert_matches;
-use pueue_lib::{network::message::*, state::GroupStatus, task::*};
+use pueue_lib::{GroupStatus, network::message::*, task::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -71,7 +71,7 @@ async fn test_pause_with_wait() -> Result<()> {
     wait_for_task_condition(shared, 0, Task::is_running).await?;
 
     // Pauses the default queue while waiting for tasks
-    let message = PauseMessage {
+    let message = PauseRequest {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
         wait: true,
     };

--- a/pueue/tests/daemon/integration/priority.rs
+++ b/pueue/tests/daemon/integration/priority.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::TaskSelection, task::Task};
+use pueue_lib::{Task, network::message::TaskSelection};
 use rstest::rstest;
 
 use crate::{helper::*, internal_prelude::*};

--- a/pueue/tests/daemon/integration/remove.rs
+++ b/pueue/tests/daemon/integration/remove.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::*, task::Task};
+use pueue_lib::{Task, network::message::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -32,7 +32,7 @@ async fn test_normal_remove() -> Result<()> {
     // Stash task 5
     send_request(
         shared,
-        StashMessage {
+        StashRequest {
             tasks: TaskSelection::TaskIds(vec![5]),
             enqueue_at: None,
         },

--- a/pueue/tests/daemon/integration/reset.rs
+++ b/pueue/tests/daemon/integration/reset.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::*, state::GroupStatus, task::Task};
+use pueue_lib::{GroupStatus, Task, network::message::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -18,7 +18,7 @@ async fn test_reset() -> Result<()> {
     // Reset all groups of the daemon
     send_request(
         shared,
-        ResetMessage {
+        ResetRequest {
             target: ResetTarget::All,
         },
     )
@@ -64,7 +64,7 @@ async fn test_reset_single_group() -> Result<()> {
     // Reset only the test_2 of the daemon.
     send_request(
         shared,
-        ResetMessage {
+        ResetRequest {
             target: ResetTarget::Groups(vec!["test_2".to_string()]),
         },
     )
@@ -106,7 +106,7 @@ async fn test_reset_multiple_groups() -> Result<()> {
     // Reset only the test_2 of the daemon.
     send_request(
         shared,
-        ResetMessage {
+        ResetRequest {
             target: ResetTarget::Groups(vec!["test_2".to_string(), "test_3".to_string()]),
         },
     )

--- a/pueue/tests/daemon/integration/restart.rs
+++ b/pueue/tests/daemon/integration/restart.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use pueue_lib::{network::message::*, task::Task};
+use pueue_lib::{Task, network::message::*};
 
 use crate::{helper::*, internal_prelude::*};
 
@@ -18,7 +18,7 @@ async fn test_restart_in_place() -> Result<()> {
     let original_task = wait_for_task_condition(shared, 0, Task::is_done).await?;
 
     // Restart task 0 with an sleep command and with a different path.
-    let restart_message = RestartMessage {
+    let restart_message = RestartRequest {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: "sleep 60".to_string(),
@@ -64,7 +64,7 @@ async fn test_cannot_restart_running() -> Result<()> {
     let task = get_task(shared, 1).await?;
 
     // Try to restart task 0
-    let restart_message = RestartMessage {
+    let restart_message = RestartRequest {
         tasks: vec![TaskToRestart {
             task_id: 0,
             command: task.command,

--- a/pueue/tests/daemon/integration/restore.rs
+++ b/pueue/tests/daemon/integration/restore.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::TaskSelection, state::GroupStatus};
+use pueue_lib::{GroupStatus, network::message::TaskSelection};
 use rstest::rstest;
 
 use crate::{helper::*, internal_prelude::*};

--- a/pueue/tests/daemon/integration/spawn.rs
+++ b/pueue/tests/daemon/integration/spawn.rs
@@ -1,9 +1,6 @@
 use std::io::Read;
 
-use pueue_lib::{
-    log::get_log_file_handle,
-    task::{TaskResult, TaskStatus},
-};
+use pueue_lib::{TaskResult, TaskStatus, log::get_log_file_handle};
 use rstest::rstest;
 
 use crate::{helper::*, internal_prelude::*};

--- a/pueue/tests/daemon/integration/start.rs
+++ b/pueue/tests/daemon/integration/start.rs
@@ -11,22 +11,22 @@ use crate::{helper::*, internal_prelude::*};
 /// - Via specific ids.
 #[rstest]
 #[case(
-    StartMessage {
+    StartRequest {
         tasks: TaskSelection::All,
     }
 )]
 #[case(
-    StartMessage {
+    StartRequest {
         tasks: TaskSelection::Group(PUEUE_DEFAULT_GROUP.into()),
     }
 )]
 #[case(
-    StartMessage {
+    StartRequest {
         tasks: TaskSelection::TaskIds(vec![0, 1, 2]),
     }
 )]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_start_tasks(#[case] start_message: StartMessage) -> Result<()> {
+async fn test_start_tasks(#[case] start_message: StartRequest) -> Result<()> {
     let daemon = daemon().await?;
     let shared = &daemon.settings.shared;
 

--- a/pueue/tests/daemon/integration/stashed.rs
+++ b/pueue/tests/daemon/integration/stashed.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Local, TimeDelta};
-use pueue_lib::{network::message::*, state::GroupStatus, task::*};
+use pueue_lib::{GroupStatus, network::message::*, task::*};
 use rstest::rstest;
 
 use crate::{helper::*, internal_prelude::*};
@@ -31,7 +31,7 @@ async fn test_enqueued_tasks(#[case] enqueue_at: Option<DateTime<Local>>) -> Res
     }
 
     // Manually enqueue the task
-    let enqueue_message = EnqueueMessage {
+    let enqueue_message = EnqueueRequest {
         tasks: TaskSelection::TaskIds(vec![0]),
         enqueue_at: None,
     };
@@ -91,7 +91,7 @@ async fn test_stash_queued_task() -> Result<()> {
     // Stash the task
     send_request(
         shared,
-        StashMessage {
+        StashRequest {
             tasks: TaskSelection::TaskIds(vec![0]),
             enqueue_at: None,
         },

--- a/pueue/tests/daemon/integration/worker_environment_variables.rs
+++ b/pueue/tests/daemon/integration/worker_environment_variables.rs
@@ -1,4 +1,4 @@
-use pueue_lib::{network::message::TaskSelection, state::PUEUE_DEFAULT_GROUP, task::Task};
+use pueue_lib::{Task, network::message::TaskSelection, state::PUEUE_DEFAULT_GROUP};
 
 use crate::{helper::*, internal_prelude::*};
 

--- a/pueue/tests/daemon/state_backward_compatibility.rs
+++ b/pueue/tests/daemon/state_backward_compatibility.rs
@@ -1,10 +1,10 @@
 use std::{fs::File, io::prelude::*};
 
 use pueue::daemon::internal_state::state::InternalState;
-use pueue_lib::settings::Settings;
+use pueue_lib::Settings;
 use tempfile::TempDir;
 
-use crate::{helper::enable_logger, internal_prelude::*};
+use crate::internal_prelude::*;
 
 /// 4.0.0 introduced numerous breaking changes.
 /// From here on, we now aim to once again have full backward compatibility.
@@ -17,7 +17,6 @@ use crate::{helper::enable_logger, internal_prelude::*};
 /// This should be handled as well.
 #[test]
 fn test_restore_from_old_state() -> Result<()> {
-    enable_logger();
     better_panic::install();
     let old_state = include_str!("data/v4.0.0_state.json");
 

--- a/pueue/tests/helper/asserts.rs
+++ b/pueue/tests/helper/asserts.rs
@@ -22,7 +22,7 @@ pub fn assert_failure(message: Response) {
     assert_matches!(
         message,
         Response::Failure(_),
-        "Expected to get FailureMessage, got {message:?}",
+        "Expected to get FailureResponse, got {message:?}",
     );
 }
 
@@ -103,7 +103,7 @@ pub async fn assert_worker_envs(
     // Get the log output for the task.
     let response = send_request(
         shared,
-        LogRequestMessage {
+        LogRequest {
             tasks: TaskSelection::TaskIds(vec![task_id]),
             send_logs: true,
             lines: None,

--- a/pueue/tests/helper/daemon.rs
+++ b/pueue/tests/helper/daemon.rs
@@ -6,7 +6,7 @@ use super::*;
 
 /// Send the Shutdown message to the test daemon.
 pub async fn shutdown_daemon(shared: &Shared) -> Result<Response> {
-    let message = Shutdown::Graceful;
+    let message = ShutdownRequest::Graceful;
 
     send_request(shared, message)
         .await

--- a/pueue/tests/helper/factories/group.rs
+++ b/pueue/tests/helper/factories/group.rs
@@ -4,7 +4,7 @@ use crate::helper::*;
 
 /// Create a new group with a specific amount of slots.
 pub async fn add_group_with_slots(shared: &Shared, group_name: &str, slots: usize) -> Result<()> {
-    let add_message = GroupMessage::Add {
+    let add_message = GroupRequest::Add {
         name: group_name.to_string(),
         parallel_tasks: Some(slots),
     };

--- a/pueue/tests/helper/log.rs
+++ b/pueue/tests/helper/log.rs
@@ -20,7 +20,7 @@ pub fn decompress_log(bytes: Vec<u8>) -> Result<String> {
 /// Convenience function to get the log of a specific task.
 /// `lines: None` requests all log lines.
 pub async fn get_task_log(shared: &Shared, task_id: usize, lines: Option<usize>) -> Result<String> {
-    let message = LogRequestMessage {
+    let message = LogRequest {
         tasks: TaskSelection::TaskIds(vec![task_id]),
         send_logs: true,
         lines,

--- a/pueue/tests/helper/task.rs
+++ b/pueue/tests/helper/task.rs
@@ -9,10 +9,10 @@ use pueue_lib::{
 
 use crate::helper::*;
 
-/// Create a bare AddMessage for testing.
+/// Create a bare [AddRequest] for testing.
 /// This is just here to minimize boilerplate code.
-pub fn create_add_message<C: ToString>(shared: &Shared, command: C) -> AddMessage {
-    AddMessage {
+pub fn create_add_message<C: ToString>(shared: &Shared, command: C) -> AddRequest {
+    AddRequest {
         command: command.to_string(),
         path: shared.pueue_directory(),
         envs: HashMap::from_iter(vars()),
@@ -43,7 +43,7 @@ pub async fn create_stashed_task(
 
 /// Helper to either continue the daemon or start specific tasks
 pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Response> {
-    let message = StartMessage { tasks };
+    let message = StartRequest { tasks };
 
     send_request(shared, message)
         .await
@@ -52,7 +52,7 @@ pub async fn start_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Respon
 
 /// Helper to pause the default group of the daemon
 pub async fn pause_tasks(shared: &Shared, tasks: TaskSelection) -> Result<Response> {
-    let message = PauseMessage { tasks, wait: false };
+    let message = PauseRequest { tasks, wait: false };
 
     send_request(shared, message)
         .await

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -11,6 +11,7 @@ The concept of SemVer is applied to the daemon/client API, but not the library A
 ### Changed
 
 - Streamline all `Request` and `Response` variant names and struct names used in unit variant.
+- Prepare `Request::Stream` and `Response::Stream` to be compatible with multiple follow tasks in the scope of [#614](https://github.com/Nukesor/pueue/issues/614).
 
 ## [0.28.1] - 2025-02-17
 

--- a/pueue_lib/CHANGELOG.md
+++ b/pueue_lib/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres **somewhat** to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The concept of SemVer is applied to the daemon/client API, but not the library API itself.
 
+## [0.29. ] - unreleased
+
+### Changed
+
+- Streamline all `Request` and `Response` variant names and struct names used in unit variant.
+
 ## [0.28.1] - 2025-02-17
 
 ### Added

--- a/pueue_lib/src/network/message/request.rs
+++ b/pueue_lib/src/network/message/request.rs
@@ -275,9 +275,16 @@ pub enum ShutdownRequest {
 }
 impl_into_request!(ShutdownRequest, Request::DaemonShutdown);
 
+/// Request the live streaming of a set of running tasks.
+///
+/// **WARNING**:
+/// Even though this type currently accepts a TaskSelection, only
+/// `TaskSelection::TaskIds(vec![])` and `TaskSelection::TaskIds(vec![id])` are accepted.
+/// We already use this format in preparation for <https://github.com/Nukesor/pueue/issues/614>
+/// That way we can stay forwards compatible without having to break the API.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub struct StreamRequest {
-    pub task_id: Option<usize>,
+    pub tasks: TaskSelection,
     pub lines: Option<usize>,
 }
 impl_into_request!(StreamRequest, Request::Stream);

--- a/pueue_lib/src/network/message/request.rs
+++ b/pueue_lib/src/network/message/request.rs
@@ -7,8 +7,8 @@ use strum::{Display, EnumString, VariantNames};
 use crate::network::message::EditableTask;
 
 /// Macro to simplify creating [From] implementations for each variant-contained
-/// Request; e.g. `impl_into_request!(AddMessage, Request::Add)` to make it possible
-/// to use `AddMessage { }.into()` and get a `Message::Add()` value.
+/// Request; e.g. `impl_into_request!(AddRequest, Request::Add)` to make it possible
+/// to use `AddRequest::into()` and get a [Request::Add] value.
 macro_rules! impl_into_request {
     ($inner:ident, $variant:expr) => {
         impl From<$inner> for Request {
@@ -24,27 +24,27 @@ macro_rules! impl_into_request {
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub enum Request {
     /// Add a new task to the daemon.
-    Add(AddMessage),
-    /// Remove a non-running/paused task.
+    Add(AddRequest),
+    /// Remove non-running/paused tasks.
     Remove(Vec<usize>),
     /// Switch two enqueued/stashed tasks.
-    Switch(SwitchMessage),
+    Switch(SwitchRequest),
     /// Stash a task or schedule it for enqueue.
-    Stash(StashMessage),
+    Stash(StashRequest),
     /// Take a stashed task and enqueue it.
-    Enqueue(EnqueueMessage),
+    Enqueue(EnqueueRequest),
 
     /// Start/unpause a [`TaskSelection`].
-    Start(StartMessage),
+    Start(StartRequest),
     /// Restart a set of finished or failed task.
-    Restart(RestartMessage),
+    Restart(RestartRequest),
     /// Pause a [`TaskSelection`].
-    Pause(PauseMessage),
+    Pause(PauseRequest),
     /// Kill a [`TaskSelection`].
-    Kill(KillMessage),
+    Kill(KillRequest),
 
     /// Used to send some input to a process's stdin
-    Send(SendMessage),
+    Send(SendRequest),
 
     /// The first part of the three-step protocol to edit a task.
     /// This one requests an edit from the daemon.
@@ -53,30 +53,30 @@ pub enum Request {
     /// The daemon will go ahead and restore the task's old state.
     EditRestore(Vec<usize>),
     /// The client sends the edited details to the daemon.
-    Edit(Vec<EditableTask>),
+    EditedTasks(Vec<EditableTask>),
 
     /// Un/-set environment variables for specific tasks.
-    Env(EnvMessage),
+    Env(EnvRequest),
 
-    Group(GroupMessage),
+    Group(GroupRequest),
 
     /// Used to set parallel tasks for a specific group
-    Parallel(ParallelMessage),
+    Parallel(ParallelRequest),
 
     /// Request the daemon's state
     Status,
     /// Request logs of a set of tasks.
-    Log(LogRequestMessage),
+    Log(LogRequest),
 
     /// The client requests a continuous stream of a task's log.
-    StreamRequest(StreamRequestMessage),
+    Stream(StreamRequest),
 
     /// Reset the daemon
-    Reset(ResetMessage),
+    Reset(ResetRequest),
     /// Tell the daemon to clean finished tasks
-    Clean(CleanMessage),
+    Clean(CleanRequest),
     /// Initiate shutdown on the daemon.
-    DaemonShutdown(Shutdown),
+    DaemonShutdown(ShutdownRequest),
 }
 
 /// This enum is used to express a selection of tasks.
@@ -90,7 +90,7 @@ pub enum TaskSelection {
 }
 
 #[derive(PartialEq, Eq, Clone, Default, Deserialize, Serialize)]
-pub struct AddMessage {
+pub struct AddRequest {
     pub command: String,
     pub path: PathBuf,
     pub envs: HashMap<String, String>,
@@ -103,12 +103,12 @@ pub struct AddMessage {
     pub label: Option<String>,
 }
 
-/// We use a custom `Debug` implementation for [AddMessage], as the `envs` field just has
+/// We use a custom `Debug` implementation for [AddRequest], as the `envs` field just has
 /// too much info in it and makes the log output much too verbose.
 ///
 /// Furthermore, there might be secrets in the environment, resulting in a possible leak
 /// if users copy-paste their log output for debugging.
-impl std::fmt::Debug for AddMessage {
+impl std::fmt::Debug for AddRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Task")
             .field("command", &self.command)
@@ -123,44 +123,44 @@ impl std::fmt::Debug for AddMessage {
             .finish()
     }
 }
-impl_into_request!(AddMessage, Request::Add);
+impl_into_request!(AddRequest, Request::Add);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct SwitchMessage {
+pub struct SwitchRequest {
     pub task_id_1: usize,
     pub task_id_2: usize,
 }
-impl_into_request!(SwitchMessage, Request::Switch);
+impl_into_request!(SwitchRequest, Request::Switch);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct StashMessage {
+pub struct StashRequest {
     pub tasks: TaskSelection,
     pub enqueue_at: Option<DateTime<Local>>,
 }
-impl_into_request!(StashMessage, Request::Stash);
+impl_into_request!(StashRequest, Request::Stash);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct EnqueueMessage {
+pub struct EnqueueRequest {
     pub tasks: TaskSelection,
     pub enqueue_at: Option<DateTime<Local>>,
 }
-impl_into_request!(EnqueueMessage, Request::Enqueue);
+impl_into_request!(EnqueueRequest, Request::Enqueue);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct StartMessage {
+pub struct StartRequest {
     pub tasks: TaskSelection,
 }
-impl_into_request!(StartMessage, Request::Start);
+impl_into_request!(StartRequest, Request::Start);
 
 /// The messages used to restart tasks.
 /// It's possible to update the command and paths when restarting tasks.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct RestartMessage {
+pub struct RestartRequest {
     pub tasks: Vec<TaskToRestart>,
     pub start_immediately: bool,
     pub stashed: bool,
 }
-impl_into_request!(RestartMessage, Request::Restart);
+impl_into_request!(RestartRequest, Request::Restart);
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaskToRestart {
@@ -176,11 +176,11 @@ pub struct TaskToRestart {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct PauseMessage {
+pub struct PauseRequest {
     pub tasks: TaskSelection,
     pub wait: bool,
 }
-impl_into_request!(PauseMessage, Request::Pause);
+impl_into_request!(PauseRequest, Request::Pause);
 
 /// This is a small custom Enum for all currently supported unix signals.
 /// Supporting all unix signals would be a mess, since there is a LOT of them.
@@ -205,21 +205,21 @@ pub enum Signal {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct KillMessage {
+pub struct KillRequest {
     pub tasks: TaskSelection,
     pub signal: Option<Signal>,
 }
-impl_into_request!(KillMessage, Request::Kill);
+impl_into_request!(KillRequest, Request::Kill);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct SendMessage {
+pub struct SendRequest {
     pub task_id: usize,
     pub input: String,
 }
-impl_into_request!(SendMessage, Request::Send);
+impl_into_request!(SendRequest, Request::Send);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub enum EnvMessage {
+pub enum EnvRequest {
     Set {
         task_id: usize,
         key: String,
@@ -230,10 +230,10 @@ pub enum EnvMessage {
         key: String,
     },
 }
-impl_into_request!(EnvMessage, Request::Env);
+impl_into_request!(EnvRequest, Request::Env);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub enum GroupMessage {
+pub enum GroupRequest {
     Add {
         name: String,
         parallel_tasks: Option<usize>,
@@ -241,7 +241,7 @@ pub enum GroupMessage {
     Remove(String),
     List,
 }
-impl_into_request!(GroupMessage, Request::Group);
+impl_into_request!(GroupRequest, Request::Group);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub enum ResetTarget {
@@ -252,35 +252,35 @@ pub enum ResetTarget {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct ResetMessage {
+pub struct ResetRequest {
     pub target: ResetTarget,
 }
-impl_into_request!(ResetMessage, Request::Reset);
+impl_into_request!(ResetRequest, Request::Reset);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct CleanMessage {
+pub struct CleanRequest {
     pub successful_only: bool,
 
     pub group: Option<String>,
 }
-impl_into_request!(CleanMessage, Request::Clean);
+impl_into_request!(CleanRequest, Request::Clean);
 
 /// Determines which type of shutdown we're dealing with.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub enum Shutdown {
+pub enum ShutdownRequest {
     /// Emergency is most likely a system unix signal or a CTRL+C in a terminal.
     Emergency,
     /// Graceful is user initiated and expected.
     Graceful,
 }
-impl_into_request!(Shutdown, Request::DaemonShutdown);
+impl_into_request!(ShutdownRequest, Request::DaemonShutdown);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct StreamRequestMessage {
+pub struct StreamRequest {
     pub task_id: Option<usize>,
     pub lines: Option<usize>,
 }
-impl_into_request!(StreamRequestMessage, Request::StreamRequest);
+impl_into_request!(StreamRequest, Request::Stream);
 
 /// Request logs for specific tasks.
 ///
@@ -288,16 +288,16 @@ impl_into_request!(StreamRequestMessage, Request::StreamRequest);
 /// `send_logs` Determines whether logs should be sent at all.
 /// `lines` Determines whether only a few lines of log should be returned.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct LogRequestMessage {
+pub struct LogRequest {
     pub tasks: TaskSelection,
     pub send_logs: bool,
     pub lines: Option<usize>,
 }
-impl_into_request!(LogRequestMessage, Request::Log);
+impl_into_request!(LogRequest, Request::Log);
 
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct ParallelMessage {
+pub struct ParallelRequest {
     pub parallel_tasks: usize,
     pub group: String,
 }
-impl_into_request!(ParallelMessage, Request::Parallel);
+impl_into_request!(ParallelRequest, Request::Parallel);

--- a/pueue_lib/src/network/message/response.rs
+++ b/pueue_lib/src/network/message/response.rs
@@ -34,8 +34,8 @@ pub fn create_failure_response<T: ToString>(text: T) -> Response {
 }
 
 /// Macro to simplify creating [From] implementations for each variant-contained
-/// Response; e.g. `impl_into_response!(AddMessage, Response::Add)` to make it possible
-/// to use `AddMessage { }.into()` and get a `Message::Add()` value.
+/// Response; e.g. `impl_into_response!(AddRequest, Response::Add)` to implement
+/// use `AddedTaskResponse::into()` and get a [Response::AddedTask] value.
 macro_rules! impl_into_response {
     ($inner:ty, $variant:expr) => {
         impl From<$inner> for Response {
@@ -50,7 +50,7 @@ macro_rules! impl_into_response {
 /// Everything that's send by the client is represented using by this enum.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 pub enum Response {
-    AddedTask(AddedTaskMessage),
+    AddedTask(AddedTaskResponse),
 
     /// The daemon locked the tasks and responds with the tasks' details.
     Edit(Vec<EditableTask>),
@@ -59,9 +59,9 @@ pub enum Response {
 
     /// The log returned from the daemon for a bunch of [`Task`]s
     /// This is the response to [`super::Request::Log`]
-    Log(BTreeMap<usize, TaskLogMessage>),
+    Log(BTreeMap<usize, TaskLogResponse>),
 
-    Group(GroupResponseMessage),
+    Group(GroupResponse),
 
     /// The next chunk of output, that's send to the client.
     Stream(String),
@@ -81,28 +81,28 @@ impl Response {
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Deserialize, Serialize)]
-pub struct AddedTaskMessage {
+pub struct AddedTaskResponse {
     pub task_id: usize,
     pub enqueue_at: Option<DateTime<Local>>,
     pub group_is_paused: bool,
 }
-impl_into_response!(AddedTaskMessage, Response::AddedTask);
+impl_into_response!(AddedTaskResponse, Response::AddedTask);
 
 /// Helper struct for sending tasks and their log output to the client.
 #[derive(PartialEq, Eq, Clone, Deserialize, Serialize)]
-pub struct TaskLogMessage {
+pub struct TaskLogResponse {
     pub task: Task,
     /// Indicates whether the log output has been truncated or not.
     pub output_complete: bool,
     pub output: Option<Vec<u8>>,
 }
-impl_into_response!(BTreeMap<usize, TaskLogMessage>, Response::Log);
+impl_into_response!(BTreeMap<usize, TaskLogResponse>, Response::Log);
 
-/// We use a custom `Debug` implementation for [TaskLogMessage], as the `output` field
+/// We use a custom `Debug` implementation for [TaskLogResponse], as the `output` field
 /// has too much info in it and renders log output unreadable.
-impl std::fmt::Debug for TaskLogMessage {
+impl std::fmt::Debug for TaskLogResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TaskLogMessage")
+        f.debug_struct("TaskLogResponse")
             .field("task", &self.task)
             .field("output_complete", &self.output_complete)
             .field("output", &"hidden")
@@ -112,7 +112,7 @@ impl std::fmt::Debug for TaskLogMessage {
 
 /// Group info send by the daemon.
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
-pub struct GroupResponseMessage {
+pub struct GroupResponse {
     pub groups: BTreeMap<String, Group>,
 }
-impl_into_response!(GroupResponseMessage, Response::Group);
+impl_into_response!(GroupResponse, Response::Group);

--- a/pueue_lib/src/network/message/response.rs
+++ b/pueue_lib/src/network/message/response.rs
@@ -64,7 +64,7 @@ pub enum Response {
     Group(GroupResponse),
 
     /// The next chunk of output, that's send to the client.
-    Stream(String),
+    Stream(StreamResponse),
 
     Success(String),
     Failure(String),
@@ -116,3 +116,12 @@ pub struct GroupResponse {
     pub groups: BTreeMap<String, Group>,
 }
 impl_into_response!(GroupResponse, Response::Group);
+
+/// Live log output returned by the daemon.
+///
+/// The logs are ordered by task id.
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+pub struct StreamResponse {
+    pub logs: BTreeMap<usize, String>,
+}
+impl_into_response!(StreamResponse, Response::Stream);

--- a/pueue_lib/src/network/protocol.rs
+++ b/pueue_lib/src/network/protocol.rs
@@ -150,7 +150,7 @@ pub async fn receive_response(stream: &mut GenericStream) -> Result<Response, Er
     receive_message::<Response>(stream).await
 }
 
-/// Convenience wrapper that receives a message and converts it into a Message.
+/// Convenience wrapper that receives a message and converts it into `T`.
 pub async fn receive_message<T: DeserializeOwned + std::fmt::Debug>(
     stream: &mut GenericStream,
 ) -> Result<T, Error> {
@@ -188,7 +188,7 @@ mod test {
 
     use super::*;
     use crate::network::{
-        message::request::{Request, SendMessage},
+        message::request::{Request, SendRequest},
         socket::Stream as PueueStream,
     };
 
@@ -209,7 +209,7 @@ mod test {
 
         // The message that should be sent
         let payload = "a".repeat(100_000);
-        let request: Request = SendMessage {
+        let request: Request = SendRequest {
             task_id: 0,
             input: payload,
         }

--- a/pueue_lib/tests/settings_backward_compatibility.rs
+++ b/pueue_lib/tests/settings_backward_compatibility.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use color_eyre::{Result, eyre::WrapErr};
-use pueue_lib::settings::Settings;
+use pueue_lib::Settings;
 
 /// From 0.15.0 on, we aim to have full backward compatibility.
 /// For this reason, an old (slightly modified) v0.15.0 serialized settings file


### PR DESCRIPTION
Streamlines all message names and adjusts the `Request::Stream` and `Response::Stream` for multiple tasks.

See #614