### PR TITLE
feat(log): report full output byte count

### DIFF
--- a/pueue/src/client/commands/log/json.rs
+++ b/pueue/src/client/commands/log/json.rs
@@ -16,6 +16,7 @@ use snap::read::FrameDecoder;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TaskLog {
     pub task: Task,
+    pub full_output_bytes: u64,
     pub output: String,
 }
 
@@ -30,52 +31,74 @@ pub fn print_log_json(
     lines: Option<usize>,
 ) {
     let mut tasks: BTreeMap<usize, Task> = BTreeMap::new();
-    let mut task_log: BTreeMap<usize, String> = BTreeMap::new();
+    let mut task_log: BTreeMap<usize, (String, u64)> = BTreeMap::new();
     for (id, message) in task_log_messages {
         tasks.insert(id, message.task);
 
         if settings.client.read_local_logs {
-            let output = get_local_log(settings, id, lines);
-            task_log.insert(id, output);
+            let (output, full_output_bytes) = get_local_log(settings, id, lines);
+            task_log.insert(id, (output, full_output_bytes));
         } else {
             let output = get_remote_log(message.output);
-            task_log.insert(id, output);
+            task_log.insert(id, (output, message.full_output_bytes));
         }
     }
 
     // Now assemble the final struct that will be returned
     let mut json = BTreeMap::new();
     for (id, mut task) in tasks {
-        let (id, output) = task_log.remove_entry(&id).unwrap();
+        let (id, (output, full_output_bytes)) = task_log.remove_entry(&id).unwrap();
 
         task.envs = HashMap::new();
-        json.insert(id, TaskLog { task, output });
+        json.insert(
+            id,
+            TaskLog {
+                task,
+                full_output_bytes,
+                output,
+            },
+        );
     }
 
     println!("{}", serde_json::to_string(&json).unwrap());
 }
 
 /// Read logs directly from local files for a specific task.
