### PR TITLE
Typo fix: "pueue groups" -> "pueue group"

### DIFF
--- a/pueue/src/client/cli.rs
+++ b/pueue/src/client/cli.rs
@@ -64,7 +64,7 @@ pub enum SubCommand {
         /// All groups run in parallel and you can specify the amount of parallel tasks for each
         /// group. If no group is specified, the default group will be used.
         ///
-        /// Create groups via the `pueue groups` subcommand
+        /// Create groups via the `pueue group` subcommand
         #[arg(short, long)]
         group: Option<String>,
 

--- a/pueue/src/daemon/network/message_handler/group.rs
+++ b/pueue/src/daemon/network/message_handler/group.rs
@@ -13,7 +13,7 @@ use crate::{
     ok_or_save_state_failure,
 };
 
-/// Invoked on `pueue groups`.
+/// Invoked on `pueue group`.
 /// Manage groups.
 /// - Show groups
 /// - Add group


### PR DESCRIPTION
Only a minor fix of typo "pueue groups" -> "pueue group"

## Checklist

Please make sure the PR adheres to this project's standards:

- [ ] I included a new entry to the `CHANGELOG.md`.
- [ ] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
