### PR TITLE
feat(status): display duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[4.0.5\] - unreleased
+## \[4.1.0\] - unreleased
+### Added
+-`pueue status` has now Duration column. #650
 
 ### Fix
 

--- a/pueue/src/client/commands/log/mod.rs
+++ b/pueue/src/client/commands/log/mod.rs
@@ -8,7 +8,7 @@ use pueue_lib::{
 };
 
 use super::{OutputStyle, handle_response, selection_from_params};
-use crate::internal_prelude::*;
+use crate::{format::humanize_duration, internal_prelude::*};
 
 mod json;
 mod local;
@@ -204,9 +204,9 @@ fn print_task_info(task: &Task, style: &OutputStyle) {
         ]);
     }
 
-    let (start, end) = task.start_and_end();
+    let (start, end, duration) = task.start_end_duration();
 
-    // Start and end time
+    // Start, end time and duration
     if let Some(start) = start {
         table.add_row(vec![
             style.styled_cell("Start:", None, Some(ComfyAttribute::Bold)),
@@ -217,6 +217,13 @@ fn print_task_info(task: &Task, style: &OutputStyle) {
         table.add_row(vec![
             style.styled_cell("End:", None, Some(ComfyAttribute::Bold)),
             Cell::new(end.to_rfc2822()),
+        ]);
+    }
+
+    if let Some(duration) = duration {
+        table.add_row(vec![
+            style.styled_cell("Duration:", None, Some(ComfyAttribute::Bold)),
+            Cell::new(humanize_duration(duration)),
         ]);
     }
 

--- a/pueue/src/client/commands/state/mod.rs
+++ b/pueue/src/client/commands/state/mod.rs
@@ -10,6 +10,7 @@ use pueue_lib::{
 
 use crate::{
     client::{commands::get_state, display_helper::get_group_headline, style::OutputStyle},
+    format::humanize_duration,
     internal_prelude::*,
 };
 
@@ -227,13 +228,13 @@ fn sort_tasks_by_group(tasks: Vec<Task>) -> BTreeMap<String, Vec<Task>> {
 ///
 /// If the task doesn't have a start and/or end yet, an empty string will be returned
 /// for the respective field.
-fn formatted_start_end(task: &Task, settings: &Settings) -> (String, String) {
-    let (start, end) = task.start_and_end();
+fn formatted_start_end_elapsed(task: &Task, settings: &Settings) -> (String, String, String) {
+    let (start, end, duration) = task.start_end_duration();
 
     // If the task didn't start yet, just return two empty strings.
     let start = match start {
         Some(start) => start,
-        None => return ("".into(), "".into()),
+        None => return ("".into(), "".into(), "".into()),
     };
 
     // If the task started today, just show the time.
@@ -241,29 +242,30 @@ fn formatted_start_end(task: &Task, settings: &Settings) -> (String, String) {
     let started_today = start >= start_of_today();
     let formatted_start = if started_today {
         start
-            .format(&settings.client.status_time_format)
+            .format(&settings.client.get_status_time_format())
             .to_string()
     } else {
         start
-            .format(&settings.client.status_datetime_format)
+            .format(&settings.client.get_status_datetime_format())
             .to_string()
     };
 
     // If the task didn't finish yet, only return the formatted start.
-    let end = match end {
-        Some(end) => end,
-        None => return (formatted_start, "".into()),
+    let (end, duration) = match (end, duration) {
+        (Some(end), Some(duration)) => (end, duration),
+        _ => return (formatted_start, "".into(), "".into()),
     };
 
     // If the task ended today we only show the time.
     // In all other circumstances, we show the full date.
     let finished_today = end >= start_of_today();
     let formatted_end = if finished_today {
-        end.format(&settings.client.status_time_format).to_string()
+        end.format(&settings.client.get_status_time_format()).to_string()
     } else {
-        end.format(&settings.client.status_datetime_format)
+        end.format(&settings.client.get_status_datetime_format())
             .to_string()
     };
+    let formatted_duration = humanize_duration(duration);
 
-    (formatted_start, formatted_end)
+    (formatted_start, formatted_end, formatted_duration)
 }

--- a/pueue/src/client/commands/state/query/filters.rs
+++ b/pueue/src/client/commands/state/query/filters.rs
@@ -115,14 +115,14 @@ pub fn datetime(section: Pair<'_, Rule>, query_result: &mut QueryResult) -> Resu
                 enqueue_at
             }
             Rule::column_start => {
-                let (start, _) = task.start_and_end();
+                let (start, _, _) = task.start_end_duration();
                 let Some(start) = start else {
                     return false;
                 };
                 start
             }
             Rule::column_end => {
-                let (_, end) = task.start_and_end();
+                let (_, end, _) = task.start_end_duration();
                 let Some(end) = end else {
                     return false;
                 };

--- a/pueue/src/client/commands/state/query/syntax.pest
+++ b/pueue/src/client/commands/state/query/syntax.pest
@@ -19,9 +19,10 @@ column_enqueue_at = { ^"enqueue_at" }
 column_dependencies = { ^"dependencies" }
 column_start = { ^"start" }
 column_end = { ^"end" }
+column_duration = { ^"duration" }
 
 // Either one of all column and a comma-separated list of columns.
-column = { column_id | column_status | column_command | column_label | column_path | column_enqueue_at | column_dependencies | column_start | column_end }
+column = { column_id | column_status | column_command | column_label | column_path | column_enqueue_at | column_dependencies | column_start | column_end | column_duration }
 multiple_columns = { column ~ (COMMA ~ column )* }
 
 // ----- Column visibility -----
@@ -55,13 +56,13 @@ datetime = { ASCII_DIGIT{4} ~ "-" ~ ASCII_DIGIT{2} ~ "-" ~ ASCII_DIGIT{2}  ~ ASC
 date = { ASCII_DIGIT{4} ~ "-" ~ ASCII_DIGIT{2} ~ "-" ~ ASCII_DIGIT{2} }
 time = { ASCII_DIGIT{2} ~ ":" ~ ASCII_DIGIT{2} ~ (":" ~ ASCII_DIGIT{2})? }
 
-datetime_filter = { (column_start | column_end | column_enqueue_at) ~ (eq | neq | lt | gt) ~ (datetime | date | time) }
+datetime_filter = { (column_start | column_end | column_duration | column_enqueue_at) ~ (eq | neq | lt | gt) ~ (datetime | date | time) }
 
 // ----- Ordering -----
 order_by = { ^"order_by" }
 ascending = { ^"asc" }
 descending = { ^"desc" }
-order_columns = { column_id | column_status | column_command | column_label | column_path | column_start | column_end }
+order_columns = { column_id | column_status | column_command | column_label | column_path | column_start | column_end | column_duration }
 order_by_condition = { order_by ~ column ~ (ascending | descending)? }
 
 // ----- Limit -----

--- a/pueue/src/client/commands/state/table_builder.rs
+++ b/pueue/src/client/commands/state/table_builder.rs
@@ -6,7 +6,7 @@ use pueue_lib::{
     task::{Task, TaskResult, TaskStatus},
 };
 
-use super::{OutputStyle, formatted_start_end, query::Rule, start_of_today};
+use super::{OutputStyle, formatted_start_end_elapsed, query::Rule, start_of_today};
 
 /// This builder is responsible for determining which table columns should be displayed and
 /// building a full [comfy_table] from a list of given [Task]s.
@@ -182,6 +182,9 @@ impl<'a> TableBuilder<'a> {
         if self.end {
             header.push(Cell::new("End"));
         }
+        if self.has_duration_column() {
+            header.push(Cell::new("Duration"));
+        }
 
         Row::from(header)
     }
@@ -192,7 +195,7 @@ impl<'a> TableBuilder<'a> {
         for task in tasks.iter() {
             let mut row = Row::new();
             // Users can set a max height per row.
-            if let Some(height) = self.settings.client.max_status_lines {
+            if let Some(height) = self.settings.client.get_status_max_lines() {
                 row.max_height(height);
             }
 
@@ -234,10 +237,12 @@ impl<'a> TableBuilder<'a> {
                     // Only show the date if the task is not supposed to be enqueued today.
                     let enqueue_today =
                         enqueue_at <= start_of_today() + TimeDelta::try_days(1).unwrap();
+                    let time_format = self.settings.client.get_status_time_format();
+                    let datetime_format = self.settings.client.get_status_datetime_format();
                     let formatted_enqueue_at = if enqueue_today {
-                        enqueue_at.format(&self.settings.client.status_time_format)
+                        enqueue_at.format(&time_format)
                     } else {
-                        enqueue_at.format(&self.settings.client.status_datetime_format)
+                        enqueue_at.format(&datetime_format)
                     };
                     row.add_cell(Cell::new(formatted_enqueue_at));
                 } else {
@@ -261,7 +266,7 @@ impl<'a> TableBuilder<'a> {
 
             // Add command and path.
             if self.command {
-                if self.settings.client.show_expanded_aliases {
+                if self.settings.client.get_show_expanded_aliases() {
                     row.add_cell(Cell::new(&task.command));
                 } else {
                     row.add_cell(Cell::new(&task.original_command));
@@ -273,7 +278,7 @@ impl<'a> TableBuilder<'a> {
             }
 
             // Add start and end info
-            let (start, end) = formatted_start_end(task, self.settings);
+            let (start, end, duration) = formatted_start_end_elapsed(task, self.settings);
             if self.start {
                 row.add_cell(Cell::new(start));
             }
@@ -281,9 +286,22 @@ impl<'a> TableBuilder<'a> {
                 row.add_cell(Cell::new(end));
             }
 
+            if self.has_duration_column() {
+                row.add_cell(Cell::new(duration));
+            }
+
             rows.push(row);
         }
 
         rows
+    }
+
+    fn has_duration_column(&self) -> bool {
+        self.settings
+            .client
+            .status
+            .additional_columns
+            .iter()
+            .any(|x| x == "Duration")
     }
 }

--- a/pueue/src/daemon/callbacks.rs
+++ b/pueue/src/daemon/callbacks.rs
@@ -90,9 +90,15 @@ pub fn build_callback_command(
         time.map(|time| time.timestamp().to_string())
             .unwrap_or_default()
     };
-    let (start, end) = task.start_and_end();
+    let (start, end, duration) = task.start_end_duration();
     parameters.insert("start", print_time(start));
     parameters.insert("end", print_time(end));
+    parameters.insert(
+        "duration",
+        duration
+            .map(|duration| duration.to_string())
+            .unwrap_or_default(),
+    );
 
     // Read the last lines of the process' output and make it available.
     if let Ok(output) = read_last_log_file_lines(

--- a/pueue/src/daemon/internal_state/state.rs
+++ b/pueue/src/daemon/internal_state/state.rs
@@ -334,9 +334,12 @@ impl InternalState {
                     task.status,
                     TaskResult::Killed
                 );
+                let end = Local::now();
+                let duration = end - start;
                 task.status = TaskStatus::Done {
                     start,
-                    end: Local::now(),
+                    end,
+                    duration,
                     enqueued_at,
                     result: TaskResult::Killed,
                 };

--- a/pueue/src/daemon/network/message_handler/mod.rs
+++ b/pueue/src/daemon/network/message_handler/mod.rs
@@ -168,6 +168,7 @@ mod fixtures {
         let enqueued_at = Local::now() - Duration::minutes(5);
         let start = Local::now() - Duration::minutes(4);
         let end = Local::now() - Duration::minutes(1);
+        let duration = end - start;
 
         let status = match status {
             StubStatus::Stashed { enqueue_at } => TaskStatus::Stashed { enqueue_at },
@@ -178,6 +179,7 @@ mod fixtures {
                 enqueued_at,
                 start,
                 end,
+                duration,
                 result,
             },
         };

--- a/pueue/src/daemon/process_handler/finish.rs
+++ b/pueue/src/daemon/process_handler/finish.rs
@@ -48,10 +48,13 @@ pub fn handle_finished_tasks(settings: &Settings, state: &mut LockedState) {
             let task = {
                 let task = state.tasks_mut().get_mut(task_id).unwrap();
 
+                let end = Local::now();
+                let duration = end - start;
                 task.status = TaskStatus::Done {
                     enqueued_at,
                     start,
-                    end: Local::now(),
+                    end,
+                    duration,
                     result: TaskResult::Errored,
                 };
 
@@ -102,10 +105,13 @@ pub fn handle_finished_tasks(settings: &Settings, state: &mut LockedState) {
                 .get_mut(task_id)
                 .expect("Task was removed before child process has finished!");
 
+            let end = Local::now();
+            let duration = end - start;
             task.status = TaskStatus::Done {
                 enqueued_at,
                 start,
-                end: Local::now(),
+                end,
+                duration,
                 result: result.clone(),
             };
 

--- a/pueue/src/daemon/process_handler/spawn.rs
+++ b/pueue/src/daemon/process_handler/spawn.rs
@@ -212,10 +212,14 @@ pub fn spawn_process(settings: &Settings, state: &mut LockedState, task_id: usiz
             // Update all necessary fields on the task.
             let task = {
                 let task = state.tasks_mut().get_mut(&task_id).unwrap();
+                let start = Local::now();
+                let end = Local::now();
+                let duration = end - start;
                 task.status = TaskStatus::Done {
                     enqueued_at,
-                    start: Local::now(),
-                    end: Local::now(),
+                    start,
+                    end,
+                    duration,
                     result: TaskResult::FailedToSpawn(error_msg),
                 };
                 task.clone()

--- a/pueue/src/daemon/task_handler.rs
+++ b/pueue/src/daemon/task_handler.rs
@@ -198,10 +198,14 @@ fn check_failed_dependencies(settings: &Settings, state: &mut LockedState) {
                 continue;
             };
 
+            let start = Local::now();
+            let end = Local::now();
+            let duration = end - start;
             task.status = TaskStatus::Done {
                 enqueued_at,
-                start: Local::now(),
-                end: Local::now(),
+                start,
+                end,
+                duration,
                 result: TaskResult::DependencyFailed,
             };
             task.clone()

--- a/pueue/src/format.rs
+++ b/pueue/src/format.rs
@@ -1,13 +1,88 @@
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, TimeDelta};
 
 use pueue_lib::settings::Settings;
 
 // If the enqueue at time is today, only show the time. Otherwise, include the date.
 pub fn format_datetime(settings: &Settings, enqueue_at: &DateTime<Local>) -> String {
     let format_string = if enqueue_at.date_naive() == Local::now().date_naive() {
-        &settings.client.status_time_format
+        &settings.client.get_status_time_format()
     } else {
-        &settings.client.status_datetime_format
+        &settings.client.get_status_datetime_format()
     };
     enqueue_at.format(format_string).to_string()
+}
+
+pub fn humanize_duration(duration: TimeDelta) -> String {
+    let days = duration.num_days();
+    let leftover = duration - TimeDelta::days(days);
+
+    let hours = leftover.num_hours();
+    let leftover = leftover - TimeDelta::hours(hours);
+
+    let minutes = leftover.num_minutes();
+    let leftover = leftover - TimeDelta::minutes(minutes);
+
+    let seconds = leftover.num_seconds();
+    let leftover = leftover - TimeDelta::seconds(seconds);
+
+    let millis = leftover.num_milliseconds();
+
+    let mut parts = Vec::new();
+    if days > 0 {
+        parts.push(format!("{days}day"));
+    }
+    if hours > 0 {
+        parts.push(format!("{hours}hr"));
+    }
+    if minutes > 0 {
+        parts.push(format!("{minutes}min"));
+    }
+    if seconds > 0 {
+        parts.push(format!("{seconds}sec"));
+    }
+    if days == 0 && hours == 0 && minutes == 0 && seconds < 3 && millis > 0 {
+        parts.push(format!("{millis}ms"));
+    }
+
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod test {
+    use super::humanize_duration;
+    use chrono::TimeDelta;
+
+    macro_rules! assert_eq_seconds {
+        ($seconds:expr, $str: expr) => {
+            assert_eq!(
+                humanize_duration(TimeDelta::new($seconds, 0).unwrap()),
+                $str.to_owned()
+            );
+        };
+    }
+
+    macro_rules! assert_eq_millis {
+        ($millis:expr, $str: expr) => {
+            assert_eq!(
+                humanize_duration(TimeDelta::try_milliseconds($millis).unwrap()),
+                $str.to_owned()
+            );
+        };
+    }
+
+    #[test]
+    fn duration() {
+        assert_eq_millis!(500, "500ms");
+        assert_eq_millis!(1500, "1sec 500ms");
+        assert_eq_millis!(2500, "2sec 500ms");
+        assert_eq_millis!(3500, "3sec");
+        assert_eq_millis!(1000 *60 + 500, "1min");
+
+        assert_eq_seconds!(1, "1sec");
+        assert_eq_seconds!(90, "1min 30sec");
+        assert_eq_seconds!(1 * 3600, "1hr");
+        assert_eq_seconds!(1 * 3600 * 24, "1day");
+        assert_eq_seconds!((1.5 * 3600. * 24.) as i64, "1day 12hr");
+        assert_eq_seconds!(2 * 3600 * 24, "2day");
+    }
 }

--- a/pueue/tests/client/_templates/log__colored
+++ b/pueue/tests/client/_templates/log__colored
@@ -1,10 +1,11 @@
 ┌───────────────────────────────────┐
 │[1m Task 0:  [0m [38;5;10m completed successfully [39m│
 └───────────────────────────────────┘
-Command: echo test
-   Path: {{ cwd }}
-  Start: {{ task_0_start_long }}
-    End: {{ task_0_end_long }}
+ Command: echo test
+    Path: {{ cwd }}
+   Start: {{ task_0_start_long }}
+     End: {{ task_0_end_long }}
+Duration: {{ task_0_duration }}
 
 [38;5;10m[1moutput:[0m
 test

--- a/pueue/tests/client/_templates/log__default
+++ b/pueue/tests/client/_templates/log__default
@@ -1,10 +1,11 @@
 ┌───────────────────────────────────┐
 │ Task 0:    completed successfully │
 └───────────────────────────────────┘
-Command: echo test
-   Path: {{ cwd }}
-  Start: {{ task_0_start_long }}
-    End: {{ task_0_end_long }}
+ Command: echo test
+    Path: {{ cwd }}
+   Start: {{ task_0_start_long }}
+     End: {{ task_0_end_long }}
+Duration: {{ task_0_duration }}
 
 output:
 test

--- a/pueue/tests/client/_templates/log__last_lines
+++ b/pueue/tests/client/_templates/log__last_lines
@@ -1,19 +1,20 @@
 ┌───────────────────────────────────┐
 │ Task 0:    completed successfully │
 └───────────────────────────────────┘
-Command: echo '1
-         2
-         3
-         4
-         5
-         6
-         7
-         8
-         9
-         10'
-   Path: {{ cwd }}
-  Start: {{ task_0_start_long }}
-    End: {{ task_0_end_long }}
+ Command: echo '1
+          2
+          3
+          4
+          5
+          6
+          7
+          8
+          9
+          10'
+    Path: {{ cwd }}
+   Start: {{ task_0_start_long }}
+     End: {{ task_0_end_long }}
+Duration: {{ task_0_duration }}
 
 output: (last 5 lines)
 6

--- a/pueue/tests/client/_templates/log__with_label
+++ b/pueue/tests/client/_templates/log__with_label
@@ -1,11 +1,12 @@
 ┌───────────────────────────────────┐
 │ Task 0:    completed successfully │
 └───────────────────────────────────┘
-Command: echo test
-   Path: {{ cwd }}
-  Label: {{ task_0_label }}
-  Start: {{ task_0_start_long }}
-    End: {{ task_0_end_long }}
+ Command: echo test
+    Path: {{ cwd }}
+   Label: {{ task_0_label }}
+   Start: {{ task_0_start_long }}
+     End: {{ task_0_end_long }}
+Duration: {{ task_0_duration }}
 
 output:
 test

--- a/pueue/tests/client/helper/compare_output.rs
+++ b/pueue/tests/client/helper/compare_output.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs::read_to_string, path::PathBuf, process::Outp
 
 use chrono::Local;
 use handlebars::Handlebars;
+use pueue::format::humanize_duration;
 use pueue_lib::{settings::*, task::TaskStatus};
 
 use crate::{helper::get_state, internal_prelude::*};
@@ -26,14 +27,14 @@ pub async fn get_task_context(settings: &Settings) -> Result<HashMap<String, Str
     for (id, task) in state.tasks {
         let task_name = format!("task_{id}");
 
-        let (start, end) = task.start_and_end();
+        let (start, end, duration) = task.start_end_duration();
 
         if let Some(start) = start {
             // Use datetime format for datetimes that aren't today.
             let format = if start.date_naive() == Local::now().date_naive() {
-                &settings.client.status_time_format
+                &settings.client.get_status_time_format()
             } else {
-                &settings.client.status_datetime_format
+                &settings.client.get_status_datetime_format()
             };
 
             let formatted = start.format(format).to_string();
@@ -43,14 +44,17 @@ pub async fn get_task_context(settings: &Settings) -> Result<HashMap<String, Str
         if let Some(end) = end {
             // Use datetime format for datetimes that aren't today.
             let format = if end.date_naive() == Local::now().date_naive() {
-                &settings.client.status_time_format
+                &settings.client.get_status_time_format()
             } else {
-                &settings.client.status_datetime_format
+                &settings.client.get_status_datetime_format()
             };
 
             let formatted = end.format(format).to_string();
             context.insert(format!("{task_name}_end"), formatted);
             context.insert(format!("{task_name}_end_long"), end.to_rfc2822());
+        }
+        if let Some(duration) = duration {
+            context.insert(format!("{task_name}_duration"), humanize_duration(duration));
         }
         if let Some(label) = &task.label {
             context.insert(format!("{task_name}_label"), label.to_string());
@@ -62,9 +66,9 @@ pub async fn get_task_context(settings: &Settings) -> Result<HashMap<String, Str
         {
             // Use datetime format for datetimes that aren't today.
             let format = if enqueue_at.date_naive() == Local::now().date_naive() {
-                &settings.client.status_time_format
+                &settings.client.get_status_time_format()
             } else {
-                &settings.client.status_datetime_format
+                &settings.client.get_status_datetime_format()
             };
 
             let enqueue_at = enqueue_at.format(format);

--- a/pueue/tests/helper/fixtures.rs
+++ b/pueue/tests/helper/fixtures.rs
@@ -168,12 +168,11 @@ pub fn daemon_base_setup() -> Result<(Settings, TempDir)> {
         ..Default::default()
     };
 
-    let client = Client {
-        max_status_lines: Some(15),
-        status_datetime_format: "%Y-%m-%d %H:%M:%S".into(),
-        edit_mode: EditMode::Files,
-        ..Default::default()
-    };
+    let client = Client::new().with_edit_mode(EditMode::Files).with_status(
+        Status::new()
+            .with_max_lines(Some(Some(15)))
+            .with_datetime_format(Some("%Y-%m-%d %H:%M:%S".into())),
+    );
 
     #[allow(deprecated)]
     let daemon = Daemon {

--- a/pueue_lib/src/setting_defaults.rs
+++ b/pueue_lib/src/setting_defaults.rs
@@ -23,6 +23,17 @@ pub(crate) fn default_status_datetime_format() -> String {
     "%Y-%m-%d\n%H:%M:%S".to_string()
 }
 
+pub(crate) fn default_additional_columns() -> Vec<String> {
+    vec![
+        "Id".into(),
+        "Status".into(),
+        "Command".into(),
+        "Path".into(),
+        "Start".into(),
+        "End".into(),
+    ]
+}
+
 pub(crate) fn default_callback_log_lines() -> usize {
     10
 }

--- a/pueue_lib/src/settings.rs
+++ b/pueue_lib/src/settings.rs
@@ -96,6 +96,7 @@ pub enum EditMode {
 
 /// All settings which are used by the client
 #[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
 pub struct Client {
     /// If set to true, all tasks will be restart in place, instead of creating a new task.
     /// False is the default, as you'll lose the logs of the previously failed tasks when
@@ -112,21 +113,110 @@ pub struct Client {
     /// Whether the client should show a confirmation question on potential dangerous actions.
     #[serde(default = "Default::default")]
     pub edit_mode: EditMode,
-    /// Whether aliases specified in `pueue_aliases.yml` should be expanded in the `pueue status`
-    /// or shown in their short form.
-    #[serde(default = "Default::default")]
-    pub show_expanded_aliases: bool,
     /// Whether the client should use dark shades instead of regular colors.
     #[serde(default = "Default::default")]
     pub dark_mode: bool,
+
+    #[serde(default = "Default::default")]
+    #[deprecated(since = "4.0.1", note = "use `status` instead")]
+    pub show_expanded_aliases: bool,
     /// The max amount of lines each task get's in the `pueue status` view.
+    #[deprecated(since = "4.0.1", note = "use `status` instead")]
     pub max_status_lines: Option<usize>,
     /// The format that will be used to display time formats in `pueue status`.
     #[serde(default = "default_status_time_format")]
+    #[deprecated(since = "4.0.1", note = "use `status` instead")]
     pub status_time_format: String,
     /// The format that will be used to display datetime formats in `pueue status`.
     #[serde(default = "default_status_datetime_format")]
+    #[deprecated(since = "4.0.1", note = "use `status` instead")]
     pub status_datetime_format: String,
+
+    #[serde(default = "Default::default")]
+    pub status: Status,
+}
+
+impl Client {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    pub fn with_edit_mode(self, edit_mode: EditMode) -> Self {
+        Self { edit_mode, ..self }
+    }
+
+    pub fn with_status(self, status: Status) -> Self {
+        Self { status, ..self }
+    }
+
+    pub fn get_show_expanded_aliases(&self) -> bool {
+        #[expect(deprecated)]
+        self.status
+            .show_expanded_aliases
+            .unwrap_or(self.show_expanded_aliases)
+    }
+
+    pub fn get_status_max_lines(&self) -> Option<usize> {
+        #[expect(deprecated)]
+        self.status.max_lines.unwrap_or(self.max_status_lines)
+    }
+
+    pub fn get_status_time_format(&self) -> String {
+        #[expect(deprecated)]
+        self.status
+            .time_format
+            .clone()
+            .unwrap_or(self.status_time_format.clone())
+    }
+
+    pub fn get_status_datetime_format(&self) -> String {
+        #[expect(deprecated)]
+        self.status
+            .datetime_format
+            .clone()
+            .unwrap_or(self.status_datetime_format.clone())
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize, Default)]
+/// Settings used for `pueue status`.
+pub struct Status {
+    /// Whether aliases specified in `pueue_aliases.yml` should be expanded in the `pueue status`
+    /// or shown in their short form.
+    #[serde(default = "Default::default")]
+    pub show_expanded_aliases: Option<bool>,
+    /// The max amount of lines each task get's in the `pueue status` view.
+    #[serde(default = "Default::default")]
+    pub max_lines: Option<Option<usize>>,
+    /// The format that will be used to display time formats in `pueue status`.
+    #[serde(default = "Default::default")]
+    pub time_format: Option<String>,
+    /// The format that will be used to display datetime formats in `pueue status`.
+    #[serde(default = "Default::default")]
+    pub datetime_format: Option<String>,
+    #[serde(default = "default_additional_columns")]
+    pub additional_columns: Vec<String>,
+}
+
+impl Status {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    pub fn with_max_lines(self, max_lines: Option<Option<usize>>) -> Self {
+        Self { max_lines, ..self }
+    }
+
+    pub fn with_datetime_format(self, datetime_format: Option<String>) -> Self {
+        Self {
+            datetime_format,
+            ..self
+        }
+    }
 }
 
 /// All settings which are used by the daemon
@@ -199,6 +289,7 @@ impl Default for Shared {
 
 impl Default for Client {
     fn default() -> Self {
+        #[expect(deprecated)]
         Client {
             restart_in_place: false,
             read_local_logs: true,
@@ -209,6 +300,7 @@ impl Default for Client {
             max_status_lines: None,
             status_time_format: default_status_time_format(),
             status_datetime_format: default_status_datetime_format(),
+            status: Default::default(),
         }
     }
 }
@@ -383,8 +475,9 @@ impl Settings {
                 .map_err(|err| Error::IoPathError(path.clone(), "opening config file", err))?;
             let reader = BufReader::new(file);
 
-            let settings = serde_yaml::from_reader(reader)
+            let settings: Settings = serde_yaml::from_reader(reader)
                 .map_err(|err| Error::ConfigDeserialization(err.to_string()))?;
+
             return Ok((settings, true));
         };
 
@@ -404,8 +497,9 @@ impl Settings {
                     .map_err(|err| Error::IoPathError(path, "opening config file.", err))?;
                 let reader = BufReader::new(file);
 
-                let settings = serde_yaml::from_reader(reader)
+                let settings: Settings = serde_yaml::from_reader(reader)
                     .map_err(|err| Error::ConfigDeserialization(err.to_string()))?;
+
                 return Ok((settings, true));
             }
         }
@@ -485,7 +579,7 @@ mod test {
         // Create some default settings and ensure that default values are loaded.
         let mut settings = Settings::default();
         assert_eq!(
-            settings.client.status_time_format,
+            settings.client.get_status_time_format(),
             default_status_time_format()
         );
         assert_eq!(
@@ -496,7 +590,7 @@ mod test {
 
         // Crate a new profile with slightly different values.
         let mut profile = Settings::default();
-        profile.client.status_time_format = "test".to_string();
+        profile.client.status.time_format = Some("test".to_string());
         profile.daemon.callback_log_lines = 100_000;
         profile.shared.host = "quatschhost".to_string();
         let profile = NestedSettings {
@@ -512,7 +606,7 @@ mod test {
             .load_profile("testprofile")
             .expect("We just added the profile");
 
-        assert_eq!(settings.client.status_time_format, "test");
+        assert_eq!(settings.client.get_status_time_format(), "test");
         assert_eq!(settings.daemon.callback_log_lines, 100_000);
         assert_eq!(settings.shared.host, "quatschhost");
     }

--- a/pueue_lib/src/task.rs
+++ b/pueue_lib/src/task.rs
@@ -1,9 +1,13 @@
 //! Everything regarding Pueue's [Task]s.
 use std::{collections::HashMap, path::PathBuf};
 
-use chrono::prelude::*;
+use chrono::{Duration, prelude::*};
 use serde::{Deserialize, Serialize};
 use strum::Display;
+
+fn default_duration() -> Duration {
+    Duration::seconds(0)
+}
 
 /// This enum represents the status of the internal task handling of Pueue.
 /// They basically represent the internal task life-cycle.
@@ -30,6 +34,8 @@ pub enum TaskStatus {
         enqueued_at: DateTime<Local>,
         start: DateTime<Local>,
         end: DateTime<Local>,
+        #[serde(default = "default_duration")]
+        duration: Duration,
         result: TaskResult,
     },
 }
@@ -95,12 +101,18 @@ impl Task {
         }
     }
 
-    pub fn start_and_end(&self) -> (Option<DateTime<Local>>, Option<DateTime<Local>>) {
+    pub fn start_end_duration(
+        &self,
+    ) -> (
+        Option<DateTime<Local>>,
+        Option<DateTime<Local>>,
+        Option<Duration>,
+    ) {
         match self.status {
-            TaskStatus::Running { start, .. } => (Some(start), None),
-            TaskStatus::Paused { start, .. } => (Some(start), None),
-            TaskStatus::Done { start, end, .. } => (Some(start), Some(end)),
-            _ => (None, None),
+            TaskStatus::Running { start, .. } => (Some(start), None, None),
+            TaskStatus::Paused { start, .. } => (Some(start), None, None),
+            TaskStatus::Done { start, end, .. } => (Some(start), Some(end), Some(end - start)),
+            _ => (None, None, None),
         }
     }
 

--- a/pueue_lib/tests/data/v0.15.0_settings.yml
+++ b/pueue_lib/tests/data/v0.15.0_settings.yml
@@ -5,9 +5,9 @@ client:
   read_local_logs: true
   show_confirmation_questions: false
   show_expanded_aliases: false
-  max_status_lines: ~
-  status_time_format: "%H:%M:%S"
-  status_datetime_format: "%Y-%m-%d\n%H:%M:%S"
+  max_status_lines: 15
+  status_time_format: "mock015-%H:%M:%S"
+  status_datetime_format: "mock015-%Y-%m-%d\n%H:%M:%S"
 daemon:
   default_parallel_tasks: 1
   pause_group_on_failure: false

--- a/pueue_lib/tests/settings_backward_compatibility.rs
+++ b/pueue_lib/tests/settings_backward_compatibility.rs
@@ -23,8 +23,15 @@ mod tests {
             .join("v0.15.0_settings.yml");
 
         // Open v0.15.0 file and ensure the settings file can be read.
-        let (_settings, config_found) = Settings::read(&Some(old_settings_path))
+        let (settings, config_found) = Settings::read(&Some(old_settings_path))
             .wrap_err("Failed to read old config with defaults:")?;
+        assert!(!settings.client.get_show_expanded_aliases());
+        assert_eq!(settings.client.get_status_max_lines(), Some(15));
+        assert_eq!(settings.client.get_status_time_format(), "mock015-%H:%M:%S");
+        assert_eq!(
+            settings.client.get_status_datetime_format(),
+            "mock015-%Y-%m-%d\n%H:%M:%S"
+        );
 
         assert!(config_found);
 


### PR DESCRIPTION
**Problem** when looking at `pueue status` it takes too many brain cycles to figure out how long a task took.

**This pr** adds duration column to `pueue status`
<img width="678" height="288" alt="image" src="https://github.com/user-attachments/assets/82328d30-31a5-4d29-a910-4469fa06edf9" />



### Checklist

Please make sure the PR adheres to this project's standards:

- [x] I included a new entry to the `CHANGELOG.md`.
- [x] I checked `cargo clippy` and `cargo fmt`. The CI will fail otherwise anyway.
- [ ] (If applicable) I added tests for this feature or adjusted existing tests.
- [ ] (If applicable) I checked if anything in the wiki needs to be changed.
