### PR TITLE
Fix flags causing service to not start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Fix extraneous double quotes being added to --config and --profile flags in Windows service install. #630
+- Fix --config/--path flags causing Windows service start to fail. #631
 
 ## \[4.0.0\] - 2025-03-09
 

--- a/pueue/src/daemon/cli.rs
+++ b/pueue/src/daemon/cli.rs
@@ -37,7 +37,7 @@ pub struct CliArguments {
 #[cfg(target_os = "windows")]
 #[derive(Copy, Clone, Debug, Subcommand)]
 pub enum ServiceSubcommandEntry {
-    /// Manage the Windows Service.
+    /// Manage the Windows Service. Note: service commands must be run as admin.
     #[command(subcommand)]
     Service(ServiceSubcommand),
 }
@@ -53,7 +53,7 @@ pub enum ServiceSubcommand {
     /// Once installed, you must not move the binary, otherwise the Windows
     /// service will not be able to find it. If you wish to move the binary,
     /// first uninstall the service, move the binary, then install the service
-    /// again.
+    /// again. This command only installs the service; it does not start it for you.
     Install,
     /// Uninstall the service.
     Uninstall,


### PR DESCRIPTION
This is a follow up to #630 . After checking, flags indeed were causing the service start up fail. I have now tested them properly and fixed the issue.

The issue was that the rust binary expects the first arg to be the current exe, e.g. `"C:\my-current-exe.exe"`, but I was not giving it.

This full expanded command now works (including profile too if specified).
`R:\path\to\pueued.exe --config C:\path\to\pueue.yml service run`

I did a small refactor in the process, cause why not

## Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [x] (If applicable) I added tests for this feature or adjusted existing tests.
- [x] (If applicable) I checked if anything in the wiki needs to be changed.