-fn get_local_log(settings: &Settings, id: usize, lines: Option<usize>) -> String {
+fn get_local_log(settings: &Settings, id: usize, lines: Option<usize>) -> (String, u64) {
     let mut file = match get_log_file_handle(id, &settings.shared.pueue_directory()) {
         Ok(file) => file,
         Err(err) => {
-            return format!("(Pueue error) Failed to get log file handle: {err}");
+            return (
+                format!("(Pueue error) Failed to get log file handle: {err}"),
+                0,
+            );
+        }
+    };
+    let full_output_bytes = match file.metadata() {
+        Ok(metadata) => metadata.len(),
+        Err(error) => {
+            return (
+                format!("(Pueue error) Failed to get local log metadata: {error:?}"),
+                0,
+            );
         }
     };
 
     // Only return the last few lines.
     if let Some(lines) = lines {
-        return read_last_lines(&mut file, lines);
+        return (read_last_lines(&mut file, lines), full_output_bytes);
     }
 
     // Read the whole local log output.
     let mut output = String::new();
     if let Err(error) = file.read_to_string(&mut output) {
-        return format!("(Pueue error) Failed to read local log output file: {error:?}");
+        return (
+            format!("(Pueue error) Failed to read local log output file: {error:?}"),
+            full_output_bytes,
+        );
     };
 
-    output
+    (output, full_output_bytes)
 }
 
 /// Read logs from from compressed remote logs.

--- a/pueue/src/daemon/network/message_handler/log.rs
+++ b/pueue/src/daemon/network/message_handler/log.rs
@@ -26,24 +26,27 @@ pub fn get_log(settings: &Settings, state: &SharedState, message: LogRequest) ->
             // We send log output and the task at the same time.
             // This isn't as efficient as sending the raw compressed data directly,
             // but it's a lot more convenient for now.
-            let (output, output_complete) = if message.send_logs {
+            let (output, output_complete, full_output_bytes) = if message.send_logs {
                 match read_and_compress_log_file(
                     *task_id,
                     &settings.shared.pueue_directory(),
                     message.lines,
                 ) {
-                    Ok((output, output_complete)) => (Some(output), output_complete),
+                    Ok((output, output_complete, full_output_bytes)) => {
+                        (Some(output), output_complete, full_output_bytes)
+                    }
                     Err(err) => {
                         // Fail early if there's some problem with getting the log output
                         return failure_msg!("Failed reading process output file: {err:?}");
                     }
                 }
             } else {
-                (None, true)
+                (None, true, 0)
             };
 
             let task_log = TaskLogResponse {
                 task: task.clone(),
+                full_output_bytes,
                 output,
                 output_complete,
             };

--- a/pueue/tests/client/integration/log.rs
+++ b/pueue/tests/client/integration/log.rs
@@ -110,18 +110,30 @@ async fn colored() -> Result<()> {
 #[derive(Debug, Deserialize)]
 pub struct TaskLog {
     pub task: Task,
+    pub full_output_bytes: u64,
     pub output: String,
 }
 
 /// Calling `pueue log --json` prints the expected json output to stdout.
+#[rstest]
+#[case(true)]
+#[case(false)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn json() -> Result<()> {
-    let daemon = daemon().await?;
+async fn json(#[case] read_local_logs: bool) -> Result<()> {
+    let mut daemon = daemon().await?;
     let shared = &daemon.settings.shared;
+
+    daemon.settings.client.read_local_logs = read_local_logs;
+    daemon
+        .settings
+        .save(&Some(daemon.tempdir.path().join("pueue.yml")))
+        .context("Couldn't write pueue config to temporary directory")?;
 
     // Add a task and wait until it finishes.
     assert_success(add_task(shared, "echo test").await?);
     wait_for_task_condition(shared, 0, Task::is_done).await?;
+    let expected_full_output_bytes =
+        std::fs::metadata(shared.pueue_directory().join("task_logs/0.log"))?.len();
 
     let output = run_client_command(shared, &["log", "--json"])?;
 
@@ -142,9 +154,41 @@ async fn json() -> Result<()> {
         "Deserialized task and original task aren't equal"
     );
 
-    // Append a newline to the deserialized task's output, which is automatically done when working
-    // with the shell.
-    assert_eq!("test", task_log.output);
+    assert_eq!("test", task_log.output.trim_end());
+    assert_eq!(expected_full_output_bytes, task_log.full_output_bytes);
+
+    Ok(())
+}
+
+/// Calling `pueue log --json --lines` reports the full log size.
+#[rstest]
+#[case(true)]
+#[case(false)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_truncated(#[case] read_local_logs: bool) -> Result<()> {
+    let mut daemon = daemon().await?;
+    let shared = &daemon.settings.shared;
+
+    daemon.settings.client.read_local_logs = read_local_logs;
+    daemon
+        .settings
+        .save(&Some(daemon.tempdir.path().join("pueue.yml")))
+        .context("Couldn't write pueue config to temporary directory")?;
+
+    assert_success(add_task(shared, "printf '1\\n2\\n3\\n'").await?);
+    wait_for_task_condition(shared, 0, Task::is_done).await?;
+    let expected_full_output_bytes =
+        std::fs::metadata(shared.pueue_directory().join("task_logs/0.log"))?.len();
+
+    let output = run_client_command(shared, &["log", "--json", "--lines=1"])?;
+    let json = String::from_utf8_lossy(&output.stdout);
+    let task_logs: BTreeMap<usize, TaskLog> = serde_json::from_str(&json)
+        .context(format!("Failed to deserialize json tasks: \n{json}"))?;
+
+    assert_eq!(
+        task_logs.get(&0).unwrap().full_output_bytes,
+        expected_full_output_bytes
+    );
 
     Ok(())
 }

--- a/pueue/tests/daemon/integration/log.rs
+++ b/pueue/tests/daemon/integration/log.rs
@@ -64,9 +64,12 @@ async fn test_full_log() -> Result<()> {
 
     // Request all log lines
     let output = get_task_log(shared, 0, None).await?;
+    let full_output_bytes =
+        std::fs::metadata(shared.pueue_directory().join("task_logs/0.log"))?.len();
 
     // Make sure it's the same
     assert_eq!(output, expected_output);
+    assert_eq!(full_output_bytes, expected_output.len() as u64);
 
     Ok(())
 }
@@ -90,7 +93,7 @@ async fn test_partial_log() -> Result<()> {
 
     // Debug output to see what the file actually looks like:
     let real_log_path = shared.pueue_directory().join("task_logs").join("0.log");
-    let content = read_to_string(real_log_path).context("Failed to read actual file")?;
+    let content = read_to_string(&real_log_path).context("Failed to read actual file")?;
     println!("Actual log file contents: \n{content}");
 
     // Request a partial log for task 0
@@ -107,6 +110,7 @@ async fn test_partial_log() -> Result<()> {
 
     // Get the received output
     let logs = logs.get(&0).unwrap();
+    let full_output_bytes = std::fs::metadata(&real_log_path)?.len();
     let output = logs
         .output
         .clone()
@@ -115,6 +119,8 @@ async fn test_partial_log() -> Result<()> {
 
     // Make sure it's the same
     assert_eq!(output, expected_output);
+    assert!(!logs.output_complete);
+    assert_eq!(logs.full_output_bytes, full_output_bytes);
 
     Ok(())
 }

--- a/pueue_lib/src/log.rs
+++ b/pueue_lib/src/log.rs
@@ -61,16 +61,21 @@ pub fn clean_log_handles(task_id: usize, pueue_dir: &Path) {
 
 /// Return the output of a task. \
 /// Task output is compressed using [snap] to save some memory and bandwidth.
-/// Return type is `(Vec<u8>, bool)`
+/// Return type is `(Vec<u8>, bool, u64)`
 /// - `Vec<u8>` the compressed task output.
 /// - `bool` Whether the full task's output has been read. `false` indicate that the log output has
 ///   been truncated.
+/// - `u64` the full size of the task output in bytes.
 pub fn read_and_compress_log_file(
     task_id: usize,
     pueue_dir: &Path,
     lines: Option<usize>,
-) -> Result<(Vec<u8>, bool), Error> {
+) -> Result<(Vec<u8>, bool, u64), Error> {
     let mut file = get_log_file_handle(task_id, pueue_dir)?;
+    let full_output_bytes = file
+        .metadata()
+        .map_err(|err| Error::IoError("getting log file metadata".to_string(), err))?
+        .len();
 
     let mut content = Vec::new();
 
@@ -91,7 +96,7 @@ pub fn read_and_compress_log_file(
             .map_err(|err| Error::IoError("compressing log output".to_string(), err))?;
     }
 
-    Ok((content, output_complete))
+    Ok((content, output_complete, full_output_bytes))
 }
 
 /// Return the last lines of of a task's output. \

--- a/pueue_lib/src/message/response.rs
+++ b/pueue_lib/src/message/response.rs
@@ -92,6 +92,9 @@ impl_into_response!(AddedTaskResponse, Response::AddedTask);
 #[derive(PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct TaskLogResponse {
     pub task: Task,
+    /// The full size of the task's log file in bytes.
+    #[serde(default)]
+    pub full_output_bytes: u64,
     /// Indicates whether the log output has been truncated or not.
     pub output_complete: bool,
     pub output: Option<Vec<u8>>,
@@ -104,9 +107,86 @@ impl std::fmt::Debug for TaskLogResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TaskLogResponse")
             .field("task", &self.task)
+            .field("full_output_bytes", &self.full_output_bytes)
             .field("output_complete", &self.output_complete)
             .field("output", &"hidden")
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    use chrono::Local;
+    use ciborium::{Value, from_reader, into_writer};
+
+    use super::*;
+    use crate::task::TaskResult;
+
+    fn remove_full_output_bytes(value: &mut Value) {
+        match value {
+            Value::Map(entries) => {
+                entries.retain(
+                    |(key, _)| !matches!(key, Value::Text(key) if key == "full_output_bytes"),
+                );
+                for (_, value) in entries {
+                    remove_full_output_bytes(value);
+                }
+            }
+            Value::Array(values) => {
+                for value in values {
+                    remove_full_output_bytes(value);
+                }
+            }
+            Value::Tag(_, value) => remove_full_output_bytes(value),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn deserialize_task_log_response_without_full_output_bytes() -> color_eyre::Result<()> {
+        let now = Local::now();
+        let task = Task::new(
+            "echo test".to_string(),
+            PathBuf::from("/tmp"),
+            Default::default(),
+            "default".to_string(),
+            crate::task::TaskStatus::Done {
+                enqueued_at: now,
+                start: now,
+                end: now,
+                result: TaskResult::Success,
+            },
+            Vec::new(),
+            0,
+            None,
+        );
+        let response = Response::Log(BTreeMap::from([(
+            0,
+            TaskLogResponse {
+                task,
+                full_output_bytes: 123,
+                output_complete: true,
+                output: Some(vec![1, 2, 3]),
+            },
+        )]));
+
+        let mut bytes = Vec::new();
+        into_writer(&response, &mut bytes)?;
+        let mut legacy_payload: Value = from_reader(bytes.as_slice())?;
+        remove_full_output_bytes(&mut legacy_payload);
+
+        let mut legacy_bytes = Vec::new();
+        into_writer(&legacy_payload, &mut legacy_bytes)?;
+        let response: Response = from_reader(legacy_bytes.as_slice())?;
+
+        let Response::Log(logs) = response else {
+            panic!("Expected a log response");
+        };
+        assert_eq!(logs.get(&0).unwrap().full_output_bytes, 0);
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

This change adds `full_output_bytes` to Pueue’s log JSON response. The value represents the size of the entire raw task log file, rather than the size of only the displayed or compressed output.

The file metadata is read before any line truncation or compression, so commands such as `pueue log --lines=1` still report the size of the complete log.

Remote clients receive the value through `TaskLogResponse`, while clients configured to read logs locally calculate it directly from the file metadata.

## Backward compatibility

`#[serde(default)]` preserves compatibility with older daemons by setting the missing value to `0`.

A compatibility test removes the field from an older-style CBOR response and confirms that the current response type can still deserialize it.

## Testing

- Windows workspace tests passed
- 10 client log integration tests passed
- 5 daemon log integration tests passed
- Full WSL workspace suite passed: 190 tests and doc tests, 0 failed
- `cargo fmt --all -- --check` passed
- `cargo clippy --workspace --all-targets -- -D warnings` passed
- `git diff --check` passed

## Scope

This change does not modify the normal status display, task persistence, task state, or queue ordering.

## Agent assistance

I used a coding agent to help investigate the codebase and generate parts of the implementation. I personally reviewed the changes, ran the tests and verification commands, and worked through the client, daemon, serialization, and log-file data flow so I understood the implementation before submitting it.

I also enjoyed working through this change and learning how Pueue handles local and remote log data.

Closes #663
