### PR TITLE
Fix extraneous double quotes in Windows service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[4.0.1\] - unreleased
+
+### Fixed
+
+- Fix extraneous double quotes being added to --config and --profile flags in Windows service install. #630
+
 ## \[4.0.0\] - 2025-03-09
 
 This release aims to further improve Pueue and to rectify some old design decisions.

--- a/pueue/src/daemon/service.rs
+++ b/pueue/src/daemon/service.rs
@@ -125,11 +125,11 @@ pub fn install_service(config_path: Option<PathBuf>, profile: Option<String>) ->
     if let Some(config_path) = config_path {
         args.extend([
             "--config".into(),
-            format!(r#""{}""#, config_path.to_string_lossy()).into(),
+            config_path.to_string_lossy().to_string().into(),
         ]);
     }
     if let Some(profile) = profile {
-        args.extend(["--profile".into(), format!(r#""{profile}""#).into()]);
+        args.extend(["--profile".into(), profile.into()]);
     }
 
     args.extend(["service".into(), "run".into()]);


### PR DESCRIPTION
When running `pueued -c "space path" service install`, the service cli got expanded to `pueued --config "\"space path\"" service run`, which is definitely not correct. Turns out that the `windows_service` crate already handled the case of spaces in the arg for us. Nice. This PR fixes this bug. Now it expands to `pueued --config "space path" service run` or `pueued --config no_space_path service run`

(I don't know the next version for the changelog, but I assumed it's 4.0.1. Please let me know if the changelog entry needs to be fixed)

TODO:
- [ ] double check if this area is correct: (I think it is, but gotta make sure) https://github.com/Nukesor/pueue/blob/33290e674212593e6306ca481e868be6f0a19404/pueue/src/daemon/service.rs#L634

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [x] (If applicable) I checked if anything in the wiki needs to be changed.
